### PR TITLE
Limit Docker logs size

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,11 @@ services:
       - /srv/log/wp1bot/:/var/log/wp1bot/
     links:
       - redis
+    logging:
+      driver: "json-file"
+      options:
+        max-file: 2
+        max-size: 10m
     restart: always
     depends_on:
       - redis
@@ -34,6 +39,11 @@ services:
       - /data/wp1bot/rq-credentials.txt:/usr/src/app/rq-credentials.txt
     links:
       - redis
+    logging:
+      driver: "json-file"
+      options:
+        max-file: 2
+        max-size: 10m
     restart: always
     depends_on:
       - redis
@@ -69,6 +79,10 @@ services:
       - "/data/certs:/etc/nginx/certs:rw"
       - "/var/local/vhost.d:/etc/nginx/vhost.d"
       - "/data/html:/usr/share/nginx/html"
+    logging:
+      driver: "none"
+      options:
+        max-size: 10k
     restart: always
 
 networks:


### PR DESCRIPTION
This is an attempt to reduce Docker logs size on master system.

@audiodude At home I have a strange error with `docker-compose`... but this seems unrelated to that PR.

```
$ docker-compose images
ERROR: The Compose file './docker-compose.yml' is invalid because:
networks.default value Additional properties are not allowed ('name' was unexpected)
$ docker-compose --version
docker-compose version 1.17.1, build unknown
```