### PR TITLE
Create Development/Production "environments"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 **/__pycache__
 venv
-credentials.py

--- a/wp1/base_db_test.py
+++ b/wp1/base_db_test.py
@@ -1,5 +1,12 @@
+import importlib
 import unittest
+import unittest
+import unittest.mock
+import sys
+
 import pymysql
+
+from wp1.environment import Environment
 
 
 def parse_sql(filename):
@@ -95,3 +102,24 @@ class BaseCombinedDbTest(BaseWikiDbTest, BaseWpOneDbTest):
 
     self.addCleanup(self._cleanup_wp_one_db)
     self._setup_wp_one_db()
+
+
+def get_test_connect_creds():
+  return {
+      Environment.DEVELOPMENT: {
+          'WP10DB': {
+              'user': 'root',
+              'host': 'localhost',
+              'db': 'enwp10_test',
+          },
+          'WIKIDB': {
+              'user': 'root',
+              'host': 'localhost',
+              'db': 'enwikip_test',
+          }
+      },
+      Environment.PRODUCTION: {
+          'WP10DB': {},
+          'WIKIDB': {},
+      }
+  }

--- a/wp1/base_db_test.py
+++ b/wp1/base_db_test.py
@@ -1,6 +1,5 @@
 import importlib
 import unittest
-import unittest
 import unittest.mock
 import sys
 

--- a/wp1/base_db_test.py
+++ b/wp1/base_db_test.py
@@ -118,8 +118,5 @@ def get_test_connect_creds():
               'db': 'enwikip_test',
           }
       },
-      Environment.PRODUCTION: {
-          'WP10DB': {},
-          'WIKIDB': {},
-      }
+      Environment.PRODUCTION: {}
   }

--- a/wp1/credentials.py
+++ b/wp1/credentials.py
@@ -1,0 +1,62 @@
+from wp1.environment import Environment
+
+ENV = Environment.DEVELOPMENT
+
+CREDENTIALS = {
+    Environment.DEVELOPMENT: {
+        # Database credentials for the wikipedia replica database.
+        'WIKIDB': {
+            'user': 'someuser',
+            'password': 'somepass',
+            'host': 'enwiki.analytics.db.svc.eqiad.wmflabs',
+            'db': 'enwiki_p',
+        },
+
+        # Database credentials for the enwp10 project/application database.
+        'WP10DB': {
+            'user': 'someuser',
+            'password': 'somepass',
+            'host': 'tools.db.svc.eqiad.wmflabs',
+            'db': 's51114_enwp10',
+        },
+
+        # WMF wiki OAuth credentials.
+        'API': {
+            'CONSUMER_TOKEN': 'some_consumer_token',
+            'CONSUMER_SECRET': 'some_consumer_secret',
+            'ACCESS_TOKEN': 'some_access_token',
+            'ACCESS_SECRET': 'some_access_secret',
+        }
+    },
+
+    # EDIT: Remove the next line after you've provided actual credentials.
+    Environment.PRODUCTION: {}
+
+    # Example production config. Edit the indicated lines to provide credentials.
+    # When you're done, remove the empty Environment.PRODUCTION key above.
+    # Environment.PRODUCTION: {
+    #   # Database credentials for the wikipedia replica database.
+    #   'WIKIDB': {
+    #     'user': 'someuser', # EDIT this line for production.
+    #     'password': 'somepass', # EDIT this line for production.
+    #     'host': 'enwiki.analytics.db.svc.eqiad.wmflabs',
+    #     'db': 'enwiki_p',
+    #   },
+
+    #   # Database credentials for the enwp10 project/application database.
+    #   'WP10DB': {
+    #     'user': 'someuser', # EDIT this line for production.
+    #     'password': 'somepass', # EDIT this line for production.
+    #     'host': 'tools.db.svc.eqiad.wmflabs',
+    #     'db': 's51114_enwp10',
+    #   },
+
+    #   # WMF wiki oauth credentials
+    #   'API': {
+    #     'CONSUMER_TOKEN': 'a_consumer_token', # EDIT this line for production.
+    #     'CONSUMER_SECRET': 'a_consumer_secret', # EDIT this line for production.
+    #     'ACCESS_TOKEN': 'an_access_token', # EDIT this line for production.
+    #     'ACCESS_SECRET': 'an_access_secret', # EDIT this line for production.
+    #   }
+    # }
+}

--- a/wp1/db.py
+++ b/wp1/db.py
@@ -1,0 +1,42 @@
+import logging
+import os
+import time
+
+import pymysql
+import pymysql.cursors
+import pymysql.err
+
+from wp1.credentials import CREDENTIALS, ENV
+
+logger = logging.getLogger(__name__)
+
+RETRY_TIME_SECONDS = 5
+
+
+def connect(db_name):
+  print(CREDENTIALS)
+  print(ENV)
+
+  creds = CREDENTIALS[ENV].get(db_name)
+  if creds is None:
+    raise ValueError('db credentials for %r in ENV=%s are None')
+
+  kwargs = {
+      'charset': None,
+      'use_unicode': False,
+      'cursorclass': pymysql.cursors.SSDictCursor,
+      **creds
+  }
+
+  tries = 4
+  while True:
+    try:
+      return pymysql.connect(**kwargs)
+    except pymysql.err.InternalError:
+      if tries > 0:
+        logging.warning('Could not connect to database, retrying in %s seconds',
+                        RETRY_TIME_SECONDS)
+        time.sleep(RETRY_TIME_SECONDS)
+        tries -= 1
+      else:
+        raise

--- a/wp1/db.py
+++ b/wp1/db.py
@@ -14,9 +14,6 @@ RETRY_TIME_SECONDS = 5
 
 
 def connect(db_name):
-  print(CREDENTIALS)
-  print(ENV)
-
   creds = CREDENTIALS[ENV].get(db_name)
   if creds is None:
     raise ValueError('db credentials for %r in ENV=%s are None')

--- a/wp1/db_test.py
+++ b/wp1/db_test.py
@@ -1,0 +1,28 @@
+import unittest
+import unittest.mock
+
+import pymysql.err
+
+from wp1.base_db_test import get_test_connect_creds
+from wp1.environment import Environment
+
+
+class DbTest(unittest.TestCase):
+
+  @unittest.mock.patch('wp1.db.ENV', Environment.DEVELOPMENT)
+  @unittest.mock.patch('wp1.db.CREDENTIALS', get_test_connect_creds())
+  def test_connect_works_with_creds(self):
+    from wp1.db import connect
+    self.assertIsNotNone(connect('WP10DB'))
+    self.assertIsNotNone(connect('WIKIDB'))
+
+  @unittest.mock.patch('wp1.db.ENV', Environment.DEVELOPMENT)
+  @unittest.mock.patch('wp1.db.CREDENTIALS', get_test_connect_creds())
+  @unittest.mock.patch('wp1.db.pymysql.connect')
+  @unittest.mock.patch('wp1.db.time.sleep')
+  def test_retries_four_times_failure(self, patched_sleep, patched_pymysql):
+    from wp1.db import connect
+    patched_pymysql.side_effect = pymysql.err.InternalError()
+    with self.assertRaises(pymysql.err.InternalError):
+      connect('WP10DB')
+    self.assertEqual(5, patched_pymysql.call_count)

--- a/wp1/db_test.py
+++ b/wp1/db_test.py
@@ -16,6 +16,16 @@ class DbTest(unittest.TestCase):
     self.assertIsNotNone(connect('WP10DB'))
     self.assertIsNotNone(connect('WIKIDB'))
 
+  @unittest.mock.patch('wp1.db.ENV', Environment.PRODUCTION)
+  @unittest.mock.patch('wp1.db.CREDENTIALS', get_test_connect_creds())
+  def test_exception_thrown_with_empty_creds(self):
+    from wp1.db import connect
+    with self.assertRaises(ValueError):
+      connect('WP10DB')
+
+    with self.assertRaises(ValueError):
+      self.assertIsNotNone(connect('WIKIDB'))
+
   @unittest.mock.patch('wp1.db.ENV', Environment.DEVELOPMENT)
   @unittest.mock.patch('wp1.db.CREDENTIALS', get_test_connect_creds())
   @unittest.mock.patch('wp1.db.pymysql.connect')

--- a/wp1/environment.py
+++ b/wp1/environment.py
@@ -1,0 +1,6 @@
+import enum
+
+
+class Environment(enum.Enum):
+  DEVELOPMENT = 0
+  PRODUCTION = 1

--- a/wp1/wiki_db.py
+++ b/wp1/wiki_db.py
@@ -1,42 +1,5 @@
-import logging
-import os
-import time
+from functools import partial
 
-import pymysql
-import pymysql.cursors
-import pymysql.err
+from wp1.db import connect
 
-logger = logging.getLogger(__name__)
-
-RETRY_TIME_SECONDS = 5
-
-try:
-  from wp1.credentials import WIKI_CREDS
-
-  def connect():
-    kwargs = {
-        'charset': None,
-        'use_unicode': False,
-        'cursorclass': pymysql.cursors.SSDictCursor,
-        **WIKI_CREDS
-    }
-
-    tries = 4
-    while True:
-      try:
-        return pymysql.connect(**kwargs)
-      except pymysql.err.InternalError:
-        if tries > 0:
-          logging.warning(
-              'Could not connect to database, retrying in %s seconds',
-              RETRY_TIME_SECONDS)
-          time.sleep(RETRY_TIME_SECONDS)
-          tries -= 1
-        else:
-          raise
-
-except ImportError:
-  # No creds, so return an empty connect method that will blow up. This is only
-  # to satisfy imports.
-  def connect():
-    pass
+connect = partial(connect, 'WIKIDB')

--- a/wp1/wiki_db_test.py
+++ b/wp1/wiki_db_test.py
@@ -1,41 +1,14 @@
-import importlib
 import unittest
 import unittest.mock
-import sys
 
-import pymysql.err
-
-import wp1.wiki_db
-
-
-class WikiDbImportTest(unittest.TestCase):
-
-  def test_connect_method_returns_none_with_no_creds(self):
-    self.assertIsNone(wp1.wiki_db.connect())
+from wp1.base_db_test import get_test_connect_creds
+from wp1.environment import Environment
+from wp1 import wiki_db
 
 
 class WikiDbTest(unittest.TestCase):
-  WIKI_CREDS = {
-      'user': 'root',
-      'host': 'localhost',
-      'db': 'enwikip_test',
-  }
 
-  def setUp(self):
-    creds = unittest.mock.MagicMock()
-    creds.WIKI_CREDS = self.WIKI_CREDS
-    sys.modules['wp1.credentials'] = creds
-    importlib.reload(wp1.wiki_db)
-
+  @unittest.mock.patch('wp1.db.ENV', Environment.DEVELOPMENT)
+  @unittest.mock.patch('wp1.db.CREDENTIALS', get_test_connect_creds())
   def test_connect_works_with_creds(self):
-    from wp1.wiki_db import connect
-    self.assertIsNotNone(connect())
-
-  @unittest.mock.patch('wp1.wiki_db.pymysql.connect')
-  @unittest.mock.patch('wp1.wiki_db.time.sleep')
-  def test_retries_four_times_failure(self, patched_sleep, patched_pymysql):
-    from wp1.wiki_db import connect
-    patched_pymysql.side_effect = pymysql.err.InternalError()
-    with self.assertRaises(pymysql.err.InternalError):
-      connect()
-    self.assertEquals(5, patched_pymysql.call_count)
+    self.assertIsNotNone(wiki_db.connect())

--- a/wp1/wp10_db.py
+++ b/wp1/wp10_db.py
@@ -1,42 +1,5 @@
-import logging
-import os
-import time
+from functools import partial
 
-import pymysql
-import pymysql.cursors
-import pymysql.err
+from wp1.db import connect
 
-logger = logging.getLogger(__name__)
-
-RETRY_TIME_SECONDS = 5
-
-try:
-  from wp1.credentials import WP10_CREDS
-
-  def connect():
-    kwargs = {
-        'charset': None,
-        'use_unicode': False,
-        'cursorclass': pymysql.cursors.DictCursor,
-        **WP10_CREDS
-    }
-
-    tries = 4
-    while True:
-      try:
-        return pymysql.connect(**kwargs)
-      except pymysql.err.InternalError:
-        if tries > 0:
-          logging.warning(
-              'Could not connect to database, retrying in %s seconds',
-              RETRY_TIME_SECONDS)
-          time.sleep(RETRY_TIME_SECONDS)
-          tries -= 1
-        else:
-          raise
-
-except ImportError:
-  # No creds, so return an empty connect method that will blow up. This is only
-  # to satisfy imports.
-  def connect():
-    return None
+connect = partial(connect, 'WP10DB')

--- a/wp1/wp10_db_test.py
+++ b/wp1/wp10_db_test.py
@@ -1,41 +1,14 @@
-import importlib
 import unittest
 import unittest.mock
-import sys
 
-import pymysql.err
-
-import wp1.wp10_db
-
-
-class Wp10DbImportTest(unittest.TestCase):
-
-  def test_connect_method_returns_none_with_no_creds(self):
-    self.assertIsNone(wp1.wp10_db.connect())
+from wp1.base_db_test import get_test_connect_creds
+from wp1.environment import Environment
+from wp1 import wp10_db
 
 
 class Wp10DbTest(unittest.TestCase):
-  WP10_CREDS = {
-      'user': 'root',
-      'host': 'localhost',
-      'db': 'enwp10_test',
-  }
 
-  def setUp(self):
-    creds = unittest.mock.MagicMock()
-    creds.WP10_CREDS = self.WP10_CREDS
-    sys.modules['wp1.credentials'] = creds
-    importlib.reload(wp1.wp10_db)
-
+  @unittest.mock.patch('wp1.db.ENV', Environment.DEVELOPMENT)
+  @unittest.mock.patch('wp1.db.CREDENTIALS', get_test_connect_creds())
   def test_connect_works_with_creds(self):
-    from wp1.wp10_db import connect
-    self.assertIsNotNone(connect())
-
-  @unittest.mock.patch('wp1.wp10_db.pymysql.connect')
-  @unittest.mock.patch('wp1.wiki_db.time.sleep')
-  def test_retries_four_times_failure(self, patched_sleep, patched_pymysql):
-    from wp1.wp10_db import connect
-    patched_pymysql.side_effect = pymysql.err.InternalError()
-    with self.assertRaises(pymysql.err.InternalError):
-      connect()
-    self.assertEquals(5, patched_pymysql.call_count)
+    self.assertIsNotNone(wp10_db.connect())


### PR DESCRIPTION
In order to facilitate #137 it would be advantageous to ship "default" development credentials in credentials.py. In the past, this file has been excluded from source control, and while we could simply ask developers to configure it manually when they set up the project, it seems much more attractive to ship with reasonable defaults so that users can get up and running more quickly.

This PR adds a credentials.py file, and introduces an environment.py file which is simply an enum. The redundant database connection methods, which were duplicated, are consolidated in db.py.