### PR TITLE
FIrst "hello world" version of web app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ after_success:
   - codecov
 services:
   - mysql
+  - redis-server

--- a/docker/web/start.sh
+++ b/docker/web/start.sh
@@ -3,4 +3,4 @@ export RQ_USER=$(head -n 1 app/rq-credentials.txt)
 export RQ_PASS=$(tail -n 1 app/rq-credentials.txt)
 
 cd app
-gunicorn -b 0.0.0.0:6555 wp1.web.app:app
+gunicorn -b 0.0.0.0:6555 'wp1.web.app:create_app()'

--- a/docker/web/start.sh
+++ b/docker/web/start.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-USER=$(head -n 1 app/rq-credentials.txt)
-PASS=$(tail -n 1 app/rq-credentials.txt)
+export RQ_USER=$(head -n 1 app/rq-credentials.txt)
+export RQ_PASS=$(tail -n 1 app/rq-credentials.txt)
 
-rq-dashboard --username $USER --password $PASS -H redis
+cd app
+gunicorn -b 0.0.0.0:6555 wp1.web.app:app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 arrow==0.14.5
 aspy.yaml==1.3.0
 attrs==18.2.0
+blinker==1.4
 certifi==2018.11.29
 cfgv==2.0.1
 chardet==3.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ chardet==3.0.4
 Click==7.0
 croniter==0.3.30
 Flask==1.1.1
+gunicorn==19.9.0
 identify==1.4.6
 idna==2.8
 importlib-metadata==0.19

--- a/wp1/api_test.py
+++ b/wp1/api_test.py
@@ -1,5 +1,4 @@
 import importlib
-import sys
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/wp1/logic/project.py
+++ b/wp1/logic/project.py
@@ -35,15 +35,21 @@ RE_INDICATOR = re.compile(b'([A-Za-z]+)[ _-]')
 RE_REJECT_GENERIC = re.compile(ARTICLES_LABEL + b'_' + BY_QUALITY, re.I)
 
 
+def count_projects(wp10db):
+  with wp10db.cursor() as cursor:
+    cursor.execute('SELECT COUNT(*) AS count FROM projects')
+    res = cursor.fetchone()
+
+  return res and res['count']
+
+
 def update_global_project_count():
   wp10db = wp10_connect()
   try:
     logger.info('Querying for number of projects')
-    with wp10db.cursor() as cursor:
-      cursor.execute('SELECT COUNT(*) AS count FROM projects')
-      res = cursor.fetchone()
 
-    count = res['count']
+    count = count_projects(wp10db)
+
     logger.info('Found %s projects, updating wiki', count)
     page = api.get_page('User:WP 1.0 bot/Data/Count')
     api.save_page(page, '%s\n' % count, 'Updating count: %s projects' % count)

--- a/wp1/web/app.py
+++ b/wp1/web/app.py
@@ -15,8 +15,8 @@ rq_pass = os.environ.get('RQ_PASS')
 
 if rq_user is not None and rq_pass is not None:
   app.config.from_object(rq_dashboard.default_settings)
-  app.config.update({'RQ_DASHBOARD_REDISH_HOST': 'redis'})
-  add_basic_auth(rq_dashboard.blueprint, 'foo', 'bar')
+  app.config.update({'RQ_DASHBOARD_REDIS_HOST': 'redis'})
+  add_basic_auth(rq_dashboard.blueprint, rq_user, rq_pass)
   app.register_blueprint(rq_dashboard.blueprint, url_prefix="/rq")
 else:
   print('No RQ_USER/RQ_PASS found in env, no rq dashboard created')

--- a/wp1/web/app.py
+++ b/wp1/web/app.py
@@ -7,40 +7,46 @@ from rq_dashboard.cli import add_basic_auth
 import wp1.logic.project as logic_project
 from wp1.web.db import get_db, has_db
 
-app = flask.Flask(__name__)
 
-try:
-  from wp1.credentials import REDIS_CREDS
-except ImportError:
-  print('No REDIS_CREDS found, using defaults')
-  REDIS_CREDS = None
-
-rq_user = os.environ.get('RQ_USER')
-rq_pass = os.environ.get('RQ_PASS')
-
-if rq_user is not None and rq_pass is not None:
-  app.config.from_object(rq_dashboard.default_settings)
-  if REDIS_CREDS is not None:
-    app.config.update({'RQ_DASHBOARD_REDIS_HOST': REDIS_CREDS['host']})
-    app.config.update({'RQ_DASHBOARD_REDIS_PORT': REDIS_CREDS['port']})
-  add_basic_auth(rq_dashboard.blueprint, rq_user, rq_pass)
-  app.register_blueprint(rq_dashboard.blueprint, url_prefix="/rq")
-else:
-  print('No RQ_USER/RQ_PASS found in env, no rq dashboard created')
+def get_redis_creds():
+  try:
+    from wp1.credentials import REDIS_CREDS
+    return REDIS_CREDS
+  except ImportError:
+    print('No REDIS_CREDS found, using defaults.')
+    return None
 
 
-@app.teardown_request
-def close_dbs(ex):
-  if has_db('wikidb'):
-    conn = get_db('wikidb')
-    conn.close()
-  if has_db('wp10db'):
-    conn = get_db('wp10db')
-    conn.close()
+def create_app():
+  app = flask.Flask(__name__)
 
+  rq_user = os.environ.get('RQ_USER')
+  rq_pass = os.environ.get('RQ_PASS')
+  redis_creds = get_redis_creds()
 
-@app.route('/')
-def index():
-  wp10db = get_db('wp10db')
-  count = logic_project.count_projects(wp10db)
-  return flask.render_template('index.html.jinja2', count=count)
+  if rq_user is not None and rq_pass is not None:
+    app.config.from_object(rq_dashboard.default_settings)
+    if redis_creds is not None:
+      app.config.update({'RQ_DASHBOARD_REDIS_HOST': redis_creds['host']})
+      app.config.update({'RQ_DASHBOARD_REDIS_PORT': redis_creds['port']})
+    add_basic_auth(rq_dashboard.blueprint, rq_user, rq_pass)
+    app.register_blueprint(rq_dashboard.blueprint, url_prefix="/rq")
+  else:
+    print('No RQ_USER/RQ_PASS found in env. RQ dashboard not created.')
+
+  @app.teardown_request
+  def close_dbs(ex):
+    if has_db('wikidb'):
+      conn = get_db('wikidb')
+      conn.close()
+    if has_db('wp10db'):
+      conn = get_db('wp10db')
+      conn.close()
+
+  @app.route('/')
+  def index():
+    wp10db = get_db('wp10db')
+    count = logic_project.count_projects(wp10db)
+    return flask.render_template('index.html.jinja2', count=count)
+
+  return app

--- a/wp1/web/app.py
+++ b/wp1/web/app.py
@@ -5,59 +5,42 @@ import rq_dashboard
 from rq_dashboard.cli import add_basic_auth
 
 import wp1.logic.project as logic_project
-from wp1.wp10_db import connect as wp10_connect
-from wp1.wiki_db import connect as wiki_connect
+from wp1.web.db import get_db, has_db
 
 app = flask.Flask(__name__)
+
+try:
+  from wp1.credentials import REDIS_CREDS
+except ImportError:
+  print('No REDIS_CREDS found, using defaults')
+  REDIS_CREDS = None
 
 rq_user = os.environ.get('RQ_USER')
 rq_pass = os.environ.get('RQ_PASS')
 
 if rq_user is not None and rq_pass is not None:
   app.config.from_object(rq_dashboard.default_settings)
-  app.config.update({'RQ_DASHBOARD_REDIS_HOST': 'redis'})
+  if REDIS_CREDS is not None:
+    app.config.update({'RQ_DASHBOARD_REDIS_HOST': REDIS_CREDS['host']})
+    app.config.update({'RQ_DASHBOARD_REDIS_PORT': REDIS_CREDS['port']})
   add_basic_auth(rq_dashboard.blueprint, rq_user, rq_pass)
   app.register_blueprint(rq_dashboard.blueprint, url_prefix="/rq")
 else:
   print('No RQ_USER/RQ_PASS found in env, no rq dashboard created')
 
 
-def has_wp10db():
-  return hasattr(flask.g, 'wp10db')
-
-
-def get_wp10db():
-  if not has_wp10db():
-    flask.g.wp10db = wp10_connect()
-  return flask.g.wp10db
-
-
 @app.teardown_request
-def close_wp10db(ex):
-  if has_wp10db():
-    conn = get_wp10db()
+def close_dbs(ex):
+  if has_db('wikidb'):
+    conn = get_db('wikidb')
     conn.close()
-
-
-def has_wikidb():
-  return hasattr(flask.g, 'wikidb')
-
-
-def get_wikidb():
-  if not has_wikidb():
-    flask.g.wikidb = wiki_connect()
-  return flask.g.wikidb
-
-
-@app.teardown_request
-def close_wikidb(ex):
-  if has_wikidb():
-    conn = get_wikidb()
+  if has_db('wp10db'):
+    conn = get_db('wp10db')
     conn.close()
 
 
 @app.route('/')
 def index():
-  wp10db = get_wp10db()
+  wp10db = get_db('wp10db')
   count = logic_project.count_projects(wp10db)
   return flask.render_template('index.html.jinja2', count=count)

--- a/wp1/web/app.py
+++ b/wp1/web/app.py
@@ -1,0 +1,63 @@
+import os
+
+import flask
+import rq_dashboard
+from rq_dashboard.cli import add_basic_auth
+
+import wp1.logic.project as logic_project
+from wp1.wp10_db import connect as wp10_connect
+from wp1.wiki_db import connect as wiki_connect
+
+app = flask.Flask(__name__)
+
+rq_user = os.environ.get('RQ_USER')
+rq_pass = os.environ.get('RQ_PASS')
+
+if rq_user is not None and rq_pass is not None:
+  app.config.from_object(rq_dashboard.default_settings)
+  app.config.update({'RQ_DASHBOARD_REDISH_HOST': 'redis'})
+  add_basic_auth(rq_dashboard.blueprint, 'foo', 'bar')
+  app.register_blueprint(rq_dashboard.blueprint, url_prefix="/rq")
+else:
+  print('No RQ_USER/RQ_PASS found in env, no rq dashboard created')
+
+
+def has_wp10db():
+  return hasattr(flask.g, 'wp10db')
+
+
+def get_wp10db():
+  if not has_wp10db():
+    flask.g.wp10db = wp10_connect()
+  return flask.g.wp10db
+
+
+@app.teardown_request
+def close_wp10db(ex):
+  if has_wp10db():
+    conn = get_wp10db()
+    conn.close()
+
+
+def has_wikidb():
+  return hasattr(flask.g, 'wikidb')
+
+
+def get_wikidb():
+  if not has_wikidb():
+    flask.g.wikidb = wiki_connect()
+  return flask.g.wikidb
+
+
+@app.teardown_request
+def close_wikidb(ex):
+  if has_wikidb():
+    conn = get_wikidb()
+    conn.close()
+
+
+@app.route('/')
+def index():
+  wp10db = get_wp10db()
+  count = logic_project.count_projects(wp10db)
+  return flask.render_template('index.html.jinja2', count=count)

--- a/wp1/web/app_test.py
+++ b/wp1/web/app_test.py
@@ -1,0 +1,10 @@
+from wp1.web.app import app
+from wp1.web.base_web_testcase import BaseWebTestcase
+
+
+class AppTest(BaseWebTestcase):
+
+  def test_index(self):
+    with self._override_db(app), app.test_client() as client:
+      rv = client.get('/')
+      self.assertTrue(b'Wikipedia 1.0 Server' in rv.data)

--- a/wp1/web/app_test.py
+++ b/wp1/web/app_test.py
@@ -43,7 +43,7 @@ class RqTest(unittest.TestCase):
         'port': 6379,
     }
     os.environ['RQ_USER'] = 'testuser'
-    os.environ['RQ_PASS'] = 'testpass'
+    os.environ['RQ_PASS'] = 'testpass'  # nosec
     self.app = create_app()
     with self.app.test_client() as client:
       rv = client.get('/rq', follow_redirects=True)
@@ -56,7 +56,7 @@ class RqTest(unittest.TestCase):
         'port': 6379,
     }
     os.environ['RQ_USER'] = 'testuser'
-    os.environ['RQ_PASS'] = 'testpass'
+    os.environ['RQ_PASS'] = 'testpass'  # nosec
     self.app = create_app()
     with self.app.test_client() as client:
       rv = client.get(

--- a/wp1/web/app_test.py
+++ b/wp1/web/app_test.py
@@ -5,6 +5,26 @@ from wp1.web.base_web_testcase import BaseWebTestcase
 class AppTest(BaseWebTestcase):
 
   def test_index(self):
-    with self._override_db(app), app.test_client() as client:
+    with self.override_db(app), app.test_client() as client:
       rv = client.get('/')
       self.assertTrue(b'Wikipedia 1.0 Server' in rv.data)
+
+  def test_index_project_count(self):
+    projects = []
+    for i in range(101):
+      projects.append({
+          'p_project': b'Project %s' % str(i).encode('utf-8'),
+          'p_timestamp': b'20181225'
+      })
+
+    with self.wp10db.cursor() as cursor:
+      cursor.executemany(
+          'INSERT INTO projects (p_project, p_timestamp) '
+          'VALUES (%(p_project)s, %(p_timestamp)s)', projects)
+    self.wp10db.commit()
+
+    with self.override_db(app), app.test_client() as client:
+      rv = client.get('/')
+      print(rv.data)
+      self.assertTrue(b'There are currently 101 projects being tracked '
+                      b'and updated each day.' in rv.data)

--- a/wp1/web/app_test.py
+++ b/wp1/web/app_test.py
@@ -1,11 +1,16 @@
-from wp1.web.app import app
+from base64 import b64encode
+import os
+import unittest
+from unittest.mock import patch
+
+from wp1.web.app import create_app
 from wp1.web.base_web_testcase import BaseWebTestcase
 
 
 class AppTest(BaseWebTestcase):
 
   def test_index(self):
-    with self.override_db(app), app.test_client() as client:
+    with self.override_db(self.app), self.app.test_client() as client:
       rv = client.get('/')
       self.assertTrue(b'Wikipedia 1.0 Server' in rv.data)
 
@@ -23,8 +28,43 @@ class AppTest(BaseWebTestcase):
           'VALUES (%(p_project)s, %(p_timestamp)s)', projects)
     self.wp10db.commit()
 
-    with self.override_db(app), app.test_client() as client:
+    with self.override_db(self.app), self.app.test_client() as client:
       rv = client.get('/')
-      print(rv.data)
       self.assertTrue(b'There are currently 101 projects being tracked '
                       b'and updated each day.' in rv.data)
+
+
+class RqTest(unittest.TestCase):
+
+  @patch('wp1.web.app.get_redis_creds')
+  def test_rq_no_login(self, patched_get_creds):
+    patched_get_creds.return_value = {
+        'host': 'localhost',
+        'port': 6379,
+    }
+    os.environ['RQ_USER'] = 'testuser'
+    os.environ['RQ_PASS'] = 'testpass'
+    self.app = create_app()
+    with self.app.test_client() as client:
+      rv = client.get('/rq', follow_redirects=True)
+      self.assertTrue(b'Please login' in rv.data)
+
+  @patch('wp1.web.app.get_redis_creds')
+  def test_rq_login(self, patched_get_creds):
+    patched_get_creds.return_value = {
+        'host': 'localhost',
+        'port': 6379,
+    }
+    os.environ['RQ_USER'] = 'testuser'
+    os.environ['RQ_PASS'] = 'testpass'
+    self.app = create_app()
+    with self.app.test_client() as client:
+      rv = client.get(
+          '/rq',
+          headers={
+              'Authorization':
+                  'Basic {}'.format(
+                      b64encode(b'testuser:testpass').decode('utf-8'))
+          },
+          follow_redirects=True)
+      self.assertFalse(b'Please login' in rv.data)

--- a/wp1/web/base_web_testcase.py
+++ b/wp1/web/base_web_testcase.py
@@ -5,7 +5,7 @@ from flask import appcontext_pushed, g
 import pymysql
 
 from wp1.base_db_test import parse_sql
-from wp1.web.app import app
+from wp1.web.app import create_app
 
 
 class BaseWebTestcase(unittest.TestCase):
@@ -65,7 +65,8 @@ class BaseWebTestcase(unittest.TestCase):
     self.addCleanup(self._cleanup_wp_one_db)
     self._setup_wp_one_db()
 
-    app.config['TESTING'] = True
+    self.app = create_app()
+    self.app.config['TESTING'] = True
 
   @contextmanager
   def override_db(self, app):

--- a/wp1/web/base_web_testcase.py
+++ b/wp1/web/base_web_testcase.py
@@ -1,0 +1,36 @@
+from contextlib import contextmanager
+from flask import appcontext_pushed, g
+
+from wp1.base_db_test import BaseCombinedDbTest
+from wp1.web.app import app
+
+
+class BaseWebTestcase(BaseCombinedDbTest):
+
+  def setUp(self):
+    super().setUp()
+    app.config['TESTING'] = True
+
+  @contextmanager
+  def _override_db(self, app):
+
+    @contextmanager
+    def set_wiki_db():
+
+      def handler(sender, **kwargs):
+        g.wikidb = self.wikidb
+
+      with appcontext_pushed.connected_to(handler, app):
+        yield
+
+    @contextmanager
+    def set_wp10_db():
+
+      def handler(sender, **kwargs):
+        g.wp10db = self.wp10db
+
+      with appcontext_pushed.connected_to(handler, app):
+        yield
+
+    with set_wiki_db(), set_wp10_db():
+      yield

--- a/wp1/web/db.py
+++ b/wp1/web/db.py
@@ -1,0 +1,19 @@
+import flask
+
+from wp1.wp10_db import connect as wp10_connect
+from wp1.wiki_db import connect as wiki_connect
+
+DB_CONNECT = {
+    'wp10db': wp10_connect,
+    'wikidb': wiki_connect,
+}
+
+
+def has_db(name):
+  return hasattr(flask.g, name)
+
+
+def get_db(name):
+  if not has_db(name):
+    setattr(flask.g, name, DB_CONNECT[name]())
+  return getattr(flask.g, name)

--- a/wp1/web/templates/index.html.jinja2
+++ b/wp1/web/templates/index.html.jinja2
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Wikipedia 1.0 Server</title>
+</head>
+<body>
+  <h1>Wikipedia 1.0 Server</h1>
+  <p>
+    There are currently {{count}} projects being tracked and updated each day.
+  </p>
+</body>
+</html>


### PR DESCRIPTION
Replaces the rq dashboard at "/" with a hello page that simply lists the number of projects that we are serving. However, this serves as a good test for database connectivity, Flask being installed correctly, etc.

The rq dashboard is now on "/rq", with the same credentials as before, which are now taken from the environment.