### PR TITLE
Display project table on Frontend homepage when project is selected

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -42,6 +42,30 @@ paths:
                 properties:
                   count:
                     type: integer
+  /projects/{projectId}/table:
+    get:
+      summary: 'Data for building a summary table for a given project'
+      operationId: projectTable
+      responses:
+        200:
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  table_data:
+                    type: object
+                    description: 'The various data needed to construct the table'
+        404:
+          description: 'No project with that projectId was found'
+    parameters:
+      - name: projectId
+        in: path
+        required: true
+        description: 'The name of the project, with spaces replaced by "_"'
+        schema:
+          type: string
 components:
   schemas:
     Project:

--- a/wp1-frontend/src/App.vue
+++ b/wp1-frontend/src/App.vue
@@ -12,7 +12,14 @@
           A list of indexed projects is available using the autocomplete search
           box below
         </p>
-        <Autocomplete></Autocomplete>
+        <Autocomplete
+          v-on:select-project="currentProject = $event"
+        ></Autocomplete>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col">
+        <ProjectTable v-bind:projectId="currentProjectId"></ProjectTable>
       </div>
     </div>
   </div>
@@ -20,13 +27,28 @@
 
 <script>
 import Autocomplete from './components/Autocomplete.vue';
+import ProjectTable from './components/ProjectTable.vue';
 import Stats from './components/Stats.vue';
 
 export default {
   name: 'app',
   components: {
     Autocomplete,
+    ProjectTable,
     Stats
+  },
+  data: function() {
+    return {
+      currentProject: null
+    };
+  },
+  computed: {
+    currentProjectId: function() {
+      if (!this.currentProject) {
+        return null;
+      }
+      return this.currentProject.replace(' ', '_');
+    }
   }
 };
 </script>

--- a/wp1-frontend/src/components/Autocomplete.vue
+++ b/wp1-frontend/src/components/Autocomplete.vue
@@ -56,7 +56,7 @@ export default {
     },
     focusList: function() {
       if (!this.results.length) {
-        return;
+        this.results = this.projects;
       }
       this.isOpen = true;
       this.$refs.list.children[0].focus();
@@ -94,6 +94,8 @@ export default {
       this.search = event.target.innerText;
       this.isOpen = false;
       this.filterResults();
+      window.console.log('About to emit');
+      this.$emit('select-project', this.search);
     }
   }
 };

--- a/wp1-frontend/src/components/Autocomplete.vue
+++ b/wp1-frontend/src/components/Autocomplete.vue
@@ -10,6 +10,9 @@
         type="text"
         placeholder="Project name"
       />
+      <button v-on:click="onButtonClick()" class="btn-primary">
+        Make Table
+      </button>
     </div>
     <ul tabindex="0" ref="list" class="results" v-show="isOpen">
       <li
@@ -90,12 +93,20 @@ export default {
       }
       this.filterResults();
     },
-    selectResult: function(event) {
-      this.search = event.target.innerText;
+    makeSelection: function() {
       this.isOpen = false;
       this.filterResults();
-      window.console.log('About to emit');
       this.$emit('select-project', this.search);
+    },
+    onButtonClick: function() {
+      if (this.results.length == 1) {
+        this.search = this.results[0].name;
+      }
+      this.makeSelection();
+    },
+    selectResult: function(event) {
+      this.search = event.target.innerText;
+      this.makeSelection();
     }
   }
 };

--- a/wp1-frontend/src/components/ProjectTable.vue
+++ b/wp1-frontend/src/components/ProjectTable.vue
@@ -1,16 +1,110 @@
 <template>
-  <table>
-    <tbody>
-      <tr>
-        <td>{{ tableData }}</td>
-      </tr>
-    </tbody>
+  <table v-if="tableData">
+    <th :colspan="tableData.total_cols">{{ tableData.title }}</th>
+    <tr>
+      <th class="quality" rowspan="2">Quality</th>
+      <th
+        v-if="!tableData.is_single_col"
+        class="importance"
+        :colspan="tableData.total_cols - 1"
+      >
+        Importance
+      </th>
+    </tr>
+    <tr>
+      <th
+        v-for="col in tableData.ordered_cols"
+        :class="getClass(tableData.col_labels[col])"
+        :key="col"
+      >
+        <WikiLink
+          v-if="tableData.col_labels[col].href"
+          :href="tableData.col_labels[col].href"
+          :text="tableData.col_labels[col].text"
+        ></WikiLink>
+        <span v-if="!tableData.col_labels[col].href">{{
+          tableData.col_labels[col]
+        }}</span>
+      </th>
+      <th class="total">Total</th>
+    </tr>
+
+    <tr />
+    <tr v-for="row in tableData.ordered_rows" :key="row">
+      <th :class="getClass(tableData.row_labels[row])">
+        <span v-if="tableData.row_labels[row].text == 'FA'">
+          <img
+            alt="Featured list"
+            src="//upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Featured_article_star.svg/16px-Featured_article_star.svg.png"
+            decoding="async"
+            width="16"
+            height="16"
+            srcset="
+              //upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Featured_article_star.svg/24px-Featured_article_star.svg.png 1.5x,
+              //upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Featured_article_star.svg/32px-Featured_article_star.svg.png 2x
+            "
+            data-file-width="180"
+            data-file-height="180"
+            style="position:relative; top: -2px"
+          />
+        </span>
+        <span v-if="tableData.row_labels[row].text == 'GA'">
+          <img
+            alt=""
+            src="//upload.wikimedia.org/wikipedia/en/thumb/9/94/Symbol_support_vote.svg/16px-Symbol_support_vote.svg.png"
+            decoding="async"
+            title="Good article"
+            width="16"
+            height="16"
+            srcset="
+              //upload.wikimedia.org/wikipedia/en/thumb/9/94/Symbol_support_vote.svg/24px-Symbol_support_vote.svg.png 1.5x,
+              //upload.wikimedia.org/wikipedia/en/thumb/9/94/Symbol_support_vote.svg/32px-Symbol_support_vote.svg.png 2x
+            "
+            data-file-width="180"
+            data-file-height="185"
+            style="position:relative; top: -2px"
+          />
+        </span>
+        <WikiLink
+          v-if="tableData.row_labels[row].href"
+          :href="tableData.row_labels[row].href"
+          :text="tableData.row_labels[row].text"
+        ></WikiLink>
+        <span v-if="!tableData.row_labels[row].href">
+          {{ tableData.row_labels[row] }}
+        </span>
+      </th>
+      <td v-for="col in tableData.ordered_cols" :key="col">
+        <span v-if="tableData.data[row][col]">
+          {{ tableData.data[row][col] }}
+        </span>
+      </td>
+      <td>
+        {{ tableData.row_totals[row] }}
+      </td>
+    </tr>
+
+    <tr />
+    <tr>
+      <td>Total</td>
+      <td v-for="col in tableData.ordered_cols" :key="col">
+        {{ tableData.col_totals[col] }}
+      </td>
+      <td>
+        {{ tableData.total }}
+      </td>
+    </tr>
   </table>
 </template>
 
 <script>
+import WikiLink from './WikiLink.vue';
+
 export default {
   name: 'projecttable',
+  components: {
+    WikiLink
+  },
   props: {
     projectId: String
   },
@@ -32,8 +126,108 @@ export default {
       this.tableData = json.table_data;
     }
   },
-  methods: {}
+  methods: {
+    getClass: function(cls) {
+      if (cls.text) {
+        return cls.text;
+      }
+      return cls;
+    }
+  }
 };
 </script>
 
-<style scoped></style>
+<style scoped>
+table {
+  background: #eee;
+  border-collapse: collapse;
+  border: 1px solid #aaa;
+  margin: auto;
+  text-align: right;
+}
+
+th {
+  border: 1px solid #aaa;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  text-align: center;
+}
+
+td {
+  border: 1px solid #aaa;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.quality {
+  vertical-align: bottom;
+}
+
+.Top {
+  background: #ff97ff;
+}
+
+.High {
+  background: #ffacff;
+}
+
+.Mid {
+  background: #ffc1ff;
+}
+
+.Low {
+  background: #ffd6ff;
+}
+
+.FA {
+  background: #9cbdff;
+}
+
+.GA {
+  background: #66ff66;
+}
+
+.B {
+  background: #b2ff66;
+}
+
+.C {
+  background: #ffff66;
+}
+
+.Start {
+  background: #ffaa66;
+}
+
+.Stub {
+  background: #ffa4a4;
+}
+
+.List {
+  background: #c7b1ff;
+}
+
+.Category {
+  background: #ffdb58;
+}
+
+.Disambig {
+  background: #00fa9a;
+}
+
+.File {
+  background: #ddccff;
+}
+
+.Project {
+  background: #c0c090;
+}
+
+.Redirect {
+  background: #c0c0c0;
+}
+
+.Template {
+  background: #fbceb1;
+}
+</style>

--- a/wp1-frontend/src/components/ProjectTable.vue
+++ b/wp1-frontend/src/components/ProjectTable.vue
@@ -1,0 +1,39 @@
+<template>
+  <table>
+    <tbody>
+      <tr>
+        <td>{{ tableData }}</td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script>
+export default {
+  name: 'projecttable',
+  props: {
+    projectId: String
+  },
+  data: function() {
+    return {
+      tableData: null
+    };
+  },
+  watch: {
+    projectId: async function(projectId) {
+      if (!projectId) {
+        this.tableData = null;
+        return;
+      }
+      const response = await fetch(
+        `${process.env.VUE_APP_API_URL}/projects/${projectId}/table`
+      );
+      const json = await response.json();
+      this.tableData = json.table_data;
+    }
+  },
+  methods: {}
+};
+</script>
+
+<style scoped></style>

--- a/wp1-frontend/src/components/WikiLink.vue
+++ b/wp1-frontend/src/components/WikiLink.vue
@@ -1,0 +1,15 @@
+<template>
+  <a :href="href">{{ text }}</a>
+</template>
+
+<script>
+export default {
+  name: 'wikilink',
+  props: {
+    href: String,
+    text: String
+  }
+};
+</script>
+
+<style scoped></style>

--- a/wp1-frontend/yarn.lock
+++ b/wp1-frontend/yarn.lock
@@ -1796,11 +1796,6 @@ abab@^2.0.0:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
   integrity sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==
 
-abbrev@1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
-  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
-
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -3832,7 +3827,7 @@ debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.0.1, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
+debug@^3.0.0, debug@^3.0.1, debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -3867,11 +3862,6 @@ deep-equal@^1.0.1, deep-equal@^1.1.1:
     object-is "^1.0.1"
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -3989,11 +3979,6 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-node@^2.0.4:
   version "2.0.4"
@@ -5092,13 +5077,6 @@ fs-extra@^8.0.1, fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
-  dependencies:
-    minipass "^2.6.0"
-
 fs-minipass@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
@@ -5724,7 +5702,7 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -5747,13 +5725,6 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
-
-ignore-walk@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
-  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
-  dependencies:
-    minimatch "^3.0.4"
 
 ignore@^3.3.5:
   version "3.3.10"
@@ -5851,7 +5822,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.5, ini@~1.3.0:
+ini@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -7118,27 +7089,12 @@ minipass-pipeline@^1.2.2:
   dependencies:
     minipass "^3.0.0"
 
-minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
 minipass@^3.0.0, minipass@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.1.tgz#7607ce778472a185ad6d89082aa2070f79cedcd5"
   integrity sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==
   dependencies:
     yallist "^4.0.0"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
 
 mississippi@^3.0.0:
   version "3.0.0"
@@ -7164,7 +7120,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -7262,15 +7218,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.0.tgz#6833e74975c444642590e15a750288c5f939b57c"
-  integrity sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -7363,36 +7310,12 @@ node-loggly-bulk@^2.2.4:
     moment "^2.18.1"
     request ">=2.76.0 <3.0.0"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.29, node-releases@^1.1.46:
   version "1.1.47"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.47.tgz#c59ef739a1fd7ecbd9f0b7cf5b7871e8a8b591e4"
   integrity sha512-k4xjVPx5FpwBUj0Gw7uvFOTF4Ep8Hok1I6qjwL3pLfwe7Y0REQSAqOwwv9TWBCUtMHxcXfY4PgRLRozcChvTcA==
   dependencies:
     semver "^6.3.0"
-
-nopt@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
-  integrity sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=
-  dependencies:
-    abbrev "1"
-    osenv "^0.1.4"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -7441,27 +7364,6 @@ normalize-url@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
-npm-bundled@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
-  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
-  dependencies:
-    npm-normalize-package-bin "^1.0.1"
-
-npm-normalize-package-bin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
-  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
-
-npm-packlist@^1.1.6:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
-  integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
-    npm-normalize-package-bin "^1.0.1"
-
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -7476,7 +7378,7 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -7719,11 +7621,6 @@ os-browserify@^0.3.0:
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
   integrity sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=
 
-os-homedir@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
-  integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
-
 os-locale@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
@@ -7740,18 +7637,10 @@ os-locale@^3.0.0:
     lcid "^2.0.0"
     mem "^4.0.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
+os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
-
-osenv@^0.1.4:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
-  integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
-  dependencies:
-    os-homedir "^1.0.0"
-    os-tmpdir "^1.0.0"
 
 p-defer@^1.0.0:
   version "1.0.0"
@@ -8797,16 +8686,6 @@ raw-loader@^3.1.0:
     loader-utils "^1.1.0"
     schema-utils "^2.0.1"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 react-clientside-effect@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz#6212fb0e07b204e714581dd51992603d1accc837"
@@ -9422,7 +9301,7 @@ selfsigned@^1.10.7:
   dependencies:
     node-forge "0.9.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -10091,7 +9970,7 @@ strip-indent@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
   integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
-strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
+strip-json-comments@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
@@ -10190,19 +10069,6 @@ tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
-
-tar@^4.4.2:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
 
 telejson@^3.2.0:
   version "3.3.0"
@@ -11179,7 +11045,7 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
+yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==

--- a/wp1/api.py
+++ b/wp1/api.py
@@ -23,7 +23,7 @@ def login():
   try:
     api_creds = get_credentials()
     if api_creds is None:
-      logger.warning('Not creating site, no credentials')
+      logger.warning('Not creating API site object, no credentials')
       return
     site = mwclient.Site('en.wikipedia.org', clients_useragent=_ua)
     site.login(api_creds['user'], api_creds['pass'])

--- a/wp1/tables.py
+++ b/wp1/tables.py
@@ -131,10 +131,11 @@ def make_wiki_link(wiki_text):
 
   if wiki_text == '{{Assessed-Class}}':
     return 'Assessed'
-  elif 'Other' in wiki_text:
+
+  if 'Other' in wiki_text:
     return 'Other'
-  else:
-    return wiki_text
+
+  return wiki_text
 
 
 def convert_table_data_for_web(data):

--- a/wp1/tables.py
+++ b/wp1/tables.py
@@ -117,6 +117,39 @@ def db_project_categories(wp10db, project_name):
     return cursor.fetchall()
 
 
+def convert_table_data_for_web(data):
+  data = dict(data)
+  if 'project' in data:
+    data['project'] = data['project'].decode('utf-8')
+  if 'ordered_cols' in data:
+    data['ordered_cols'] = [x.decode('utf-8') for x in data['ordered_cols']]
+  if 'ordered_rows' in data:
+    data['ordered_rows'] = [x.decode('utf-8') for x in data['ordered_rows']]
+  if 'col_labels' in data:
+    data['col_labels'] = dict((key.decode('utf-8'), val.replace("'''", ''))
+                              for key, val in data['col_labels'].items())
+  if 'row_labels' in data:
+    data['row_labels'] = dict(
+        (key.decode('utf-8'), val.replace('{{', '').replace('}}', ''))
+        for key, val in data['row_labels'].items())
+  if 'row_totals' in data:
+    data['row_totals'] = dict(
+        (key.decode('utf-8'), val) for key, val in data['row_totals'].items())
+  if 'col_totals' in data:
+    data['col_totals'] = dict(
+        (key.decode('utf-8'), val) for key, val in data['col_totals'].items())
+
+  if 'data' in data:
+    new = {}
+    for key, value in data['data'].items():
+      print('k: %s, v: %s' % (key, value))
+      new[key.decode('utf-8')] = dict(
+          (k.decode('utf-8'), v) for k, v in value.items())
+    data['data'] = new
+
+  return data
+
+
 def get_project_categories(wp10db, project_name):
   sort_imp = {}
   sort_qual = {}

--- a/wp1/tables.py
+++ b/wp1/tables.py
@@ -227,7 +227,6 @@ def generate_table_data(stats, categories, table_overrides=None):
   for col in cols.keys():
     if col not in categories['sort_imp']:
       to_del.append(col)
-  print('cols to del %s' % to_del)
   for c in to_del:
     del cols[c]
 

--- a/wp1/tables.py
+++ b/wp1/tables.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 import logging
+import re
 
 from wp1 import api
 from wp1.conf import get_conf
@@ -20,6 +21,9 @@ config = get_conf()
 NOT_A_CLASS = config['NOT_A_CLASS'].encode('utf-8')
 ASSESSED_CLASS = b'Assessed-Class'
 UNASSESSED_CLASS = b'Unassessed-Class'
+
+WIKI_BASE = 'https://en.wikipedia.org/wiki/'
+WIKI_LINK_RE = re.compile(r'{{([^|]+)\|category=([^}]+)}}')
 
 
 def labels_for_classes(sort_qual, sort_imp):
@@ -117,6 +121,21 @@ def db_project_categories(wp10db, project_name):
     return cursor.fetchall()
 
 
+def make_wiki_link(wiki_text):
+  md = WIKI_LINK_RE.match(wiki_text)
+  if md:
+    text = md.group(1).replace('-Class', '')
+    if text == 'Unknown':
+      text = '???'
+    return {'href': WIKI_BASE + md.group(2), 'text': text}
+  elif wiki_text == '{{Assessed-Class}}':
+    return 'Assessed'
+  elif 'Other' in wiki_text:
+    return 'Other'
+  else:
+    return wiki_text
+
+
 def convert_table_data_for_web(data):
   data = dict(data)
   if 'project' in data:
@@ -126,12 +145,11 @@ def convert_table_data_for_web(data):
   if 'ordered_rows' in data:
     data['ordered_rows'] = [x.decode('utf-8') for x in data['ordered_rows']]
   if 'col_labels' in data:
-    data['col_labels'] = dict((key.decode('utf-8'), val.replace("'''", ''))
+    data['col_labels'] = dict((key.decode('utf-8'), make_wiki_link(val))
                               for key, val in data['col_labels'].items())
   if 'row_labels' in data:
-    data['row_labels'] = dict(
-        (key.decode('utf-8'), val.replace('{{', '').replace('}}', ''))
-        for key, val in data['row_labels'].items())
+    data['row_labels'] = dict((key.decode('utf-8'), make_wiki_link(val))
+                              for key, val in data['row_labels'].items())
   if 'row_totals' in data:
     data['row_totals'] = dict(
         (key.decode('utf-8'), val) for key, val in data['row_totals'].items())
@@ -142,7 +160,6 @@ def convert_table_data_for_web(data):
   if 'data' in data:
     new = {}
     for key, value in data['data'].items():
-      print('k: %s, v: %s' % (key, value))
       new[key.decode('utf-8')] = dict(
           (k.decode('utf-8'), v) for k, v in value.items())
     data['data'] = new
@@ -215,6 +232,7 @@ def generate_table_data(stats, categories, table_overrides=None):
   for col in cols.keys():
     if col not in categories['sort_imp']:
       to_del.append(col)
+  print('cols to del %s' % to_del)
   for c in to_del:
     del cols[c]
 
@@ -266,6 +284,7 @@ def generate_table_data(stats, categories, table_overrides=None):
       'total': total,
       'col_labels': categories['imp_labels'],
       'row_labels': categories['qual_labels'],
+      'total_cols': len(ordered_cols) + 2,
   }
 
   # If we have only one column, don't display it because it is identical to the
@@ -351,7 +370,5 @@ def create_wikicode(table_data):
   template = jinja_env.get_template('table.jinja2')
   display = {
       'LIST_URL': LIST_URL,
-      # Number of columns plus one, plus a column for Total.
-      'total_cols': len(table_data['ordered_cols']) + 2,
   }
   return template.render({**table_data, **display})

--- a/wp1/tables.py
+++ b/wp1/tables.py
@@ -128,7 +128,8 @@ def make_wiki_link(wiki_text):
     if text == 'Unknown':
       text = '???'
     return {'href': WIKI_BASE + md.group(2), 'text': text}
-  elif wiki_text == '{{Assessed-Class}}':
+
+  if wiki_text == '{{Assessed-Class}}':
     return 'Assessed'
   elif 'Other' in wiki_text:
     return 'Other'
@@ -139,31 +140,23 @@ def make_wiki_link(wiki_text):
 def convert_table_data_for_web(data):
   data = dict(data)
 
-  if 'project' in data:
-    data['project'] = data['project'].decode('utf-8')
-  if 'ordered_cols' in data:
-    data['ordered_cols'] = [x.decode('utf-8') for x in data['ordered_cols']]
-  if 'ordered_rows' in data:
-    data['ordered_rows'] = [x.decode('utf-8') for x in data['ordered_rows']]
-  if 'col_labels' in data:
-    data['col_labels'] = dict((key.decode('utf-8'), make_wiki_link(val))
-                              for key, val in data['col_labels'].items())
-  if 'row_labels' in data:
-    data['row_labels'] = dict((key.decode('utf-8'), make_wiki_link(val))
-                              for key, val in data['row_labels'].items())
-  if 'row_totals' in data:
-    data['row_totals'] = dict(
-        (key.decode('utf-8'), val) for key, val in data['row_totals'].items())
-  if 'col_totals' in data:
-    data['col_totals'] = dict(
-        (key.decode('utf-8'), val) for key, val in data['col_totals'].items())
+  data['project'] = data['project'].decode('utf-8')
+  data['ordered_cols'] = [x.decode('utf-8') for x in data['ordered_cols']]
+  data['ordered_rows'] = [x.decode('utf-8') for x in data['ordered_rows']]
+  data['col_labels'] = dict((key.decode('utf-8'), make_wiki_link(val))
+                            for key, val in data['col_labels'].items())
+  data['row_labels'] = dict((key.decode('utf-8'), make_wiki_link(val))
+                            for key, val in data['row_labels'].items())
+  data['row_totals'] = dict(
+      (key.decode('utf-8'), val) for key, val in data['row_totals'].items())
+  data['col_totals'] = dict(
+      (key.decode('utf-8'), val) for key, val in data['col_totals'].items())
 
-  if 'data' in data:
-    new = {}
-    for key, value in data['data'].items():
-      new[key.decode('utf-8')] = dict(
-          (k.decode('utf-8'), v) for k, v in value.items())
-    data['data'] = new
+  new = {}
+  for key, value in data['data'].items():
+    new[key.decode('utf-8')] = dict(
+        (k.decode('utf-8'), v) for k, v in value.items())
+  data['data'] = new
 
   return data
 

--- a/wp1/tables.py
+++ b/wp1/tables.py
@@ -138,6 +138,7 @@ def make_wiki_link(wiki_text):
 
 def convert_table_data_for_web(data):
   data = dict(data)
+
   if 'project' in data:
     data['project'] = data['project'].decode('utf-8')
   if 'ordered_cols' in data:

--- a/wp1/tables_test.py
+++ b/wp1/tables_test.py
@@ -781,3 +781,428 @@ class TestMakeWikiLink(unittest.TestCase):
   def test_replaces_assessed(self):
     link = tables.make_wiki_link('{{Assessed-Class}}')
     self.assertEqual(link, 'Assessed')
+
+
+class TestConvertTableForWeb(unittest.TestCase):
+
+  data = {
+      'project': b'Modern_philosophy',
+      'project_display': 'Modern philosophy',
+      'create_link': True,
+      'title': 'Modern philosophy articles by quality and importance',
+      'center_table': False,
+      'data': {
+          b'B-Class': {
+              b'High-Class': 24,
+              b'Low-Class': 11,
+              b'Mid-Class': 15,
+              b'Top-Class': 7,
+              b'Unknown-Class': 3
+          },
+          b'C-Class': {
+              b'High-Class': 24,
+              b'Low-Class': 44,
+              b'Mid-Class': 49,
+              b'Top-Class': 3,
+              b'Unknown-Class': 10
+          },
+          b'Category-Class': {
+              b'Mid-Class': 1,
+              b'NotA-Class': 95
+          },
+          b'Disambig-Class': {
+              b'NotA-Class': 2
+          },
+          b'FA-Class': {
+              b'Mid-Class': 7
+          },
+          b'File-Class': {
+              b'NotA-Class': 10
+          },
+          b'GA-Class': {
+              b'High-Class': 4,
+              b'Low-Class': 4,
+              b'Top-Class': 1
+          },
+          b'List-Class': {
+              b'High-Class': 1,
+              b'Low-Class': 2,
+              b'Mid-Class': 1,
+              b'NotA-Class': 1
+          },
+          b'Project-Class': {
+              b'NotA-Class': 2
+          },
+          b'Redirect-Class': {
+              b'Low-Class': 2,
+              b'NotA-Class': 11
+          },
+          b'Start-Class': {
+              b'High-Class': 42,
+              b'Low-Class': 178,
+              b'Mid-Class': 77,
+              b'Top-Class': 1,
+              b'Unknown-Class': 11
+          },
+          b'Stub-Class': {
+              b'High-Class': 13,
+              b'Low-Class': 303,
+              b'Mid-Class': 49,
+              b'Unknown-Class': 11
+          },
+          b'Template-Class': {
+              b'NotA-Class': 10
+          },
+          b'Unassessed-Class': {
+              b'Unknown-Class': 1
+          },
+          b'Assessed-Class': {
+              b'Top-Class': 12,
+              b'High-Class': 108,
+              b'Mid-Class': 199,
+              b'Low-Class': 544,
+              b'NotA-Class': 131,
+              b'Unknown-Class': 35
+          }
+      },
+      'ordered_cols': [
+          b'Top-Class', b'High-Class', b'Mid-Class', b'Low-Class',
+          b'NotA-Class', b'Unknown-Class'
+      ],
+      'ordered_rows': [
+          b'FA-Class', b'GA-Class', b'B-Class', b'C-Class', b'Start-Class',
+          b'Stub-Class', b'List-Class', b'Category-Class', b'Disambig-Class',
+          b'File-Class', b'Project-Class', b'Redirect-Class', b'Template-Class',
+          b'Assessed-Class', b'Unassessed-Class'
+      ],
+      'row_totals': {
+          b'FA-Class': 7,
+          b'GA-Class': 9,
+          b'B-Class': 60,
+          b'C-Class': 130,
+          b'Start-Class': 309,
+          b'Stub-Class': 376,
+          b'List-Class': 5,
+          b'Category-Class': 96,
+          b'Disambig-Class': 2,
+          b'File-Class': 10,
+          b'Project-Class': 2,
+          b'Redirect-Class': 13,
+          b'Template-Class': 10,
+          b'Assessed-Class': 1029,
+          b'Unassessed-Class': 1
+      },
+      'col_totals': {
+          b'Top-Class': 12,
+          b'High-Class': 108,
+          b'Mid-Class': 199,
+          b'Low-Class': 544,
+          b'NotA-Class': 131,
+          b'Unknown-Class': 36
+      },
+      'total': 1030,
+      'col_labels': {
+          b'High-Class':
+              '{{High-Class|category=Category:High-importance_Modern_philosophy_articles}}',
+          b'Low-Class':
+              '{{Low-Class|category=Category:Low-importance_Modern_philosophy_articles}}',
+          b'Mid-Class':
+              '{{Mid-Class|category=Category:Mid-importance_Modern_philosophy_articles}}',
+          b'NotA-Class':
+              'Other',
+          b'Top-Class':
+              '{{Top-Class|category=Category:Top-importance_Modern_philosophy_articles}}',
+          b'Unknown-Class':
+              '{{Unknown-Class|category=Category:Unknown-importance_Modern_philosophy_articles}}',
+          b'Unassessed-Class':
+              'No-Class'
+      },
+      'row_labels': {
+          b'A-Class':
+              '{{A-Class|category=Category:A-Class_Modern_philosophy_articles}}',
+          b'B-Class':
+              '{{B-Class|category=Category:B-Class_Modern_philosophy_articles}}',
+          b'C-Class':
+              '{{C-Class|category=Category:C-Class_Modern_philosophy_articles}}',
+          b'Category-Class':
+              '{{Category-Class|category=Category:Category-Class_Modern_philosophy_articles}}',
+          b'Disambig-Class':
+              '{{Disambig-Class|category=Category:Disambig-Class_Modern_philosophy_articles}}',
+          b'FA-Class':
+              '{{FA-Class|category=Category:FA-Class_Modern_philosophy_articles}}',
+          b'File-Class':
+              '{{File-Class|category=Category:File-Class_Modern_philosophy_articles}}',
+          b'GA-Class':
+              '{{GA-Class|category=Category:GA-Class_Modern_philosophy_articles}}',
+          b'List-Class':
+              '{{List-Class|category=Category:List-Class_Modern_philosophy_articles}}',
+          b'NotA-Class':
+              ' style="text-align: center;" | \'\'\'Other\'\'\'',
+          b'Project-Class':
+              '{{Project-Class|category=Category:Project-Class_Modern_philosophy_articles}}',
+          b'Redirect-Class':
+              '{{Redirect-Class|category=Category:Redirect-Class_Modern_philosophy_articles}}',
+          b'Start-Class':
+              '{{Start-Class|category=Category:Start-Class_Modern_philosophy_articles}}',
+          b'Stub-Class':
+              '{{Stub-Class|category=Category:Stub-Class_Modern_philosophy_articles}}',
+          b'Template-Class':
+              '{{Template-Class|category=Category:Template-Class_Modern_philosophy_articles}}',
+          b'Unassessed-Class':
+              '{{Unassessed-Class|category=Category:Unassessed_Modern_philosophy_articles}}',
+          b'Assessed-Class':
+              '{{Assessed-Class}}'
+      },
+      'total_cols': 8
+  }
+
+  expected = {
+      'project': 'Modern_philosophy',
+      'project_display': 'Modern philosophy',
+      'create_link': True,
+      'title': 'Modern philosophy articles by quality and importance',
+      'center_table': False,
+      'data': {
+          'B-Class': {
+              'High-Class': 24,
+              'Low-Class': 11,
+              'Mid-Class': 15,
+              'Top-Class': 7,
+              'Unknown-Class': 3
+          },
+          'C-Class': {
+              'High-Class': 24,
+              'Low-Class': 44,
+              'Mid-Class': 49,
+              'Top-Class': 3,
+              'Unknown-Class': 10
+          },
+          'Category-Class': {
+              'Mid-Class': 1,
+              'NotA-Class': 95
+          },
+          'Disambig-Class': {
+              'NotA-Class': 2
+          },
+          'FA-Class': {
+              'Mid-Class': 7
+          },
+          'File-Class': {
+              'NotA-Class': 10
+          },
+          'GA-Class': {
+              'High-Class': 4,
+              'Low-Class': 4,
+              'Top-Class': 1
+          },
+          'List-Class': {
+              'High-Class': 1,
+              'Low-Class': 2,
+              'Mid-Class': 1,
+              'NotA-Class': 1
+          },
+          'Project-Class': {
+              'NotA-Class': 2
+          },
+          'Redirect-Class': {
+              'Low-Class': 2,
+              'NotA-Class': 11
+          },
+          'Start-Class': {
+              'High-Class': 42,
+              'Low-Class': 178,
+              'Mid-Class': 77,
+              'Top-Class': 1,
+              'Unknown-Class': 11
+          },
+          'Stub-Class': {
+              'High-Class': 13,
+              'Low-Class': 303,
+              'Mid-Class': 49,
+              'Unknown-Class': 11
+          },
+          'Template-Class': {
+              'NotA-Class': 10
+          },
+          'Unassessed-Class': {
+              'Unknown-Class': 1
+          },
+          'Assessed-Class': {
+              'Top-Class': 12,
+              'High-Class': 108,
+              'Mid-Class': 199,
+              'Low-Class': 544,
+              'NotA-Class': 131,
+              'Unknown-Class': 35
+          }
+      },
+      'ordered_cols': [
+          'Top-Class', 'High-Class', 'Mid-Class', 'Low-Class', 'NotA-Class',
+          'Unknown-Class'
+      ],
+      'ordered_rows': [
+          'FA-Class', 'GA-Class', 'B-Class', 'C-Class', 'Start-Class',
+          'Stub-Class', 'List-Class', 'Category-Class', 'Disambig-Class',
+          'File-Class', 'Project-Class', 'Redirect-Class', 'Template-Class',
+          'Assessed-Class', 'Unassessed-Class'
+      ],
+      'row_totals': {
+          'FA-Class': 7,
+          'GA-Class': 9,
+          'B-Class': 60,
+          'C-Class': 130,
+          'Start-Class': 309,
+          'Stub-Class': 376,
+          'List-Class': 5,
+          'Category-Class': 96,
+          'Disambig-Class': 2,
+          'File-Class': 10,
+          'Project-Class': 2,
+          'Redirect-Class': 13,
+          'Template-Class': 10,
+          'Assessed-Class': 1029,
+          'Unassessed-Class': 1
+      },
+      'col_totals': {
+          'Top-Class': 12,
+          'High-Class': 108,
+          'Mid-Class': 199,
+          'Low-Class': 544,
+          'NotA-Class': 131,
+          'Unknown-Class': 36
+      },
+      'total': 1030,
+      'col_labels': {
+          'High-Class': {
+              'href':
+                  'https://en.wikipedia.org/wiki/Category:High-importance_Modern_philosophy_articles',
+              'text':
+                  'High'
+          },
+          'Low-Class': {
+              'href':
+                  'https://en.wikipedia.org/wiki/Category:Low-importance_Modern_philosophy_articles',
+              'text':
+                  'Low'
+          },
+          'Mid-Class': {
+              'href':
+                  'https://en.wikipedia.org/wiki/Category:Mid-importance_Modern_philosophy_articles',
+              'text':
+                  'Mid'
+          },
+          'NotA-Class': 'Other',
+          'Top-Class': {
+              'href':
+                  'https://en.wikipedia.org/wiki/Category:Top-importance_Modern_philosophy_articles',
+              'text':
+                  'Top'
+          },
+          'Unknown-Class': {
+              'href':
+                  'https://en.wikipedia.org/wiki/Category:Unknown-importance_Modern_philosophy_articles',
+              'text':
+                  '???'
+          },
+          'Unassessed-Class': 'No-Class'
+      },
+      'row_labels': {
+          'A-Class': {
+              'href':
+                  'https://en.wikipedia.org/wiki/Category:A-Class_Modern_philosophy_articles',
+              'text':
+                  'A'
+          },
+          'B-Class': {
+              'href':
+                  'https://en.wikipedia.org/wiki/Category:B-Class_Modern_philosophy_articles',
+              'text':
+                  'B'
+          },
+          'C-Class': {
+              'href':
+                  'https://en.wikipedia.org/wiki/Category:C-Class_Modern_philosophy_articles',
+              'text':
+                  'C'
+          },
+          'Category-Class': {
+              'href':
+                  'https://en.wikipedia.org/wiki/Category:Category-Class_Modern_philosophy_articles',
+              'text':
+                  'Category'
+          },
+          'Disambig-Class': {
+              'href':
+                  'https://en.wikipedia.org/wiki/Category:Disambig-Class_Modern_philosophy_articles',
+              'text':
+                  'Disambig'
+          },
+          'FA-Class': {
+              'href':
+                  'https://en.wikipedia.org/wiki/Category:FA-Class_Modern_philosophy_articles',
+              'text':
+                  'FA'
+          },
+          'File-Class': {
+              'href':
+                  'https://en.wikipedia.org/wiki/Category:File-Class_Modern_philosophy_articles',
+              'text':
+                  'File'
+          },
+          'GA-Class': {
+              'href':
+                  'https://en.wikipedia.org/wiki/Category:GA-Class_Modern_philosophy_articles',
+              'text':
+                  'GA'
+          },
+          'List-Class': {
+              'href':
+                  'https://en.wikipedia.org/wiki/Category:List-Class_Modern_philosophy_articles',
+              'text':
+                  'List'
+          },
+          'NotA-Class': 'Other',
+          'Project-Class': {
+              'href':
+                  'https://en.wikipedia.org/wiki/Category:Project-Class_Modern_philosophy_articles',
+              'text':
+                  'Project'
+          },
+          'Redirect-Class': {
+              'href':
+                  'https://en.wikipedia.org/wiki/Category:Redirect-Class_Modern_philosophy_articles',
+              'text':
+                  'Redirect'
+          },
+          'Start-Class': {
+              'href':
+                  'https://en.wikipedia.org/wiki/Category:Start-Class_Modern_philosophy_articles',
+              'text':
+                  'Start'
+          },
+          'Stub-Class': {
+              'href':
+                  'https://en.wikipedia.org/wiki/Category:Stub-Class_Modern_philosophy_articles',
+              'text':
+                  'Stub'
+          },
+          'Template-Class': {
+              'href':
+                  'https://en.wikipedia.org/wiki/Category:Template-Class_Modern_philosophy_articles',
+              'text':
+                  'Template'
+          },
+          'Unassessed-Class': {
+              'href':
+                  'https://en.wikipedia.org/wiki/Category:Unassessed_Modern_philosophy_articles',
+              'text':
+                  'Unassessed'
+          },
+          'Assessed-Class': 'Assessed'
+      },
+      'total_cols': 8
+  }
+
+  def test_conversion(self):
+    actual = tables.convert_table_data_for_web(self.data)
+    self.assertEqual(actual, self.expected)

--- a/wp1/tables_test.py
+++ b/wp1/tables_test.py
@@ -762,3 +762,22 @@ class TablesDbTest(BaseWpOneDbTest):
       tables.upload_global_table()
     finally:
       self.wp10db.close = orig_close
+
+
+class TestMakeWikiLink(unittest.TestCase):
+
+  def test_creates_link(self):
+    link = tables.make_wiki_link(
+        '{{Foo-Class|category=Foo_categories_by_importance}}')
+    self.assertEqual(link['text'], 'Foo')
+    self.assertEqual(
+        link['href'],
+        'https://en.wikipedia.org/wiki/Foo_categories_by_importance')
+
+  def test_returns_verbatim(self):
+    link = tables.make_wiki_link('Foo Bar Baz')
+    self.assertEqual(link, 'Foo Bar Baz')
+
+  def test_replaces_assessed(self):
+    link = tables.make_wiki_link('{{Assessed-Class}}')
+    self.assertEqual(link, 'Assessed')

--- a/wp1/web/projects.py
+++ b/wp1/web/projects.py
@@ -3,6 +3,7 @@ import flask
 
 from wp1.web.db import get_db
 import wp1.logic.project as logic_project
+import wp1.tables as tables
 
 projects = flask.Blueprint('projects', __name__)
 
@@ -19,3 +20,13 @@ def count():
   wp10db = get_db('wp10db')
   count = logic_project.count_projects(wp10db)
   return flask.jsonify({'count': count})
+
+
+@projects.route('/<project_name>/table')
+def table(project_name):
+  wp10db = get_db('wp10db')
+  project_name_bytes = project_name.encode('utf-8')
+  data = tables.generate_project_table_data(wp10db, project_name_bytes)
+  data = tables.convert_table_data_for_web(data)
+
+  return flask.jsonify({'table_data': data})

--- a/wp1/web/projects.py
+++ b/wp1/web/projects.py
@@ -26,6 +26,10 @@ def count():
 def table(project_name):
   wp10db = get_db('wp10db')
   project_name_bytes = project_name.encode('utf-8')
+  project = logic_project.get_project_by_name(wp10db, project_name_bytes)
+  if project is None:
+    return flask.abort(404)
+
   data = tables.generate_project_table_data(wp10db, project_name_bytes)
   data = tables.convert_table_data_for_web(data)
 

--- a/wp1/web/projects_test.py
+++ b/wp1/web/projects_test.py
@@ -32,3 +32,14 @@ class ProjectTest(BaseWebTestcase):
       rv = client.get('/v1/projects/count')
       data = json.loads(rv.data)
       self.assertEqual(101, data['count'])
+
+  def test_table(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get('/v1/projects/Project 1/table')
+      data = json.loads(rv.data)
+      self.assertTrue('data' in data['table_data'])
+
+  def test_table_404(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get('/v1/projects/Foo Fake Project/table')
+      self.assertEqual('404 NOT FOUND', rv.status)


### PR DESCRIPTION
This PR creates a mapping from the project data used to generate the wikicode tables for Wikipedia, to a Vue component which displays a similar table on the homepage of the frontend server.

It adds a new endpoint to the API, which is documented in `openapi.yml`.

There are also some changes to the Autocomplete component to allow it to pass the project that is selected. Future changes will introduce routing so that users can visit the table page of a project directly.
