### PR TITLE
Setup the environment for a development database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 **/__pycache__
 venv
+
+# Don't commit credentials!
+wp1/credentials.py

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ run [inside the workers image](https://github.com/openzim/wp1/blob/master/docker
 
 The `setup` directory contains a historical record of the database
 schema used by the tool for what is refered to in code as the `wp10`
-database. This file has been heavily edited from its mysqldump roots
-and cannot be directly run without errors.
+database. This file has been heavily edited, but should be able to be
+used to re-create the `enwp10` database if necessary.
 
 `wp1-frontend` contains the code for the Vue-CLI based frontend,
 which is encapsulated and served from the `frontend` docker image.
@@ -45,6 +45,13 @@ library code.
 `docker-compose.yml` is a file read by the `docker-compose`
 [command](https://docs.docker.com/compose/) in order to generate the
 graph of required docker images that represent the production environment.
+
+`docker-compose-dev.yml` is a similar file which sets up a dev environment,
+with Redis and a MariaDB server for the `enwp10` database. Use it like so
+
+```bash
+docker-compose -f docker-compose-dev.yml up -d
+```
 
 The `*.dockerfile` symlinks allow for each docker image in this repository
 to be more easily built on [Docker Hub](https://hub.docker.com/). See:
@@ -65,7 +72,7 @@ interfaces with. They are used for unit testing.
 
 ## Installation
 
-This code is targetted to and tested on Python 3.7.5.
+This code is targeted to and tested on Python 3.7.5.
 
 ### Creating your virtualenv
 
@@ -127,7 +134,9 @@ and create a copy called `credentials.py` with the relevant information
 filled in. The production version of this code also requires Englis Wikipedia
 API credentials for automatically editing and updating
 [tables like this one](https://en.wikipedia.org/wiki/User:WP_1.0_bot/Tables/Project/Catholicism).
-There is currently no way to disable the API editing portion of the tool.
+Currently, if your environment is DEVELOPMENT, jobs that utilize the API
+to edit Wikipedia are disabled. There is no development wiki that gets edited
+at this time.
 
 ## Updating production
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,19 @@
+version: '3.5'
+services:
+  redis:
+    image: redis
+    container_name: wp1bot-redis-dev
+    ports:
+      - '9736:6379'
+    restart: always
+
+  dev-database:
+    image: openzim/wp1-dev-database
+    container_name: wp1bot-db-dev
+    ports:
+      - '6300:3306'
+    restart: always
+
+networks:
+  default:
+    name: dev.openzim.org

--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -1,3 +1,9 @@
+# Copy this file to credentials.py (in the same directory). Your application
+# database should work immediately after you run:
+# $ docker-compose -f docker-compose-dev.yml -d
+# in the root directory. The Wiki replica database requires actual toolforge
+# credentials to be accessible.
+
 from wp1.environment import Environment
 
 ENV = Environment.DEVELOPMENT
@@ -5,19 +11,28 @@ ENV = Environment.DEVELOPMENT
 CREDENTIALS = {
     Environment.DEVELOPMENT: {
         # Database credentials for the wikipedia replica database.
+        # For development, you can use your toolforge credentials and connect
+        # to a live replica via an SSH tunnel, as outlined here:
+        # https://wikitech.wikimedia.org/wiki/Help:Toolforge/Database#Connecting_to_the_database_replicas_from_your_own_computer
+        # The 'local port' you use, 4711 in the example, will correspond to the
+        # port you set below.
         'WIKIDB': {
-            'user': 'someuser',
-            'password': 'somepass',
-            'host': 'enwiki.analytics.db.svc.eqiad.wmflabs',
+            'user': 'yourtoolforgeuser', # EDIT this line
+            'password': 'yourtoolforgepass', # EDIT this line
+            'host': 'localhost',
+            'port': 4711,
             'db': 'enwiki_p',
         },
 
         # Database credentials for the enwp10 project/application database.
+        # For development, use the docker-compose-dev.yml file and spin up a
+        # local database that has some (potentially out of date) data in it.
         'WP10DB': {
-            'user': 'someuser',
-            'password': 'somepass',
-            'host': 'tools.db.svc.eqiad.wmflabs',
-            'db': 's51114_enwp10',
+            'user': 'root',
+            'password': 'wikipedia',
+            'host': 'localhost',
+            'port': 6300,
+            'db': 'enwp10_dev',
         },
 
         # WMF wiki OAuth credentials.

--- a/wp1/db.py
+++ b/wp1/db.py
@@ -6,34 +6,40 @@ import pymysql
 import pymysql.cursors
 import pymysql.err
 
-from wp1.credentials import CREDENTIALS, ENV
-
 logger = logging.getLogger(__name__)
 
-RETRY_TIME_SECONDS = 5
+try:
+  from wp1.credentials import CREDENTIALS, ENV
+except ImportError:
+  logger.exception('The file credentials.py must be populated manually in '
+                   'order to connect to the required databases')
+  CREDENTIALS = None
+  ENV = None
 
+  RETRY_TIME_SECONDS = 5
 
-def connect(db_name):
-  creds = CREDENTIALS[ENV].get(db_name)
-  if creds is None:
-    raise ValueError('db credentials for %r in ENV=%s are None')
+  def connect(db_name):
+    creds = CREDENTIALS[ENV].get(db_name)
+    if creds is None:
+      raise ValueError('db credentials for %r in ENV=%s are None')
 
-  kwargs = {
-      'charset': None,
-      'use_unicode': False,
-      'cursorclass': pymysql.cursors.SSDictCursor,
-      **creds
-  }
+    kwargs = {
+        'charset': None,
+        'use_unicode': False,
+        'cursorclass': pymysql.cursors.SSDictCursor,
+        **creds
+    }
 
-  tries = 4
-  while True:
-    try:
-      return pymysql.connect(**kwargs)
-    except pymysql.err.InternalError:
-      if tries > 0:
-        logging.warning('Could not connect to database, retrying in %s seconds',
-                        RETRY_TIME_SECONDS)
-        time.sleep(RETRY_TIME_SECONDS)
-        tries -= 1
-      else:
-        raise
+    tries = 4
+    while True:
+      try:
+        return pymysql.connect(**kwargs)
+      except pymysql.err.InternalError:
+        if tries > 0:
+          logging.warning(
+              'Could not connect to database, retrying in %s seconds',
+              RETRY_TIME_SECONDS)
+          time.sleep(RETRY_TIME_SECONDS)
+          tries -= 1
+        else:
+          raise


### PR DESCRIPTION
This PR is the logical replacement to #143. However instead of creating the docker image for the development database in this repo itself, it is now served by the repo at:

https://github.com/openzim/wp1-dev-database

This PR provides a docker-compose-dev.yml file that can be used to pull the development db and start it running.

The `credentials.py` have once again been moved to `credentials.py.example` and a gitignore rule has been added for `credentials.py`. This is because developers are now encouraged to use their toolforge DB credentials in development to SSH tunnel to the enwiki_p replica database.

The README has also been updated.