### PR TITLE
Remove extraneous print statements

### DIFF
--- a/wp1/api_test.py
+++ b/wp1/api_test.py
@@ -23,7 +23,6 @@ class ApiWithCredsTest(unittest.TestCase):
   def test_login_exception(self, patched_logger, patched_mwsite,
                            patched_credentials):
     site = patched_mwsite()
-    print('in test', site)
     site.login.side_effect = mwclient.errors.LoginError()
     wp1.api.login()
     self.assertEqual(1, patched_logger.exception.call_count)

--- a/wp1/logic/project.py
+++ b/wp1/logic/project.py
@@ -321,7 +321,6 @@ def store_new_ratings(wp10db, new_ratings, old_ratings):
 
   for article_ref, ratings_list in new_ratings.items():
     sorted_ratings = sorted(ratings_list, key=sort_rating_tuples, reverse=True)
-    print(sorted_ratings)
     rating, kind, old_rating_value = sorted_ratings[0]
 
     if kind == AssessmentKind.QUALITY:

--- a/wp1/tables.py
+++ b/wp1/tables.py
@@ -185,7 +185,6 @@ def generate_table_data(stats, categories, table_overrides=None):
   to_del = []
   for r in data.keys():
     if r not in categories['sort_qual']:
-      print(r)
       to_del.append(r)
   for r in to_del:
     del data[r]


### PR DESCRIPTION
I accidentally left in a debug print statement that was printing all the ratings for all the projects. This was causing the logs to grow extremely fast, as well as be filled with junk. Also removed some other junky print statements that weren't as serious at the same time.