### PR TITLE
Fix category update and more checks on custom categories

### DIFF
--- a/wp1/logic/category.py
+++ b/wp1/logic/category.py
@@ -12,5 +12,7 @@ def insert_or_update(wp10db, category):
         VALUES
           (%(c_project)s, %(c_type)s, %(c_rating)s, %(c_replacement)s,
            %(c_category)s, %(c_ranking)s)
-        ON DUPLICATE KEY UPDATE c_project = c_project
+        ON DUPLICATE KEY UPDATE c_replacement = %(c_replacement)s,
+          c_category = %(c_category)s, c_ranking = %(c_ranking)s
     ''', attr.asdict(category))
+  wp10db.commit()

--- a/wp1/logic/project.py
+++ b/wp1/logic/project.py
@@ -189,6 +189,7 @@ def update_category(wp10db, project, page, extra, kind, rating_to_category):
       logging.warning(
           'Could not cast "ranking" field for extra category to int: %s | %s',
           extra_category, ranking)
+      return
 
     if kind == AssessmentKind.QUALITY:
       replaces = extra_category.get('replaces')

--- a/wp1/logic/project.py
+++ b/wp1/logic/project.py
@@ -179,16 +179,16 @@ def update_category(wp10db, project, page, extra, kind, rating_to_category):
     ranking = extra_category.get('ranking')
     if rating is None or ranking is None:
       logger.warning(
-          'Skipping extra category with missing "title" or "ranking"'
-          'field: %s', extra_category)
+          'Skipping extra category with missing "title" or "ranking" field: %s',
+          extra_category)
       return
 
     try:
       ranking = int(ranking)
     except ValueError:
       logging.warning(
-          'Could not cast "ranking" field for extra category to int'
-          ': %s | %s', extra_category, ranking)
+          'Could not cast "ranking" field for extra category to int: %s | %s',
+          extra_category, ranking)
 
     if kind == AssessmentKind.QUALITY:
       replaces = extra_category.get('replaces')

--- a/wp1/logic/project_test.py
+++ b/wp1/logic/project_test.py
@@ -118,6 +118,55 @@ class UpdateCategoryTest(BaseWpOneDbTest):
     self.assertEqual(10, category.c_ranking)
     self.assertEqual(b'Disambig-Class', category.c_replacement)
 
+  def test_extra_category_missing_title_no_update(self):
+    rating_to_category = {}
+    extra = {
+        'extra': {
+            self.page_2.page_title.decode('utf-8'): {
+                'ranking': 10,
+                'replaces': 'Disambig-Class',
+            }
+        }
+    }
+    logic_project.update_category(self.wp10db, self.project, self.page_2, extra,
+                                  AssessmentKind.QUALITY, rating_to_category)
+
+    category = _get_first_category(self.wp10db)
+    self.assertIsNone(category)
+
+  def test_extra_category_missing_ranking_no_update(self):
+    rating_to_category = {}
+    extra = {
+        'extra': {
+            self.page_2.page_title.decode('utf-8'): {
+                'title': 'Draft-Class',
+                'replaces': 'Disambig-Class',
+            }
+        }
+    }
+    logic_project.update_category(self.wp10db, self.project, self.page_2, extra,
+                                  AssessmentKind.QUALITY, rating_to_category)
+
+    category = _get_first_category(self.wp10db)
+    self.assertIsNone(category)
+
+  def test_extra_category_ranking_not_int_no_update(self):
+    rating_to_category = {}
+    extra = {
+        'extra': {
+            self.page_2.page_title.decode('utf-8'): {
+                'title': 'Draft-Class',
+                'ranking': '10b',
+                'replaces': 'Disambig-Class',
+            }
+        }
+    }
+    logic_project.update_category(self.wp10db, self.project, self.page_2, extra,
+                                  AssessmentKind.QUALITY, rating_to_category)
+
+    category = _get_first_category(self.wp10db)
+    self.assertIsNone(category)
+
   def test_skips_page_with_no_mapping_match(self):
     rating_to_category = {}
     page = Page(page_title=b'123*go', page_id=None, page_namespace=None)


### PR DESCRIPTION
To partially address #116, I've added more sanity checks for the custom categories coming back from Wikipedia (since anyone could put anything there) and fixed some issues with the database query to update categories, namely that it wasn't committing the query and it wasn't updating anything in the case the category already existed.