### PR TITLE
Fix db for when there is NOT an ImportError

### DIFF
--- a/wp1/db.py
+++ b/wp1/db.py
@@ -16,30 +16,30 @@ except ImportError:
   CREDENTIALS = None
   ENV = None
 
-  RETRY_TIME_SECONDS = 5
+RETRY_TIME_SECONDS = 5
 
-  def connect(db_name):
-    creds = CREDENTIALS[ENV].get(db_name)
-    if creds is None:
-      raise ValueError('db credentials for %r in ENV=%s are None')
 
-    kwargs = {
-        'charset': None,
-        'use_unicode': False,
-        'cursorclass': pymysql.cursors.SSDictCursor,
-        **creds
-    }
+def connect(db_name):
+  creds = CREDENTIALS[ENV].get(db_name)
+  if creds is None:
+    raise ValueError('db credentials for %r in ENV=%s are None')
 
-    tries = 4
-    while True:
-      try:
-        return pymysql.connect(**kwargs)
-      except pymysql.err.InternalError:
-        if tries > 0:
-          logging.warning(
-              'Could not connect to database, retrying in %s seconds',
-              RETRY_TIME_SECONDS)
-          time.sleep(RETRY_TIME_SECONDS)
-          tries -= 1
-        else:
-          raise
+  kwargs = {
+      'charset': None,
+      'use_unicode': False,
+      'cursorclass': pymysql.cursors.SSDictCursor,
+      **creds
+  }
+
+  tries = 4
+  while True:
+    try:
+      return pymysql.connect(**kwargs)
+    except pymysql.err.InternalError:
+      if tries > 0:
+        logging.warning('Could not connect to database, retrying in %s seconds',
+                        RETRY_TIME_SECONDS)
+        time.sleep(RETRY_TIME_SECONDS)
+        tries -= 1
+      else:
+        raise


### PR DESCRIPTION
The changes in #146 fixed the db module for when credentials.py doesn't exist, mostly for unit tests. This change fixes it to work again when credentials.py *does* exist.