### PR TITLE
Article page pagination

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -66,18 +66,6 @@ paths:
         description: 'The name of the project, with spaces replaced by "_"'
         schema:
           type: string
-      - name: quality
-        in: query
-        required: false
-        description: 'The quality class of articles, used to filter the results. Eg: "FA-Class"'
-        schema:
-          type: string
-      - name: importance
-        in: query
-        required: false
-        description: 'The importance class of articles, used to filter the results. Eg: "High-Class"'
-        schema:
-          type: string
   /projects/{projectId}/articles:
     get:
       summary: 'List of articles for a project, optionally filtered by quality/importance'
@@ -88,14 +76,45 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Article'
+                type: object
+                properties:
+                  pagination:
+                    type: object
+                    properties:
+                      page:
+                        type: number
+                        description: 'The current page of results. Will be 1 if no page is specified'
+                      total:
+                        type: number
+                        description: 'The total number of results for the query'
+                      total_pages:
+                        type: number
+                        description: 'The total number of pages of results, by 100'
+                  articles:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Article'
+        400:
+          description: 'The page parameter was either not a number, or a negative number'
+        404:
+          description: 'No project with that projectId was found'
     parameters:
       - name: projectId
         in: path
         required: true
         description: 'The name of the project, with spaces replaced by "_"'
+        schema:
+          type: string
+      - name: quality
+        in: query
+        required: false
+        description: 'The quality class of articles, used to filter the results. Eg: "FA-Class"'
+        schema:
+          type: string
+      - name: importance
+        in: query
+        required: false
+        description: 'The importance class of articles, used to filter the results. Eg: "High-Class"'
         schema:
           type: string
 components:

--- a/wp1-frontend/src/components/ArticlePage.vue
+++ b/wp1-frontend/src/components/ArticlePage.vue
@@ -32,6 +32,7 @@
           :projectId="currentProjectId"
           :importance="$route.query.importance"
           :quality="$route.query.quality"
+          :page="$route.query.page"
         ></ArticleTable>
       </div>
     </div>

--- a/wp1-frontend/src/components/ArticlePage.vue
+++ b/wp1-frontend/src/components/ArticlePage.vue
@@ -11,7 +11,10 @@
     <div class="row">
       <div class="col">
         <h4>
-          {{ currentProject }} articles -
+          {{ currentProject }} articles
+          <span v-if="$route.query.importance || $route.query.quality">
+            -
+          </span>
           <span v-if="$route.query.importance"
             >{{ displayClass($route.query.importance) }} importance</span
           >
@@ -51,17 +54,17 @@ export default {
       incomingSearch: null
     };
   },
-  methods: {
-    displayClass: function(cls) {
-      return cls.split('-')[0];
-    }
-  },
   computed: {
     currentProjectId: function() {
       if (!this.currentProject) {
         return null;
       }
       return this.currentProject.replace(/ /g, '_');
+    }
+  },
+  methods: {
+    displayClass: function(cls) {
+      return cls.split('-')[0];
     }
   },
   watch: {

--- a/wp1-frontend/src/components/ArticlePage.vue
+++ b/wp1-frontend/src/components/ArticlePage.vue
@@ -16,7 +16,7 @@
             >{{ displayClass($route.query.importance) }} importance</span
           >
           <span v-if="$route.query.quality"
-            ><span v-if="$route.query.importance"> and </span
+            ><span v-if="$route.query.importance"> / </span
             >{{ displayClass($route.query.quality) }} quality</span
           >
         </h4>

--- a/wp1-frontend/src/components/ArticleTable.vue
+++ b/wp1-frontend/src/components/ArticleTable.vue
@@ -1,5 +1,23 @@
 <template>
   <div>
+    <p
+      v-if="articleData && articleData.pagination.total_pages > 1"
+      class="pages-cont"
+    >
+      Pages:
+      <span
+        v-for="i in articleData.pagination.total_pages"
+        :key="i"
+        :class="
+          'page-indicator' +
+            (i === Number(page) || (i === 1 && !page) ? '' : ' link')
+        "
+        ><a v-on:click="updatePage(i)">{{ i }}</a></span
+      >
+    </p>
+
+    <hr />
+
     <table>
       <tr v-for="row in tableData" :key="row.article">
         <td>
@@ -27,7 +45,8 @@ export default {
   props: {
     projectId: String,
     importance: String,
-    quality: String
+    quality: String,
+    page: String
   },
   computed: {
     tableData: function() {
@@ -50,6 +69,9 @@ export default {
     },
     quality: async function() {
       await this.updateTable();
+    },
+    page: async function() {
+      await this.updateTable();
     }
   },
   methods: {
@@ -64,12 +86,30 @@ export default {
       if (this.quality) {
         params.quality = this.quality;
       }
+      if (this.page) {
+        params.page = this.page;
+      }
       Object.keys(params).forEach(key =>
         url.searchParams.append(key, params[key])
       );
 
       const response = await fetch(url);
       this.articleData = await response.json();
+    },
+    updatePage: function(page) {
+      if (page === this.page) {
+        return;
+      }
+
+      const projectName = this.projectId.replace(/_/g, ' ');
+      this.$router.push({
+        path: `/project/${projectName}/articles`,
+        query: {
+          quality: this.quality,
+          importance: this.importance,
+          page: page
+        }
+      });
     }
   }
 };
@@ -95,5 +135,21 @@ td {
 
 tr:nth-child(even) {
   background: lightyellow;
+}
+
+.pages-cont {
+  margin: auto;
+  padding: 0.5rem;
+  text-align: center;
+}
+
+.page-indicator {
+  display: inline-block;
+  padding: 0 0.25rem;
+}
+
+.page-indicator.link {
+  color: #007bff;
+  cursor: pointer;
 }
 </style>

--- a/wp1-frontend/src/components/ArticleTable.vue
+++ b/wp1-frontend/src/components/ArticleTable.vue
@@ -1,19 +1,23 @@
 <template>
   <div>
-    <p
-      v-if="articleData && articleData.pagination.total_pages > 1"
-      class="pages-cont"
-    >
-      Pages:
-      <span
-        v-for="i in articleData.pagination.total_pages"
-        :key="i"
-        :class="
-          'page-indicator' +
-            (i === Number(page) || (i === 1 && !page) ? '' : ' link')
-        "
-        ><a v-on:click="updatePage(i)">{{ i }}</a></span
-      >
+    <p v-if="articleData" class="pages-cont">
+      {{ articleData.pagination.total }} articles
+
+      <span v-if="articleData.pagination.total_pages > 1">
+        - Pages:
+        <span
+          v-for="i in Math.min(articleData.pagination.total_pages, 15)"
+          :key="i"
+          :class="
+            'page-indicator' +
+              (i === Number(page) || (i === 1 && !page) ? '' : ' link')
+          "
+          ><a v-on:click="updatePage(i)">{{ i }}</a></span
+        >
+        <span v-if="articleData.pagination.total_pages > 15">
+          ...(more results truncated)
+        </span>
+      </span>
     </p>
 
     <hr />
@@ -139,7 +143,6 @@ tr:nth-child(even) {
 
 .pages-cont {
   margin: auto;
-  padding: 0.5rem;
   text-align: center;
 }
 

--- a/wp1-frontend/src/components/ArticleTable.vue
+++ b/wp1-frontend/src/components/ArticleTable.vue
@@ -21,13 +21,21 @@ export default {
   name: 'articletable',
   data: function() {
     return {
-      tableData: null
+      articleData: null
     };
   },
   props: {
     projectId: String,
     importance: String,
     quality: String
+  },
+  computed: {
+    tableData: function() {
+      if (this.articleData === null) {
+        return [];
+      }
+      return this.articleData['articles'];
+    }
   },
   watch: {
     projectId: async function(projectId) {
@@ -61,7 +69,7 @@ export default {
       );
 
       const response = await fetch(url);
-      this.tableData = await response.json();
+      this.articleData = await response.json();
     }
   }
 };

--- a/wp1-frontend/src/components/ProjectTable.vue
+++ b/wp1-frontend/src/components/ProjectTable.vue
@@ -1,6 +1,10 @@
 <template>
   <table v-if="tableData">
-    <th :colspan="tableData.total_cols">{{ tableData.title }}</th>
+    <th :colspan="tableData.total_cols">
+      <a :href="'#/project/' + currentProject + '/articles'">{{
+        tableData.title
+      }}</a>
+    </th>
     <tr>
       <th class="quality" rowspan="2">Quality</th>
       <th
@@ -118,6 +122,14 @@ export default {
     return {
       tableData: null
     };
+  },
+  computed: {
+    currentProject: function() {
+      if (!this.projectId) {
+        return null;
+      }
+      return this.projectId.replace(/_/g, '_');
+    }
   },
   watch: {
     projectId: async function(projectId) {

--- a/wp1-frontend/vue.config.js
+++ b/wp1-frontend/vue.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  publicPath: '/',
+  devServer: {
+    disableHostCheck: true,
+    host: '0.0.0.0',
+    port: 3000
+  }
+};

--- a/wp1/constants.py
+++ b/wp1/constants.py
@@ -29,3 +29,5 @@ LOG_NS = 4
 MAX_LOGS_PER_DAY = 100000
 
 WIKI_BASE = 'https://en.wikipedia.org/wiki/'
+
+PAGE_SIZE = 100

--- a/wp1/logic/project_test.py
+++ b/wp1/logic/project_test.py
@@ -23,20 +23,21 @@ ROOT_CATEGORY = config['ROOT_CATEGORY']
 
 def _get_first_category(wp10db):
   with wp10db.cursor() as cursor:
-    cursor.execute('SELECT * FROM ' + Category.table_name + ' LIMIT 1')
+    cursor.execute('SELECT * FROM ' + Category.table_name +  # nosec
+                   ' LIMIT 1')
     db_category = cursor.fetchone()
     return Category(**db_category) if db_category else None
 
 
 def _get_all_categories(wp10db):
   with wp10db.cursor() as cursor:
-    cursor.execute('SELECT * FROM ' + Category.table_name)
+    cursor.execute('SELECT * FROM ' + Category.table_name)  # nosec
     return [Category(**db_category) for db_category in cursor.fetchall()]
 
 
 def _get_all_ratings(wp10db):
   with wp10db.cursor() as cursor:
-    cursor.execute('SELECT * FROM ' + Rating.table_name)
+    cursor.execute('SELECT * FROM ' + Rating.table_name)  # nosec
     return [Rating(**db_rating) for db_rating in cursor.fetchall()]
 
 

--- a/wp1/logic/rating.py
+++ b/wp1/logic/rating.py
@@ -58,8 +58,8 @@ def _project_rating_query(project_name,
     query += ' ORDER BY gri.gr_ranking DESC'
 
   if page is not None:
-    page = int(page)
-    query += ' LIMIT %s,100' % page
+    page = int(page) - 1
+    query += ' LIMIT %s,100' % (page * 100)
   else:
     query += ' LIMIT 100'
 

--- a/wp1/logic/rating.py
+++ b/wp1/logic/rating.py
@@ -63,7 +63,6 @@ def _project_rating_query(project_name,
   else:
     query += ' LIMIT 100'
 
-  print(query)
   return query
 
 
@@ -83,7 +82,6 @@ def get_project_rating_count_by_type(wp10db,
             'r_importance': importance,
         })
     res = cursor.fetchone()
-    print(res)
     return res['count']
 
 

--- a/wp1/logic/rating_test.py
+++ b/wp1/logic/rating_test.py
@@ -145,3 +145,56 @@ class GetProjectRatingByTypeTest(BaseWpOneDbTest):
                                                       quality='Foo-Class',
                                                       importance='Bar-Class')
     self.assertEqual(0, len(ratings))
+
+  def test_sorted_by_quality(self):
+    ratings = logic_rating.get_project_rating_by_type(self.wp10db,
+                                                      b'Project 0',
+                                                      importance='High-Class')
+
+    self.assertEqual(75, len(ratings))
+    for rating in ratings[:25]:
+      self.assertEqual(b'FA-Class', rating.r_quality)
+    for rating in ratings[25:50]:
+      self.assertEqual(b'A-Class', rating.r_quality)
+    for rating in ratings[50:]:
+      self.assertEqual(b'B-Class', rating.r_quality)
+
+  def test_sorted_by_importance(self):
+    ratings = logic_rating.get_project_rating_by_type(self.wp10db,
+                                                      b'Project 0',
+                                                      quality='FA-Class')
+
+    self.assertEqual(50, len(ratings))
+    for rating in ratings[:25]:
+      self.assertEqual(b'High-Class', rating.r_importance)
+    for rating in ratings[25:50]:
+      self.assertEqual(b'Low-Class', rating.r_importance)
+
+  def test_overall_sort_and_paging(self):
+    ratings = logic_rating.get_project_rating_by_type(self.wp10db, b'Project 0')
+
+    self.assertEqual(100, len(ratings))
+    for rating in ratings[:25]:
+      self.assertEqual(b'FA-Class', rating.r_quality)
+      self.assertEqual(b'High-Class', rating.r_importance)
+    for rating in ratings[25:50]:
+      self.assertEqual(b'FA-Class', rating.r_quality)
+      self.assertEqual(b'Low-Class', rating.r_importance)
+    for rating in ratings[50:75]:
+      self.assertEqual(b'A-Class', rating.r_quality)
+      self.assertEqual(b'High-Class', rating.r_importance)
+    for rating in ratings[75:]:
+      self.assertEqual(b'A-Class', rating.r_quality)
+      self.assertEqual(b'Low-Class', rating.r_importance)
+
+    ratings = logic_rating.get_project_rating_by_type(self.wp10db,
+                                                      b'Project 0',
+                                                      page=2)
+
+    self.assertEqual(50, len(ratings))
+    for rating in ratings[:25]:
+      self.assertEquals(b'B-Class', rating.r_quality)
+      self.assertEquals(b'High-Class', rating.r_importance)
+    for rating in ratings[25:50]:
+      self.assertEquals(b'B-Class', rating.r_quality)
+      self.assertEquals(b'Low-Class', rating.r_importance)

--- a/wp1/web/projects.py
+++ b/wp1/web/projects.py
@@ -48,7 +48,7 @@ def articles(project_name):
 
   quality = flask.request.args.get('quality')
   importance = flask.request.args.get('importance')
-  page = flask.request.args.get('page', 1)
+  page = flask.request.args.get('page')
 
   if quality:
     quality = quality.encode('utf-8')
@@ -64,7 +64,8 @@ def articles(project_name):
   articles = logic_rating.get_project_rating_by_type(wp10db,
                                                      project_name_bytes,
                                                      quality=quality,
-                                                     importance=importance)
+                                                     importance=importance,
+                                                     page=page)
 
   output = {
       'pagination': {

--- a/wp1/web/projects.py
+++ b/wp1/web/projects.py
@@ -1,6 +1,7 @@
 import attr
 import flask
 
+from wp1.constants import PAGE_SIZE
 from wp1.web.db import get_db
 import wp1.logic.project as logic_project
 import wp1.logic.rating as logic_rating
@@ -47,15 +48,30 @@ def articles(project_name):
 
   quality = flask.request.args.get('quality')
   importance = flask.request.args.get('importance')
+  page = flask.request.args.get('page', 1)
 
   if quality:
     quality = quality.encode('utf-8')
   if importance:
     importance = importance.encode('utf-8')
 
-  ratings = logic_rating.get_project_rating_by_type(wp10db,
-                                                    project_name_bytes,
-                                                    quality=quality,
-                                                    importance=importance)
+  total = logic_rating.get_project_rating_count_by_type(wp10db,
+                                                        project_name_bytes,
+                                                        quality=quality,
+                                                        importance=importance)
+  total_pages = total // PAGE_SIZE + 1 if total % PAGE_SIZE != 0 else 0
 
-  return flask.jsonify(list(rating.to_web_dict() for rating in ratings))
+  articles = logic_rating.get_project_rating_by_type(wp10db,
+                                                     project_name_bytes,
+                                                     quality=quality,
+                                                     importance=importance)
+
+  output = {
+      'pagination': {
+          'page': page,
+          'total_pages': total_pages,
+          'total': total
+      },
+      'articles': list(article.to_web_dict() for article in articles),
+  }
+  return flask.jsonify(output)

--- a/wp1/web/projects.py
+++ b/wp1/web/projects.py
@@ -78,7 +78,7 @@ def articles(project_name):
 
   output = {
       'pagination': {
-          'page': page,
+          'page': page or 1,
           'total_pages': total_pages,
           'total': total
       },

--- a/wp1/web/projects.py
+++ b/wp1/web/projects.py
@@ -49,6 +49,15 @@ def articles(project_name):
   quality = flask.request.args.get('quality')
   importance = flask.request.args.get('importance')
   page = flask.request.args.get('page')
+  if page is not None:
+    try:
+      page_int = int(page)
+    except ValueError:
+      # Non-integer page number
+      return flask.abort(400)
+    if page_int < 1:
+      # Negative page number
+      return flask.abort(400)
 
   if quality:
     quality = quality.encode('utf-8')

--- a/wp1/web/projects_test.py
+++ b/wp1/web/projects_test.py
@@ -120,6 +120,16 @@ class ProjectTest(BaseWebTestcase):
       data = json.loads(rv.data)
       self.assertEqual(0, len(data['articles']))
 
+  def test_articles_pagination(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get('/v1/projects/Project 0/articles')
+      self.assertEqual('200 OK', rv.status)
+      data = json.loads(rv.data)
+
+      self.assertEqual(1, data['pagination']['page'])
+      self.assertEqual(150, data['pagination']['total'])
+      self.assertEqual(2, data['pagination']['total_pages'])
+
   def test_articles_page_2(self):
     with self.override_db(self.app), self.app.test_client() as client:
       rv = client.get('/v1/projects/Project 0/articles?page=2')

--- a/wp1/web/projects_test.py
+++ b/wp1/web/projects_test.py
@@ -78,7 +78,7 @@ class ProjectTest(BaseWebTestcase):
       data = json.loads(rv.data)
 
       # Currently limited to 100 items
-      self.assertEqual(100, len(data))
+      self.assertEqual(100, len(data['articles']))
 
   def test_articles_quality_only(self):
     with self.override_db(self.app), self.app.test_client() as client:
@@ -86,8 +86,8 @@ class ProjectTest(BaseWebTestcase):
       data = json.loads(rv.data)
 
       # Currently limited to 100 items
-      self.assertEqual(50, len(data))
-      for article in data:
+      self.assertEqual(50, len(data['articles']))
+      for article in data['articles']:
         self.assertEqual('FA', article['quality'])
 
   def test_articles_importance_only(self):
@@ -95,8 +95,8 @@ class ProjectTest(BaseWebTestcase):
       rv = client.get('/v1/projects/Project 0/articles?importance=High-Class')
       data = json.loads(rv.data)
 
-      self.assertEqual(75, len(data))
-      for article in data:
+      self.assertEqual(75, len(data['articles']))
+      for article in data['articles']:
         self.assertEqual('High', article['importance'])
 
   def test_articles_quality_importance(self):
@@ -106,8 +106,8 @@ class ProjectTest(BaseWebTestcase):
       )
       data = json.loads(rv.data)
 
-      self.assertEqual(25, len(data))
-      for article in data:
+      self.assertEqual(25, len(data['articles']))
+      for article in data['articles']:
         self.assertEqual('Low', article['importance'])
         self.assertEqual('A', article['quality'])
 
@@ -118,4 +118,25 @@ class ProjectTest(BaseWebTestcase):
       )
       self.assertEqual('200 OK', rv.status)
       data = json.loads(rv.data)
-      self.assertEqual(0, len(data))
+      self.assertEqual(0, len(data['articles']))
+
+  def test_articles_page_2(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get('/v1/projects/Project 0/articles?page=2')
+      self.assertEqual('200 OK', rv.status)
+      data = json.loads(rv.data)
+      self.assertEqual(50, len(data['articles']))
+
+  def test_articles_404(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get('/v1/projects/Foo Fake Project/articles')
+      self.assertEqual('404 NOT FOUND', rv.status)
+
+  def test_articles_400_invalid_page(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get('/v1/projects/Project 0/articles?page=foo')
+      self.assertEqual('400 BAD REQUEST', rv.status)
+
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get('/v1/projects/Project 0/articles?page=-5')
+      self.assertEqual('400 BAD REQUEST', rv.status)


### PR DESCRIPTION
This PR adds pagination to the article tables. Previously, only the first 100 results were shown and there was no way to see the rest.

Now, if there are more than 100 results, a page indicator is shown at the top of the table, with links to additional pages of results.

These pages are bookmarkable and navigable, like other pages in the site.