### PR TITLE
Put Redis credentials in credentials.py.example

### DIFF
--- a/enqueue-all.py
+++ b/enqueue-all.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 
 from redis import Redis
@@ -9,41 +10,52 @@ from wp1 import tables
 from wp1.logic import project as logic_project
 from wp1.wiki_db import connect as wiki_connect
 
+logger = logging.getLogger(__name__)
+
+try:
+  from wp1.credentials import ENV, CREDENTIALS
+except ImportError:
+  logger.exception('The file credentials.py must be populated manually in '
+                   'order to connect to Redis')
+  CREDENTIALS = None
+  ENV = None
+
 
 def main():
+  logging.basicConfig(level=logging.INFO)
+
   upload_only = False
   if len(sys.argv) > 1 and sys.argv[1] == '--upload-only':
     upload_only = True
 
-  update_q = Queue('update', connection=Redis(host='redis'))
-  upload_q = Queue('upload', connection=Redis(host='redis'))
+  creds = CREDENTIALS[ENV]['REDIS']
+
+  update_q = Queue('update', connection=Redis(**creds))
+  upload_q = Queue('upload', connection=Redis(**creds))
 
   if (update_q.count > 0 or upload_q.count > 0):
-    print('Queues are not empty. Refusing to add more work.')
+    logger.error('Queues are not empty. Refusing to add more work.')
     return
 
   wikidb = wiki_connect()
   for project_name in logic_project.project_names_to_update(wikidb):
-    if upload_only:
-      print('Enqueuing upload %s' % project_name)
-      upload_q.enqueue(tables.upload_project_table,
-                       project_name,
-                       job_timeout=constants.JOB_TIMEOUT)
-    else:
-      print('Enqueuing update %s' % project_name)
+
+    if not upload_only:
+      logger.info('Enqueuing update %s', project_name)
       update_job = update_q.enqueue(logic_project.update_project_by_name,
                                     project_name,
                                     job_timeout=constants.JOB_TIMEOUT)
-      print('Enqueuing upload (dependent) %s' % project_name)
-      upload_q.enqueue(tables.upload_project_table,
-                       project_name,
-                       depends_on=update_job,
-                       job_timeout=constants.JOB_TIMEOUT)
-      print('Enqueuing log upload (dependent) %s' % project_name)
-      upload_q.enqueue(logs.update_log_page_for_project,
-                       project_name,
-                       depends_on=update_job,
-                       job_timeout=constants.JOB_TIMEOUT)
+
+    logger.info('Enqueuing upload (dependent) %s', project_name)
+    upload_q.enqueue(tables.upload_project_table,
+                     project_name,
+                     depends_on=update_job,
+                     job_timeout=constants.JOB_TIMEOUT)
+    logger.info('Enqueuing log upload (dependent) %s', project_name)
+    upload_q.enqueue(logs.update_log_page_for_project,
+                     project_name,
+                     depends_on=update_job,
+                     job_timeout=constants.JOB_TIMEOUT)
 
 
 if __name__ == '__main__':

--- a/enqueue-project.py
+++ b/enqueue-project.py
@@ -1,31 +1,56 @@
+import logging
 import sys
 
 from redis import Redis
 from rq import Queue
 
 from wp1 import constants
+from wp1.environment import Environment
 import wp1.logic.project as logic_project
 from wp1 import tables
 
+logger = logging.getLogger(__name__)
+
+try:
+  from wp1.credentials import ENV, CREDENTIALS
+except ImportError:
+  logger.exception('The file credentials.py must be populated manually in '
+                   'order to connect to Redis')
+  CREDENTIALS = None
+  ENV = None
+
 
 def main():
-  update_q = Queue('update', connection=Redis(host='redis'))
-  upload_q = Queue('upload', connection=Redis(host='redis'))
+  logging.basicConfig(level=logging.INFO)
+
+  creds = CREDENTIALS[ENV]['REDIS']
+
+  update_q = Queue('update', connection=Redis(**creds))
+  upload_q = Queue('upload', connection=Redis(**creds))
 
   # Job methods expect project names as bytes.
   project_names = [n.encode('utf-8') for n in sys.argv[1:]]
-  print(project_names)
+  logger.debug(project_names)
 
   for project_name in project_names:
-    print('Enqueuing update %s' % project_name)
+    logger.info('Enqueuing update %s', project_name)
     update_job = update_q.enqueue(logic_project.update_project_by_name,
                                   project_name,
                                   job_timeout=constants.JOB_TIMEOUT)
-    print('Enqueuing upload (dependent) %s' % project_name)
-    upload_q.enqueue(tables.upload_project_table,
-                     project_name,
-                     depends_on=update_job,
-                     job_timeout=constants.JOB_TIMEOUT)
+    if ENV == Environment.PRODUCTION:
+      logger.info('Enqueuing upload (dependent) %s', project_name)
+      upload_q.enqueue(tables.upload_project_table,
+                       project_name,
+                       depends_on=update_job,
+                       job_timeout=constants.JOB_TIMEOUT)
+      logger.info('Enqueuing log upload (dependent) %s', project_name)
+      upload_q.enqueue(logs.update_log_page_for_project,
+                       project_name,
+                       depends_on=update_job,
+                       job_timeout=constants.JOB_TIMEOUT)
+    else:
+      logger.warning('Skipping enqueuing the upload job because environment is '
+                     'not PRODUCTION')
 
 
 if __name__ == '__main__':

--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -35,6 +35,13 @@ CREDENTIALS = {
             'db': 'enwp10_dev',
         },
 
+        # Credentials for connecting to Redis. In deveoplment, this is also
+        # run as a docker-compose service.
+        'REDIS': {
+            'host': 'localhost',
+            'port': 9736,
+        },
+
         # WMF wiki OAuth credentials.
         'API': {
             'CONSUMER_TOKEN': 'some_consumer_token',
@@ -65,6 +72,12 @@ CREDENTIALS = {
     #     'host': 'tools.db.svc.eqiad.wmflabs',
     #     'db': 's51114_enwp10',
     #   },
+
+    #   # Credentials for connecting to Redis. In production, this is part of
+    #   # the production docker-compose and has hostname 'redis'.
+    #   'REDIS': {
+    #       'host': 'redis',
+    #   }
 
     #   # WMF wiki oauth credentials
     #   'API': {


### PR DESCRIPTION
And use the environment specific credentials in enqueue-* scripts.

This allows a development user to update his or her development database using those scripts.