### PR TITLE
Create a docker image for a dev database

### DIFF
--- a/dev-database.Dockerfile
+++ b/dev-database.Dockerfile
@@ -1,0 +1,4 @@
+FROM mariadb:10.1
+
+ENV MYSQL_ROOT_PASSWORD wikipedia
+COPY enwp10_dev.sample.sql /docker-entrypoint-initdb.d

--- a/docker/dev-database/Dockerfile
+++ b/docker/dev-database/Dockerfile
@@ -1,0 +1,4 @@
+FROM mariadb:10.1
+
+ENV MYSQL_ROOT_PASSWORD wikipedia
+COPY enwp10_dev.sample.sql /docker-entrypoint-initdb.d

--- a/enqueue-project.py
+++ b/enqueue-project.py
@@ -4,13 +4,16 @@ from redis import Redis
 from rq import Queue
 
 from wp1 import constants
+from wp1.credentials import CREDENTIALS, ENV
+from wp1.environment import Environment
 import wp1.logic.project as logic_project
 from wp1 import tables
 
 
 def main():
-  update_q = Queue('update', connection=Redis(host='redis'))
-  upload_q = Queue('upload', connection=Redis(host='redis'))
+  redis_creds = CREDENTIALS[ENV]['REDIS']
+  update_q = Queue('update', connection=Redis(**redis_creds))
+  upload_q = Queue('upload', connection=Redis(**redis_creds))
 
   # Job methods expect project names as bytes.
   project_names = [n.encode('utf-8') for n in sys.argv[1:]]
@@ -21,11 +24,15 @@ def main():
     update_job = update_q.enqueue(logic_project.update_project_by_name,
                                   project_name,
                                   job_timeout=constants.JOB_TIMEOUT)
-    print('Enqueuing upload (dependent) %s' % project_name)
-    upload_q.enqueue(tables.upload_project_table,
-                     project_name,
-                     depends_on=update_job,
-                     job_timeout=constants.JOB_TIMEOUT)
+
+    # No wiki to update in Development mode, so only do this if we're in
+    # Production.
+    if ENV == Environment.PRODUCTION:
+      print('Enqueuing upload (dependent) %s' % project_name)
+      upload_q.enqueue(tables.upload_project_table,
+                       project_name,
+                       depends_on=update_job,
+                       job_timeout=constants.JOB_TIMEOUT)
 
 
 if __name__ == '__main__':

--- a/setup/schema.sql
+++ b/setup/schema.sql
@@ -13,7 +13,6 @@ CREATE TABLE `categories` (
   `c_ranking` int(10) unsigned NOT NULL,
   PRIMARY KEY (`c_project`,`c_type`,`c_rating`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 CREATE TABLE `global_articles` (
   `a_article` varbinary(255) NOT NULL,
@@ -55,8 +54,6 @@ CREATE TABLE `moves` (
   KEY `m_new_namespace` (`m_new_namespace`,`m_new_article`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
-
-DROP TABLE IF EXISTS `namespacename`;
 CREATE TABLE `namespacename` (
   `dbname` varbinary(32) NOT NULL,
   `domain` varbinary(48) NOT NULL,
@@ -96,9 +93,6 @@ CREATE TABLE `ratings` (
   KEY `nstitle` (`r_namespace`,`r_article`(50))
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
-DROP TABLE IF EXISTS `selection_data`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `selection_data` (
   `sd_article` varbinary(255) NOT NULL,
   `sd_langlinks` int(10) unsigned NOT NULL DEFAULT '0',
@@ -108,9 +102,6 @@ CREATE TABLE `selection_data` (
   PRIMARY KEY (`sd_article`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
-DROP TABLE IF EXISTS `workingselection`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `workingselection` (
   `ws_article` varbinary(255) NOT NULL,
   `ws_revid` int(8) unsigned DEFAULT NULL,
@@ -122,6 +113,7 @@ CREATE TABLE `workingselection` (
 -- tool, which was written in Perl. The current code in this repository neither
 -- reads from nor updates these tables. They are kept here for archival reasons.
 
+/**
 --- Only used by old Perl bot.
 CREATE TABLE `cache` (
   `c_key` varchar(255) COLLATE utf8_bin NOT NULL,
@@ -155,8 +147,6 @@ CREATE TABLE `manualselectionlog` (
 
 -- Only used by old Perl bot.
 DROP TABLE IF EXISTS `passwd`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `passwd` (
   `pw_user` varchar(255) COLLATE utf8_bin NOT NULL,
   `pw_password` binary(32) NOT NULL,
@@ -165,8 +155,6 @@ CREATE TABLE `passwd` (
 
 -- Only used by old Perl bot.
 DROP TABLE IF EXISTS `releases`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `releases` (
   `rel_article` varbinary(255) NOT NULL,
   `rel_0p5_category` varbinary(63) NOT NULL,
@@ -183,3 +171,5 @@ CREATE TABLE `reviews` (
   PRIMARY KEY (`rev_article`),
   KEY `rev_value` (`rev_value`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+**/

--- a/wp1/credentials.py
+++ b/wp1/credentials.py
@@ -5,19 +5,34 @@ ENV = Environment.DEVELOPMENT
 CREDENTIALS = {
     Environment.DEVELOPMENT: {
         # Database credentials for the wikipedia replica database.
+        # For development, you can use your toolforge credentials and connect
+        # to a live replica via an SSH tunnel, as outlined here:
+        # https://wikitech.wikimedia.org/wiki/Help:Toolforge/Database#Connecting_to_the_database_replicas_from_your_own_computer
+        # The 'local port' you use, 4711 in the example, will correspond to the
+        # port you set below.
         'WIKIDB': {
-            'user': 'someuser',
-            'password': 'somepass',
-            'host': 'enwiki.analytics.db.svc.eqiad.wmflabs',
+            'user': 'youruser',
+            'password': 'yourpass',
+            'host': 'localhost',
+            'port': 4711,
             'db': 'enwiki_p',
         },
 
         # Database credentials for the enwp10 project/application database.
+        # For development, use the docker-compose-dev.yml file and spin up a
+        # local database that has some (potentially out of date) data in it.
         'WP10DB': {
-            'user': 'someuser',
-            'password': 'somepass',
-            'host': 'tools.db.svc.eqiad.wmflabs',
-            'db': 's51114_enwp10',
+            'user': 'root',
+            'password': 'wikipedia',
+            'host': 'localhost',
+            'port': 6300,
+            'db': 'enwp10_dev',
+        },
+
+        # Development Redis is provided by docker-compose-dev graph.
+        'REDIS': {
+            'host': 'localhost',
+            'port': 9736,
         },
 
         # WMF wiki OAuth credentials.
@@ -50,6 +65,12 @@ CREDENTIALS = {
     #     'host': 'tools.db.svc.eqiad.wmflabs',
     #     'db': 's51114_enwp10',
     #   },
+
+    #   # Redis is available on the docker network for production
+    #   # docker-compose.
+    #   'REDIS': {
+    #     'host': 'redis',
+    #   }
 
     #   # WMF wiki oauth credentials
     #   'API': {


### PR DESCRIPTION
Create a dev database with 30 MB of sample data (included in the repo). This can be loaded as a docker image using the new docker-compose-dev.yml, then used to test data collection (when connected to the enwiki_p replica database through an SSH tunnel) or used to power a dev version of the web frontend.