### PR TITLE
Add special handling for links from table with quality=Assessed-Class

### DIFF
--- a/wp1/logic/rating.py
+++ b/wp1/logic/rating.py
@@ -46,7 +46,11 @@ def _project_rating_query(project_name,
   query += ' WHERE r_project = %(r_project)s'
 
   if quality is not None:
-    query += ' AND r_quality = %(r_quality)s'
+    if quality == b'Assessed-Class':
+      print('Assessed-Class triggered')
+      query += ' AND r_quality != "Unassessed-Class"'
+    else:
+      query += ' AND r_quality = %(r_quality)s'
   if importance is not None:
     query += ' AND r_importance = %(r_importance)s'
 


### PR DESCRIPTION
Although "Assessed" isn't a real quality class stored in the database, the old server allows for queries for this class when browsing project tables. For feature parity, this PR adds support for it in the backend, which makes the frontend no longer return no results for queries of this kind.