### PR TITLE
List articles and show links to article lists in project tables

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -66,6 +66,38 @@ paths:
         description: 'The name of the project, with spaces replaced by "_"'
         schema:
           type: string
+      - name: quality
+        in: query
+        required: false
+        description: 'The quality class of articles, used to filter the results. Eg: "FA-Class"'
+        schema:
+          type: string
+      - name: importance
+        in: query
+        required: false
+        description: 'The importance class of articles, used to filter the results. Eg: "High-Class"'
+        schema:
+          type: string
+  /projects/{projectId}/articles:
+    get:
+      summary: 'List of articles for a project, optionally filtered by quality/importance'
+      operationId: projectArticles
+      responses:
+        200:
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Article'
+    parameters:
+      - name: projectId
+        in: path
+        required: true
+        description: 'The name of the project, with spaces replaced by "_"'
+        schema:
+          type: string
 components:
   schemas:
     Project:
@@ -76,3 +108,26 @@ components:
         last_updated:
           type: string
           description: 'The last time the project was updated, in the date format YYYYMMDDhhmmss. So, year month day, hour minute second'
+    Article:
+      type: object
+      properties:
+        article:
+          type: string
+          description: 'The name of the article, as it appears on Wikipedia'
+        article_link:
+          type: string
+          description: 'A link to the article on Wikipedia'
+        importance:
+          type: string
+          description: 'The importance class of the article'
+        quality:
+          type: string
+          description: 'The quality class of the article'
+        importance_updated:
+          type: string
+          format: date
+          description: 'The date on which the article importance classification was updated'
+        quality_updated:
+          type: string
+          format: date
+          description: 'The date on which the article quality classification was updated'

--- a/wp1-frontend/src/components/ArticlePage.vue
+++ b/wp1-frontend/src/components/ArticlePage.vue
@@ -3,8 +3,33 @@
     <div class="row">
       <div class="col-6">
         <Autocomplete
+          :incomingSearch="incomingSearch || $route.params.projectName"
           v-on:select-project="currentProject = $event"
         ></Autocomplete>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col">
+        <h4>
+          {{ currentProject }} articles -
+          <span v-if="$route.query.importance"
+            >{{ displayClass($route.query.importance) }} importance</span
+          >
+          <span v-if="$route.query.quality"
+            ><span v-if="$route.query.importance"> and </span
+            >{{ displayClass($route.query.quality) }} quality</span
+          >
+        </h4>
+        <p><a :href="'#/project/' + currentProject">Back to table</a></p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col">
+        <ArticleTable
+          :projectId="currentProjectId"
+          :importance="$route.query.importance"
+          :quality="$route.query.quality"
+        ></ArticleTable>
       </div>
     </div>
   </div>
@@ -12,11 +37,49 @@
 
 <script>
 import Autocomplete from './Autocomplete.vue';
+import ArticleTable from './ArticleTable.vue';
 
 export default {
   name: 'articlepage',
   components: {
-    Autocomplete
+    Autocomplete,
+    ArticleTable
+  },
+  data: function() {
+    return {
+      currentProject: null,
+      incomingSearch: null
+    };
+  },
+  methods: {
+    displayClass: function(cls) {
+      return cls.split('-')[0];
+    }
+  },
+  computed: {
+    currentProjectId: function() {
+      if (!this.currentProject) {
+        return null;
+      }
+      return this.currentProject.replace(/ /g, '_');
+    }
+  },
+  watch: {
+    currentProject: function(val) {
+      if (val !== this.$route.params.projectName) {
+        this.$router.push({
+          path: `/project/${val}/articles`,
+          query: {
+            importance: this.$route.query.importance,
+            quality: this.$route.query.quality
+          }
+        });
+      }
+    }
+  },
+  beforeRouteUpdate(to, from, next) {
+    this.incomingSearch = to.params.projectName;
+    next();
   }
 };
 </script>

--- a/wp1-frontend/src/components/ArticlePage.vue
+++ b/wp1-frontend/src/components/ArticlePage.vue
@@ -14,21 +14,11 @@
 import Autocomplete from './Autocomplete.vue';
 
 export default {
-  name: 'app',
+  name: 'articlepage',
   components: {
     Autocomplete
-  },
-  data: function() {
-    return {
-      currentProject: null
-    };
-  },
-  watch: {
-    currentProject: function(val) {
-      this.$router.replace({ path: `project/${val}` });
-    }
   }
 };
 </script>
 
-<style></style>
+<style scoped></style>

--- a/wp1-frontend/src/components/ArticleTable.vue
+++ b/wp1-frontend/src/components/ArticleTable.vue
@@ -1,0 +1,91 @@
+<template>
+  <div>
+    <table>
+      <tr v-for="row in tableData" :key="row.article">
+        <td>
+          <a :href="row.article_link">{{ row.article }}</a>
+        </td>
+        <td :class="row.importance">{{ row.importance }}</td>
+        <td>{{ row.importance_updated }}</td>
+        <td :class="row.quality">{{ row.quality }}</td>
+        <td>{{ row.quality_updated }}</td>
+      </tr>
+    </table>
+
+    <h2 v-if="!tableData.length">No results to display</h2>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'articletable',
+  data: function() {
+    return {
+      tableData: null
+    };
+  },
+  props: {
+    projectId: String,
+    importance: String,
+    quality: String
+  },
+  watch: {
+    projectId: async function(projectId) {
+      if (!projectId) {
+        this.tableData = null;
+        return;
+      }
+      await this.updateTable();
+    },
+    importance: async function() {
+      await this.updateTable();
+    },
+    quality: async function() {
+      await this.updateTable();
+    }
+  },
+  methods: {
+    updateTable: async function() {
+      const url = new URL(
+        `${process.env.VUE_APP_API_URL}/projects/${this.projectId}/articles`
+      );
+      const params = {};
+      if (this.importance) {
+        params.importance = this.importance;
+      }
+      if (this.quality) {
+        params.quality = this.quality;
+      }
+      Object.keys(params).forEach(key =>
+        url.searchParams.append(key, params[key])
+      );
+
+      const response = await fetch(url);
+      this.tableData = await response.json();
+    }
+  }
+};
+</script>
+
+<style scoped>
+@import '../labels.scss';
+
+h2 {
+  text-align: center;
+}
+
+table {
+  border-collapse: collapse;
+  border: 1px solid #aaa;
+  margin: 1rem auto;
+}
+
+td {
+  border: 1px solid #aaa;
+  padding: 0 0.5rem;
+}
+
+tr:nth-child(even) {
+  background: lightyellow;
+}
+</style>

--- a/wp1-frontend/src/components/Autocomplete.vue
+++ b/wp1-frontend/src/components/Autocomplete.vue
@@ -15,7 +15,7 @@
         placeholder="Project name"
       />
       <button v-on:click="onButtonClick()" class="btn-primary">
-        Make Table
+        Select Project
       </button>
     </div>
     <ul tabindex="0" ref="list" class="results" v-show="isOpen">

--- a/wp1-frontend/src/components/Autocomplete.vue
+++ b/wp1-frontend/src/components/Autocomplete.vue
@@ -1,5 +1,9 @@
 <template>
   <div>
+    <p>
+      A list of indexed projects is available using the autocomplete search box
+      below
+    </p>
     <div class="input-group">
       <input
         v-model="search"

--- a/wp1-frontend/src/components/ProjectPage.vue
+++ b/wp1-frontend/src/components/ProjectPage.vue
@@ -2,10 +2,6 @@
   <div>
     <div class="row">
       <div class="col-6">
-        <p>
-          A list of indexed projects is available using the autocomplete search
-          box below
-        </p>
         <Autocomplete
           :incomingSearch="incomingSearch || $route.params.projectName"
           v-on:select-project="currentProject = $event"

--- a/wp1-frontend/src/components/ProjectTable.vue
+++ b/wp1-frontend/src/components/ProjectTable.vue
@@ -76,11 +76,15 @@
       </th>
       <td v-for="col in tableData.ordered_cols" :key="col">
         <span v-if="tableData.data[row][col]">
-          {{ tableData.data[row][col] }}
+          <a @click="setRoute(row, col)" class="table-link">{{
+            tableData.data[row][col]
+          }}</a>
         </span>
       </td>
       <td>
-        {{ tableData.row_totals[row] }}
+        <a @click="setRoute(row)" class="table-link">{{
+          tableData.row_totals[row]
+        }}</a>
       </td>
     </tr>
 
@@ -88,7 +92,9 @@
     <tr>
       <td>Total</td>
       <td v-for="col in tableData.ordered_cols" :key="col">
-        {{ tableData.col_totals[col] }}
+        <a @click="setRoute(undefined, col)" class="table-link">{{
+          tableData.col_totals[col]
+        }}</a>
       </td>
       <td>
         {{ tableData.total }}
@@ -132,12 +138,21 @@ export default {
         return cls.text;
       }
       return cls;
+    },
+    setRoute: function(quality, importance) {
+      const projectName = this.projectId.replace(/_/g, ' ');
+      this.$router.push({
+        path: `/project/${projectName}/articles`,
+        query: { quality: quality, importance: importance }
+      });
     }
   }
 };
 </script>
 
 <style scoped>
+@import '../labels.scss';
+
 table {
   background: #eee;
   border-collapse: collapse;
@@ -159,75 +174,12 @@ td {
   padding-right: 0.5rem;
 }
 
+.table-link {
+  color: #007bff;
+  cursor: pointer;
+}
+
 .quality {
   vertical-align: bottom;
-}
-
-.Top {
-  background: #ff97ff;
-}
-
-.High {
-  background: #ffacff;
-}
-
-.Mid {
-  background: #ffc1ff;
-}
-
-.Low {
-  background: #ffd6ff;
-}
-
-.FA {
-  background: #9cbdff;
-}
-
-.GA {
-  background: #66ff66;
-}
-
-.B {
-  background: #b2ff66;
-}
-
-.C {
-  background: #ffff66;
-}
-
-.Start {
-  background: #ffaa66;
-}
-
-.Stub {
-  background: #ffa4a4;
-}
-
-.List {
-  background: #c7b1ff;
-}
-
-.Category {
-  background: #ffdb58;
-}
-
-.Disambig {
-  background: #00fa9a;
-}
-
-.File {
-  background: #ddccff;
-}
-
-.Project {
-  background: #c0c090;
-}
-
-.Redirect {
-  background: #c0c0c0;
-}
-
-.Template {
-  background: #fbceb1;
 }
 </style>

--- a/wp1-frontend/src/labels.scss
+++ b/wp1-frontend/src/labels.scss
@@ -1,0 +1,67 @@
+.Top {
+  background: #ff97ff;
+}
+
+.High {
+  background: #ffacff;
+}
+
+.Mid {
+  background: #ffc1ff;
+}
+
+.Low {
+  background: #ffd6ff;
+}
+
+.FA {
+  background: #9cbdff;
+}
+
+.GA {
+  background: #66ff66;
+}
+
+.B {
+  background: #b2ff66;
+}
+
+.C {
+  background: #ffff66;
+}
+
+.Start {
+  background: #ffaa66;
+}
+
+.Stub {
+  background: #ffa4a4;
+}
+
+.List {
+  background: #c7b1ff;
+}
+
+.Category {
+  background: #ffdb58;
+}
+
+.Disambig {
+  background: #00fa9a;
+}
+
+.File {
+  background: #ddccff;
+}
+
+.Project {
+  background: #c0c090;
+}
+
+.Redirect {
+  background: #c0c0c0;
+}
+
+.Template {
+  background: #fbceb1;
+}

--- a/wp1-frontend/src/main.js
+++ b/wp1-frontend/src/main.js
@@ -5,6 +5,7 @@ import Vue from 'vue';
 import VueRouter from 'vue-router';
 
 import App from './App.vue';
+import ArticlePage from './components/ArticlePage.vue';
 import IndexPage from './components/IndexPage.vue';
 import ProjectPage from './components/ProjectPage.vue';
 
@@ -12,13 +13,38 @@ Vue.config.productionTip = false;
 
 Vue.use(VueRouter);
 
+const BASE_TITLE = 'Wikipedia 1.0 Server';
+
 const routes = [
-  { path: '/', component: IndexPage },
-  { path: '/project/:projectName', component: ProjectPage }
+  {
+    path: '/',
+    component: IndexPage,
+    meta: { title: () => BASE_TITLE }
+  },
+  {
+    path: '/project/:projectName',
+    component: ProjectPage,
+    meta: {
+      title: route => BASE_TITLE + ' - ' + route.params.projectName
+    }
+  },
+  {
+    path: '/project/:projectName/articles',
+    component: ArticlePage,
+    meta: {
+      title: route =>
+        BASE_TITLE + ' - ' + route.params.projectName + ' articles'
+    }
+  }
 ];
 
 const router = new VueRouter({
   routes
+});
+
+router.beforeEach((to, from, next) => {
+  document.title = to.meta.title(to);
+  next();
 });
 
 new Vue({

--- a/wp1/constants.py
+++ b/wp1/constants.py
@@ -27,3 +27,5 @@ JOB_TIMEOUT = 60 * 60 * 2  # 2 hours
 
 LOG_NS = 4
 MAX_LOGS_PER_DAY = 100000
+
+WIKI_BASE = 'https://en.wikipedia.org/wiki/'

--- a/wp1/logic/rating.py
+++ b/wp1/logic/rating.py
@@ -38,6 +38,7 @@ def get_project_rating_by_type(wp10db,
     if importance is not None:
       query += ' AND r_importance = %(r_importance)s'
 
+    # Hardcode a limit of 100 for now. Need to revisit this.
     query += ' LIMIT 100'
 
     cursor.execute(

--- a/wp1/logic/rating.py
+++ b/wp1/logic/rating.py
@@ -24,6 +24,31 @@ def get_project_ratings(wp10db, project_name):
     return [Rating(**db_rating) for db_rating in cursor.fetchall()]
 
 
+def get_project_rating_by_type(wp10db,
+                               project_name,
+                               quality=None,
+                               importance=None):
+  with wp10db.cursor() as cursor:
+    query = ('SELECT * FROM ' + Rating.table_name + '''
+      WHERE r_project = %(r_project)s
+    ''')
+
+    if quality is not None:
+      query += ' AND r_quality = %(r_quality)s'
+    if importance is not None:
+      query += ' AND r_importance = %(r_importance)s'
+
+    query += ' LIMIT 100'
+
+    cursor.execute(
+        query, {
+            'r_project': project_name,
+            'r_quality': quality,
+            'r_importance': importance,
+        })
+    return [Rating(**db_rating) for db_rating in cursor.fetchall()]
+
+
 def insert_or_update(wp10db, rating, kind):
   duplicate_clause = ''
   if kind == AssessmentKind.QUALITY:

--- a/wp1/models/wp10/rating.py
+++ b/wp1/models/wp10/rating.py
@@ -3,7 +3,7 @@ import logging
 
 import attr
 
-from wp1.constants import TS_FORMAT
+from wp1.constants import TS_FORMAT, WIKI_BASE
 
 logger = logging.getLogger(__name__)
 
@@ -46,3 +46,26 @@ class Rating:
           'Attempt to set rating importance_timestamp to None ignored')
       return
     self.r_importance_timestamp = dt.strftime(TS_FORMAT).encode('utf-8')
+
+  def _ts_for_web(self, ts):
+    return ts.split('T')[0]
+
+  def _web_label(self, cls):
+    return cls.split('-')[0]
+
+  def to_web_dict(self):
+    article_name = self.r_article.decode('utf-8').replace('_', ' ')
+    return {
+        'article':
+            article_name,
+        'article_link':
+            WIKI_BASE + 'index.php?title=' + article_name,
+        'quality':
+            self._web_label(self.r_quality.decode('utf-8')),
+        'quality_updated':
+            self._ts_for_web(self.r_quality_timestamp.decode('utf-8')),
+        'importance':
+            self._web_label(self.r_importance.decode('utf-8')),
+        'importance_updated':
+            self._ts_for_web(self.r_importance_timestamp.decode('utf-8')),
+    }

--- a/wp1/tables.py
+++ b/wp1/tables.py
@@ -4,7 +4,7 @@ import re
 
 from wp1 import api
 from wp1.conf import get_conf
-from wp1.constants import LIST_URL
+from wp1.constants import LIST_URL, WIKI_BASE
 from wp1.models.wp10.category import Category
 from wp1.models.wp10.rating import Rating
 from wp1.templates import env as jinja_env
@@ -22,7 +22,6 @@ NOT_A_CLASS = config['NOT_A_CLASS'].encode('utf-8')
 ASSESSED_CLASS = b'Assessed-Class'
 UNASSESSED_CLASS = b'Unassessed-Class'
 
-WIKI_BASE = 'https://en.wikipedia.org/wiki/'
 WIKI_LINK_RE = re.compile(r'{{([^|]+)\|category=([^}]+)}}')
 
 

--- a/wp1/web/projects.py
+++ b/wp1/web/projects.py
@@ -45,8 +45,8 @@ def articles(project_name):
   if project is None:
     return flask.abort(404)
 
-  quality = flask.request.form.get('quality')
-  importance = flask.request.form.get('importance')
+  quality = flask.request.args.get('quality')
+  importance = flask.request.args.get('importance')
 
   if quality:
     quality = quality.encode('utf-8')

--- a/wp1/web/projects_test.py
+++ b/wp1/web/projects_test.py
@@ -15,10 +15,33 @@ class ProjectTest(BaseWebTestcase):
           'p_timestamp': b'20181225'
       })
 
+    ratings = []
+    for i in range(25):
+      for quality in ('FA-Class', 'A-Class', 'B-Class'):
+        for importance in ('High-Class', 'Low-Class'):
+          ratings.append({
+              'r_project': 'Project 0',
+              'r_namespace': 0,
+              'r_article': '%s_%s_%s' % (quality, importance, i),
+              'r_score': 0,
+              'r_quality': quality,
+              'r_quality_timestamp': '20191225T00:00:00',
+              'r_importance': importance,
+              'r_importance_timestamp': '20191226T00:00:00',
+          })
+
     with self.wp10db.cursor() as cursor:
       cursor.executemany(
           'INSERT INTO projects (p_project, p_timestamp) '
           'VALUES (%(p_project)s, %(p_timestamp)s)', projects)
+      cursor.executemany(
+          'INSERT INTO ratings '
+          '(r_project, r_namespace, r_article, r_score, r_quality, '
+          ' r_quality_timestamp, r_importance, r_importance_timestamp) '
+          'VALUES '
+          '(%(r_project)s, %(r_namespace)s, %(r_article)s, %(r_score)s, '
+          ' %(r_quality)s, %(r_quality_timestamp)s, %(r_importance)s, '
+          ' %(r_importance_timestamp)s)', ratings)
     self.wp10db.commit()
 
   def test_list(self):
@@ -43,3 +66,56 @@ class ProjectTest(BaseWebTestcase):
     with self.override_db(self.app), self.app.test_client() as client:
       rv = client.get('/v1/projects/Foo Fake Project/table')
       self.assertEqual('404 NOT FOUND', rv.status)
+
+  def test_articles_ok(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get('/v1/projects/Project 0/articles')
+      self.assertEqual('200 OK', rv.status)
+
+  def test_articles_returned(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get('/v1/projects/Project 0/articles')
+      data = json.loads(rv.data)
+
+      # Currently limited to 100 items
+      self.assertEqual(100, len(data))
+
+  def test_articles_quality_only(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get('/v1/projects/Project 0/articles?quality=FA-Class')
+      data = json.loads(rv.data)
+
+      # Currently limited to 100 items
+      self.assertEqual(50, len(data))
+      for article in data:
+        self.assertEqual('FA', article['quality'])
+
+  def test_articles_importance_only(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get('/v1/projects/Project 0/articles?importance=High-Class')
+      data = json.loads(rv.data)
+
+      self.assertEqual(75, len(data))
+      for article in data:
+        self.assertEqual('High', article['importance'])
+
+  def test_articles_quality_importance(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get(
+          '/v1/projects/Project 0/articles?quality=A-Class&importance=Low-Class'
+      )
+      data = json.loads(rv.data)
+
+      self.assertEqual(25, len(data))
+      for article in data:
+        self.assertEqual('Low', article['importance'])
+        self.assertEqual('A', article['quality'])
+
+  def test_articles_no_results(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get(
+          '/v1/projects/Project 0/articles?quality=Foo-Bar&importance=Low-Class'
+      )
+      self.assertEqual('200 OK', rv.status)
+      data = json.loads(rv.data)
+      self.assertEqual(0, len(data))


### PR DESCRIPTION
This feature seeks to emulate the article lists from the original website, such as [here](https://tools.wmflabs.org/enwp10/cgi-bin/list2.fcgi?run=yes&projecta=Modern_philosophy&importance=Top-Class&quality=B-Class).

Currently, it only returns up to 100 results for a particular Quality/Importance specification, with no pagination. The intention is to improve upon that, but this seems like a good start.

Like the project tables, article tables get their own page in the site that is bookmarkable and history navigation works.

I will be adding a commit in a little bit to update the Swagger spec for the new endpoint.