### PR TITLE
Fix bug where inner dictionary was getting passed in

### DIFF
--- a/wp1/logic/project.py
+++ b/wp1/logic/project.py
@@ -464,8 +464,7 @@ def update_project_record(wp10db, project, metadata):
 def update_project(wikidb, wp10db, project):
   extra_assessments = api_project.get_extra_assessments(project.p_project)
 
-  update_project_assessments(wikidb, wp10db, project,
-                             extra_assessments['extra'])
+  update_project_assessments(wikidb, wp10db, project, extra_assessments)
 
   cleanup_project(wp10db, project)
 


### PR DESCRIPTION
The main update_project function was passing extra_assessments['extra'], while the update_category function was also looking for an 'extra' key in the top level extra_assessments variable. This means the key was never found and extra assessments were being ignored.

Should fix #94.