### PR TITLE
Fix some project processing

### DIFF
--- a/wp1/logic/project.py
+++ b/wp1/logic/project.py
@@ -70,8 +70,8 @@ def update_project_by_name(project_name):
   try:
     project = get_project_by_name(wp10db, project_name)
     if not project:
-      project = Project(
-        p_project=project_name, p_timestamp=GLOBAL_TIMESTAMP_WIKI)
+      project = Project(p_project=project_name,
+                        p_timestamp=GLOBAL_TIMESTAMP_WIKI)
     update_project(wikidb, wp10db, project)
   finally:
     wp10db.close()

--- a/wp1/logic/project.py
+++ b/wp1/logic/project.py
@@ -70,8 +70,8 @@ def update_project_by_name(project_name):
   try:
     project = get_project_by_name(wp10db, project_name)
     if not project:
-      logger.error('No project with name: %s', project_name)
-      return
+      project = Project(
+        p_project=project_name, p_timestamp=GLOBAL_TIMESTAMP_WIKI)
     update_project(wikidb, wp10db, project)
   finally:
     wp10db.close()
@@ -498,10 +498,10 @@ def update_project_record(wp10db, project, metadata):
     logger.warning('Setting NULL shortname for project: %s', project_display)
   else:
     project.shortname = shortname.encode('utf-8')
-  project.count = num_ratings
-  project.qcount = quality_count
-  project.icount = importance_count
-  project.scope = 0
+  project.p_count = num_ratings
+  project.p_qcount = quality_count
+  project.p_icount = importance_count
+  project.p_scope = 0
   project.upload_timestamp = b'00000000000000'
 
   insert_or_update(wp10db, project)

--- a/wp1/logic/project_test.py
+++ b/wp1/logic/project_test.py
@@ -1325,3 +1325,55 @@ class GlobalCountAndListTest(BaseWpOneDbTest):
       self.assertEqual(50, len(projects))
     finally:
       self.wp10db.close = orig_close
+
+class UpdateProjectByNameTest(BaseCombinedDbTest):
+
+  def _insert_project(self):
+    with self.wp10db.cursor() as cursor:
+      cursor.execute(
+          '''
+          INSERT INTO projects
+            (p_project, p_timestamp)
+          VALUES
+            (%s, '20181225001122')
+      ''', ('Test Projecct',))
+
+  def setUp(self):
+    super().setUp()
+    self._insert_project()
+
+  @patch('wp1.logic.project.wiki_connect')
+  @patch('wp1.logic.project.wp10_connect')
+  @patch('wp1.logic.project.update_project')
+  def test_calls_update_project_with_existing(self, patched_update_project, patched_wp10_connect, patched_wiki_connect):
+    orig_wp10_close = self.wp10db.close
+    orig_wiki_close = self.wikidb.close
+    try:
+      self.wp10db.close = lambda: True
+      self.wikidb.close = lambda: True
+      patched_wp10_connect.return_value = self.wp10db
+      patched_wiki_connect.return_value = self.wikidb
+    
+      logic_project.update_project_by_name(b'Test Project')
+      patched_update_project.assert_called_once()
+    finally:
+      self.wp10db.close = orig_wp10_close
+      self.wikidb.close = orig_wiki_close
+
+  @patch('wp1.logic.project.wiki_connect')
+  @patch('wp1.logic.project.wp10_connect')
+  @patch('wp1.logic.project.update_project')
+  def test_creates_new(self, patched_update_project, patched_wp10_connect, patched_wiki_connect):
+    orig_wp10_close = self.wp10db.close
+    orig_wiki_close = self.wikidb.close
+    try:
+      self.wp10db.close = lambda: True
+      self.wikidb.close = lambda: True
+      patched_wp10_connect.return_value = self.wp10db
+      patched_wiki_connect.return_value = self.wikidb
+    
+      logic_project.update_project_by_name(b'Foo New Project')
+      patched_update_project.assert_called_once()
+    finally:
+      self.wp10db.close = orig_wp10_close
+      self.wikidb.close = orig_wiki_close

--- a/wp1/logic/project_test.py
+++ b/wp1/logic/project_test.py
@@ -1326,6 +1326,7 @@ class GlobalCountAndListTest(BaseWpOneDbTest):
     finally:
       self.wp10db.close = orig_close
 
+
 class UpdateProjectByNameTest(BaseCombinedDbTest):
 
   def _insert_project(self):
@@ -1345,7 +1346,9 @@ class UpdateProjectByNameTest(BaseCombinedDbTest):
   @patch('wp1.logic.project.wiki_connect')
   @patch('wp1.logic.project.wp10_connect')
   @patch('wp1.logic.project.update_project')
-  def test_calls_update_project_with_existing(self, patched_update_project, patched_wp10_connect, patched_wiki_connect):
+  def test_calls_update_project_with_existing(self, patched_update_project,
+                                              patched_wp10_connect,
+                                              patched_wiki_connect):
     orig_wp10_close = self.wp10db.close
     orig_wiki_close = self.wikidb.close
     try:
@@ -1353,7 +1356,7 @@ class UpdateProjectByNameTest(BaseCombinedDbTest):
       self.wikidb.close = lambda: True
       patched_wp10_connect.return_value = self.wp10db
       patched_wiki_connect.return_value = self.wikidb
-    
+
       logic_project.update_project_by_name(b'Test Project')
       patched_update_project.assert_called_once()
     finally:
@@ -1363,7 +1366,8 @@ class UpdateProjectByNameTest(BaseCombinedDbTest):
   @patch('wp1.logic.project.wiki_connect')
   @patch('wp1.logic.project.wp10_connect')
   @patch('wp1.logic.project.update_project')
-  def test_creates_new(self, patched_update_project, patched_wp10_connect, patched_wiki_connect):
+  def test_creates_new(self, patched_update_project, patched_wp10_connect,
+                       patched_wiki_connect):
     orig_wp10_close = self.wp10db.close
     orig_wiki_close = self.wikidb.close
     try:
@@ -1371,7 +1375,7 @@ class UpdateProjectByNameTest(BaseCombinedDbTest):
       self.wikidb.close = lambda: True
       patched_wp10_connect.return_value = self.wp10db
       patched_wiki_connect.return_value = self.wikidb
-    
+
       logic_project.update_project_by_name(b'Foo New Project')
       patched_update_project.assert_called_once()
     finally:

--- a/wp1/logic/project_test.py
+++ b/wp1/logic/project_test.py
@@ -1241,13 +1241,13 @@ class UpdateProjectRecordTest(BaseWpOneDbTest):
                      self.project.parent.decode('utf-8'))
 
   def test_count(self):
-    self.assertEqual(8, self.project.count)
+    self.assertEqual(8, self.project.p_count)
 
   def test_quality_count(self):
-    self.assertEqual(5, self.project.qcount)
+    self.assertEqual(5, self.project.p_qcount)
 
   def test_importance_count(self):
-    self.assertEqual(6, self.project.icount)
+    self.assertEqual(6, self.project.p_icount)
 
 
 class ProjectNamesTest(ArticlesTest):

--- a/wp1/time.py
+++ b/wp1/time.py
@@ -3,5 +3,6 @@ This wrapper class exists so that the current time can be mocked in tests.
 """
 from datetime import datetime
 
+
 def get_current_datetime():
   return datetime.now()


### PR DESCRIPTION
Create new projects when they are found, and properly update count, qcount, and icount.

The latter variables were not being set properly on the project, even though they were being computed, and a bug in the test prevent us from catching this.