### PR TITLE
Retry db connections up to four times every 5 seconds

### DIFF
--- a/wp1/wiki_db.py
+++ b/wp1/wiki_db.py
@@ -1,7 +1,14 @@
+import logging
 import os
+import time
 
 import pymysql
 import pymysql.cursors
+import pymysql.err
+
+logger = logging.getLogger(__name__)
+
+RETRY_TIME_SECONDS = 5
 
 try:
   from wp1.credentials import WIKI_CREDS
@@ -13,7 +20,20 @@ try:
         'cursorclass': pymysql.cursors.SSDictCursor,
         **WIKI_CREDS
     }
-    return pymysql.connect(**kwargs)
+
+    tries = 4
+    while True:
+      try:
+        return pymysql.connect(**kwargs)
+      except pymysql.err.InternalError:
+        if tries > 0:
+          logging.warning(
+              'Could not connect to database, retrying in %s seconds',
+              RETRY_TIME_SECONDS)
+          time.sleep(RETRY_TIME_SECONDS)
+          tries -= 1
+        else:
+          raise
 
 except ImportError:
   # No creds, so return an empty connect method that will blow up. This is only

--- a/wp1/wiki_db_test.py
+++ b/wp1/wiki_db_test.py
@@ -1,0 +1,41 @@
+import importlib
+import unittest
+import unittest.mock
+import sys
+
+import pymysql.err
+
+import wp1.wiki_db
+
+
+class WikiDbImportTest(unittest.TestCase):
+
+  def test_connect_method_returns_none_with_no_creds(self):
+    self.assertIsNone(wp1.wiki_db.connect())
+
+
+class WikiDbTest(unittest.TestCase):
+  WIKI_CREDS = {
+      'user': 'root',
+      'host': 'localhost',
+      'db': 'enwikip_test',
+  }
+
+  def setUp(self):
+    creds = unittest.mock.MagicMock()
+    creds.WIKI_CREDS = self.WIKI_CREDS
+    sys.modules['wp1.credentials'] = creds
+    importlib.reload(wp1.wiki_db)
+
+  def test_connect_works_with_creds(self):
+    from wp1.wiki_db import connect
+    self.assertIsNotNone(connect())
+
+  @unittest.mock.patch('wp1.wiki_db.pymysql.connect')
+  @unittest.mock.patch('wp1.wiki_db.time.sleep')
+  def test_retries_four_times_failure(self, patched_sleep, patched_pymysql):
+    from wp1.wiki_db import connect
+    patched_pymysql.side_effect = pymysql.err.InternalError()
+    with self.assertRaises(pymysql.err.InternalError):
+      connect()
+    self.assertEquals(5, patched_pymysql.call_count)

--- a/wp1/wp10_db.py
+++ b/wp1/wp10_db.py
@@ -1,7 +1,14 @@
+import logging
 import os
+import time
 
 import pymysql
 import pymysql.cursors
+import pymysql.err
+
+logger = logging.getLogger(__name__)
+
+RETRY_TIME_SECONDS = 5
 
 try:
   from wp1.credentials import WP10_CREDS
@@ -13,9 +20,25 @@ try:
         'cursorclass': pymysql.cursors.DictCursor,
         **WP10_CREDS
     }
-    return pymysql.connect(**kwargs)
+
+    tries = 4
+    while True:
+      try:
+        return pymysql.connect(**kwargs)
+      except pymysql.err.InternalError:
+        if tries > 0:
+          logging.warning(
+              'Could not connect to database, retrying in %s seconds',
+              RETRY_TIME_SECONDS)
+          time.sleep(RETRY_TIME_SECONDS)
+          tries -= 1
+        else:
+          raise
+
 except ImportError:
+  print('import error')
+
   # No creds, so return an empty connect method that will blow up. This is only
   # to satisfy imports.
   def connect():
-    pass
+    return None

--- a/wp1/wp10_db_test.py
+++ b/wp1/wp10_db_test.py
@@ -1,0 +1,41 @@
+import importlib
+import unittest
+import unittest.mock
+import sys
+
+import pymysql.err
+
+import wp1.wp10_db
+
+
+class Wp10DbImportTest(unittest.TestCase):
+
+  def test_connect_method_returns_none_with_no_creds(self):
+    self.assertIsNone(wp1.wp10_db.connect())
+
+
+class Wp10DbTest(unittest.TestCase):
+  WP10_CREDS = {
+      'user': 'root',
+      'host': 'localhost',
+      'db': 'enwp10_test',
+  }
+
+  def setUp(self):
+    creds = unittest.mock.MagicMock()
+    creds.WP10_CREDS = self.WP10_CREDS
+    sys.modules['wp1.credentials'] = creds
+    importlib.reload(wp1.wp10_db)
+
+  def test_connect_works_with_creds(self):
+    from wp1.wp10_db import connect
+    self.assertIsNotNone(connect())
+
+  @unittest.mock.patch('wp1.wp10_db.pymysql.connect')
+  @unittest.mock.patch('wp1.wiki_db.time.sleep')
+  def test_retries_four_times_failure(self, patched_sleep, patched_pymysql):
+    from wp1.wp10_db import connect
+    patched_pymysql.side_effect = pymysql.err.InternalError()
+    with self.assertRaises(pymysql.err.InternalError):
+      connect()
+    self.assertEquals(5, patched_pymysql.call_count)


### PR DESCRIPTION
We have been seeing lots of db connection issues, primarily because we don't have enough db connections for all of our workers. Retrying like this should introduce some latency, but also some resilience.