### PR TITLE
Create the NotA-Class categories when updating a project

### DIFF
--- a/conf.json
+++ b/conf.json
@@ -12,6 +12,7 @@
     "Mid-Class": 200,
     "Low-Class": 100,
     "NA-Class": 25,
+    "NotA-Class": 21,
     "Unknown-Class": 0
   },
   "NOT_A_CLASS": "NotA-Class",
@@ -37,6 +38,7 @@
     "Redirect-Class": 43,
     "Template-Class": 40,
     "NA-Class": 25,
+    "NotA-Class": 21,
     "Assessed-Class": 20,
     "Unassessed-Class": 0
   },

--- a/wp1/logic/project.py
+++ b/wp1/logic/project.py
@@ -235,6 +235,26 @@ def update_category(wp10db, project, page, extra, kind, rating_to_category):
   logic_category.insert_or_update(wp10db, category)
 
 
+def create_not_a_class_categories(wp10db, project):
+  for kind in (AssessmentKind.QUALITY, AssessmentKind.IMPORTANCE):
+    rating = NOT_A_CLASS
+
+    if kind == AssessmentKind.QUALITY:
+      rating_map = QUALITY
+    else:
+      rating_map = IMPORTANCE
+    ranking = rating_map[rating]
+
+    category = Category(c_project=project.p_project,
+                        c_type=kind.value.encode('utf-8'),
+                        c_rating=rating.encode('utf-8'),
+                        c_category=b'',
+                        c_ranking=ranking,
+                        c_replacement=b'Unknown-Class')
+
+    logic_category.insert_or_update(wp10db, category)
+
+
 def update_project_categories_by_kind(wikidb, wp10db, project, extra, kind):
   logger.info('Updating project categories for %s', project.p_project)
   rating_to_category = {}
@@ -255,6 +275,10 @@ def update_project_categories_by_kind(wikidb, wp10db, project, extra, kind):
     # the alternate name ("by priority"), unless we already found pages.
     if found_page:
       break
+
+  # There is no wiki category for NotA-Class, but we need to make categories
+  # for it so that it shows up in the assessment table.
+  create_not_a_class_categories(wp10db, project)
 
   return rating_to_category
 

--- a/wp1/logic/project_test.py
+++ b/wp1/logic/project_test.py
@@ -271,6 +271,9 @@ class UpdateProjectCategoriesByKindTest(BaseCombinedDbTest):
 
     categories = _get_all_categories(self.wp10db)
     self.assertNotEqual(0, len(categories))
+    categories = [
+        cat for cat in categories if cat.c_rating != NOT_A_CLASS.encode('utf-8')
+    ]
     for category in categories:
       self.assertEqual(self.project.p_project, category.c_project)
       self.assertEqual(b'quality', category.c_type)
@@ -304,6 +307,9 @@ class UpdateProjectCategoriesByKindTest(BaseCombinedDbTest):
 
     categories = _get_all_categories(self.wp10db)
     self.assertNotEqual(0, len(categories))
+    categories = [
+        cat for cat in categories if cat.c_rating != NOT_A_CLASS.encode('utf-8')
+    ]
     for category in categories:
       self.assertEqual(self.project.p_project, category.c_project)
       self.assertEqual(b'importance', category.c_type)
@@ -327,6 +333,9 @@ class UpdateProjectCategoriesByKindTest(BaseCombinedDbTest):
 
     categories = _get_all_categories(self.wp10db)
     self.assertNotEqual(0, len(categories))
+    categories = [
+        cat for cat in categories if cat.c_rating != NOT_A_CLASS.encode('utf-8')
+    ]
     for category in categories:
       self.assertEqual(self.project.p_project, category.c_project)
       self.assertEqual(b'importance', category.c_type)


### PR DESCRIPTION
This is needed for new projects, since there is no actual wiki category for "NotAClass" category, but it's used in the assessment table. Without this, new projects won't have an "other" category displayed in their assessment table.

A consequence of this is that we need to re-run the update job for all of the dev database projects, so that the dev server produces accurate tables.