### PR TITLE
Avoid recording duplicate assessments

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ English](https://en.wikipedia.org/wiki/Wikipedia:Version_1.0_Editorial_Team).
 [![Build Status](https://travis-ci.com/openzim/wp1.svg?branch=master)](https://travis-ci.com/openzim/wp1)
 [![codecov](https://codecov.io/gh/openzim/wp1/branch/master/graph/badge.svg)](https://codecov.io/gh/openzim/wp1)
 [![CodeFactor](https://www.codefactor.io/repository/github/openzim/wp1/badge)](https://www.codefactor.io/repository/github/openzim/wp1)
+[![Docker Web Build Status](https://img.shields.io/docker/cloud/build/openzim/wp1bot-web?label=docker%20web%20build)](https://cloud.docker.com/u/openzim/repository/docker/openzim/wp1bot-web)
+[![Docker Worker Build Status](https://img.shields.io/docker/cloud/build/openzim/wp1bot-workers?label=docker%20workers%20build)](https://cloud.docker.com/u/openzim/repository/docker/openzim/wp1bot-workers)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
 
 ## Contents

--- a/wp1/logic/project.py
+++ b/wp1/logic/project.py
@@ -325,10 +325,18 @@ def update_project_assessments_by_kind(wikidb, wp10db, project,
 
 
 def store_new_ratings(wp10db, new_ratings):
+
+  def sort_rating_tuples(rating_tuple):
+    if rating_tuple[1] == AssessmentKind.QUALITY:
+      return QUALITY[rating_tuple[0].r_quality.decode('utf-8')]
+    elif rating_tuple[1] == AssessmentKind.IMPORTANCE:
+      return IMPORTANCE[rating_tuple[0].r_importance.decode('utf-8')]
+
   for _, ratings_list in new_ratings.items():
-    for (rating, kind, old_rating_value) in ratings_list:
-      logic_rating.add_log_for_rating(wp10db, rating, kind, old_rating_value)
-      logic_rating.insert_or_update(wp10db, rating, kind)
+    sorted_ratings = sorted(ratings_list, key=sort_rating_tuples, reverse=True)
+    rating, kind, old_rating_value = sorted_ratings[0]
+    logic_rating.add_log_for_rating(wp10db, rating, kind, old_rating_value)
+    logic_rating.insert_or_update(wp10db, rating, kind)
 
 
 def process_unseen_articles(wikidb, wp10db, project, old_ratings, seen):


### PR DESCRIPTION
This PR refactors the way article assessments are inserted/updated into the database. Instead of inserting them as they are found, a list of ratings for an article is made and then later that list of ratings is sorted based on the "score" value for that rating. This means that if an article is rated both Start-Class and A-Class, only the A-Class is taken and recorded.

By deferring the decision to update a rating until all "candidate" ratings have been collected, we also avoid rating thrashing, where logs for ratings are recorded with the article going back and forth between ratings, as seen in #89.