### PR TITLE
Remove reference to wikidb from api server

### DIFF
--- a/wp1/web/app.py
+++ b/wp1/web/app.py
@@ -63,9 +63,6 @@ def create_app():
 
   @app.teardown_request
   def close_dbs(ex):
-    if has_db('wikidb'):
-      conn = get_db('wikidb')
-      conn.close()
     if has_db('wp10db'):
       conn = get_db('wp10db')
       conn.close()

--- a/wp1/web/db.py
+++ b/wp1/web/db.py
@@ -1,11 +1,9 @@
 import flask
 
 from wp1.wp10_db import connect as wp10_connect
-from wp1.wiki_db import connect as wiki_connect
 
 DB_CONNECT = {
     'wp10db': wp10_connect,
-    'wikidb': wiki_connect,
 }
 
 


### PR DESCRIPTION
Originally the API server was setup to connect to both the WP 1.0 application db (wp10db) and the Wikipedia replica db (enwiki_p, or wikidb in the code).

I no longer believe that the wiki db connection is necessary so I'm removing the reference to it.