### PR TITLE
Show progress of manual updates

### DIFF
--- a/enqueue-all.py
+++ b/enqueue-all.py
@@ -3,6 +3,7 @@ import logging
 from redis import Redis
 
 from wp1 import queues
+from wp1.redis_db import connect as redis_connect
 
 logger = logging.getLogger(__name__)
 
@@ -17,9 +18,7 @@ except ImportError:
 def main():
   logging.basicConfig(level=logging.INFO)
 
-  creds = CREDENTIALS[ENV]['REDIS']
-  redis = Redis(**creds)
-
+  redis = redis_connect()
   queues.enqueue_all_projects(redis)
 
 

--- a/enqueue-project.py
+++ b/enqueue-project.py
@@ -1,18 +1,10 @@
 import logging
 import sys
 
-from redis import Redis
-
+from wp1.redis_db import connect as redis_connect
 from wp1 import queues
 
 logger = logging.getLogger(__name__)
-
-try:
-  from wp1.credentials import ENV, CREDENTIALS
-except ImportError:
-  logger.exception('The file credentials.py must be populated manually in '
-                   'order to connect to Redis')
-  raise
 
 
 def main():
@@ -22,8 +14,7 @@ def main():
   project_names = [n.encode('utf-8') for n in sys.argv[1:]]
   logger.debug(project_names)
 
-  creds = CREDENTIALS[ENV]['REDIS']
-  redis = Redis(**creds)
+  redis = redis_connect()
   queues.enqueue_multiple_projects(redis, project_names)
 
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -151,6 +151,30 @@ paths:
         description: 'The name of the project, with spaces replaced by "_"'
         schema:
           type: string
+  /projects/{projectId}/nextUpdateTime:
+    get:
+      summary: 'Get the time at which the given project can next be scheduled for a manual update, or null if the project is currently eligible for a manual update.'
+      operationId: projectNextUpdateTime
+      responses:
+        200:
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  next_update_time:
+                    type: string
+                    description: 'A string representing the UTC timestamp of when the next manual update can be performed.'
+        404:
+          description: 'No project with that projectId was found'
+    parameters:
+      - name: projectId
+        in: path
+        required: true
+        description: 'The name of the project, with spaces replaced by "_"'
+        schema:
+          type: string
 components:
   schemas:
     Project:

--- a/openapi.yml
+++ b/openapi.yml
@@ -175,6 +175,46 @@ paths:
         description: 'The name of the project, with spaces replaced by "_"'
         schema:
           type: string
+  /projects/{projectId}/update/progress:
+    get:
+      summary: 'Get the status/progress of a manual update job. If there is no manual update job, or if its status has expired, the "queue" and "job" keys will have null values.'
+      operationId: projectUpdateProgress
+      responses:
+        200:
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  queue:
+                    type: object
+                    properties:
+                      status:
+                        type: string
+                        description: 'One of "queued", "started" or "finished" based on the state of the manual update in the job queue'
+                      ended_at:
+                        type: string
+                        description: 'A datetime string representing when this job finished. Only available if the status key has a value of "finished"'
+                  job:
+                    type: object
+                    properties:
+                      progress:
+                        type: integer
+                        description: 'An abstract number representing the amount of progress that has been made on a manual update job'
+                      total:
+                        type: integer
+                        description: 'An abstract number representing the total amount of progress that must be made for this job to be considered complete. Note that it is considered reasonable for the progress number to reach a value higher than this total.'
+                    description: 'A string representing the UTC timestamp of when the next manual update can be performed.'
+        404:
+          description: 'No project with that projectId was found'
+    parameters:
+      - name: projectId
+        in: path
+        required: true
+        description: 'The name of the project, with spaces replaced by "_"'
+        schema:
+          type: string
 components:
   schemas:
     Project:

--- a/openapi.yml
+++ b/openapi.yml
@@ -151,7 +151,7 @@ paths:
         description: 'The name of the project, with spaces replaced by "_"'
         schema:
           type: string
-  /projects/{projectId}/nextUpdateTime:
+  /projects/{projectId}/update/time:
     get:
       summary: 'Get the time at which the given project can next be scheduled for a manual update, or null if the project is currently eligible for a manual update.'
       operationId: projectNextUpdateTime

--- a/wp1-frontend/src/components/UpdatePage.vue
+++ b/wp1-frontend/src/components/UpdatePage.vue
@@ -65,7 +65,7 @@ export default {
         this.$router.push({ path: `/update/${val}` });
       }
       const response = await fetch(
-        `${process.env.VUE_APP_API_URL}/projects/${this.currentProjectId}/nextUpdateTime`
+        `${process.env.VUE_APP_API_URL}/projects/${this.currentProjectId}/update/time`
       );
       const data = await response.json();
       this.updateTime = data.next_update_time;

--- a/wp1-frontend/src/components/UpdatePage.vue
+++ b/wp1-frontend/src/components/UpdatePage.vue
@@ -80,10 +80,16 @@ export default {
       return this.currentProject.replace(/ /g, '_');
     },
     jobComplete: function() {
-      return this.progressCurrent >= this.progressTotal;
+      return this.jobStatusEnum === 'finished';
+    },
+    jobFinishingUp: function() {
+      return (
+        this.jobStatusEnum !== 'finished' &&
+        this.progressCurrent >= this.progressTotal
+      );
     },
     jobNotStarted: function() {
-      return this.progressCurrent === null || this.progressTotal === null;
+      return this.jobStatusEnum === 'queued';
     },
     progressWidth: function() {
       if (this.progressCurrent !== null && this.progressTotal !== null) {
@@ -102,6 +108,9 @@ export default {
       );
       const data = await response.json();
       this.updateTime = data.next_update_time;
+      this.progressCurrent = null;
+      this.progressTotal = null;
+      this.jobStatusEnum = null;
     },
     updateTime: function(val) {
       if (val !== null) {
@@ -131,6 +140,7 @@ export default {
       const data = await response.json();
       this.progressCurrent = data.job.progress || null;
       this.progressTotal = data.job.total || null;
+      this.jobStatusEnum = data.queue.status || null;
       if (this.jobComplete) {
         this.stopProgressPolling();
       }
@@ -144,6 +154,9 @@ export default {
           'Your job is complete! You must wait up to an hour to start ' +
           'a new manual update.'
         );
+      }
+      if (this.jobFinishingUp) {
+        return 'Your job is almost finished, just wrapping up some tasks.';
       }
       return 'Your job is running, track its progress below.';
     },

--- a/wp1-frontend/src/main.js
+++ b/wp1-frontend/src/main.js
@@ -30,6 +30,12 @@ const routes = [
   {
     path: '/update/:projectName',
     component: UpdatePage,
+    props: route => ({
+      incomingSearch: route.params.projectName,
+      updateTime: route.query.updateTime,
+      showSuccessMessage: route.query.success == 1,
+      showFailureMessage: route.query.failure == 1
+    }),
     meta: {
       title: route =>
         BASE_TITLE + ' - Manual Update - ' + route.params.projectName

--- a/wp1/logic/api/page.py
+++ b/wp1/logic/api/page.py
@@ -28,7 +28,7 @@ def get_redirect(title_with_ns):
       retries -= 1
 
   if res is None:
-    logger.warn('Error contacting API, returning None')
+    logger.warning('Error contacting API, returning None')
     return None
 
   if ('query' not in res or 'redirects' not in res['query'] or
@@ -60,7 +60,7 @@ def get_moves(title_with_ns):
       retries -= 1
 
   if res is None:
-    logger.warn('Error contacting API, returning None')
+    logger.warning('Error contacting API, returning None')
     return None
 
   ans = []
@@ -86,6 +86,6 @@ def get_moves(title_with_ns):
       retries -= 1
 
   if retries == 0:
-    logger.warn('Error contacting continuation API, returning None')
+    logger.warning('Error contacting continuation API, returning None')
 
   return ans or None

--- a/wp1/logic/project.py
+++ b/wp1/logic/project.py
@@ -80,6 +80,9 @@ def update_project_by_name(project_name, track_progress=False):
                    project,
                    redis=redis,
                    track_progress=track_progress)
+
+    if track_progress:
+      redis.expire(_project_progress_key(project_name), 600)
   finally:
     wp10db.close()
     wikidb.close()
@@ -294,6 +297,11 @@ def _project_progress_key(project_name):
   return b'progress:%s' % project_name
 
 
+def clear_project_progress(redis, project_name):
+  key = _project_progress_key(project_name)
+  redis.delete(key)
+
+
 def get_project_progress(redis, project_name):
   key = _project_progress_key(project_name)
 
@@ -314,7 +322,8 @@ def count_initial_work(redis, wp10db, project_name):
   work = int(count * 1.9)
 
   key = _project_progress_key(project_name)
-  redis.hmset(key, {'work': work, 'progress': 0})
+  redis.hset(key, 'work', work)
+  redis.hset(key, 'progress', 0)
 
 
 def increment_progress_count(redis, project_name):

--- a/wp1/logic/rating.py
+++ b/wp1/logic/rating.py
@@ -108,6 +108,15 @@ def get_project_rating_by_type(wp10db,
     return [Rating(**db_rating) for db_rating in cursor.fetchall()]
 
 
+def get_all_ratings_count_for_project(wp10db, project_name):
+  with wp10db.cursor() as cursor:
+    cursor.execute('SELECT COUNT(*) as count FROM ratings WHERE r_project = %s',
+                   (project_name,))
+
+    res = cursor.fetchone()
+    return res['count']
+
+
 def insert_or_update(wp10db, rating, kind):
   duplicate_clause = ''
   if kind == AssessmentKind.QUALITY:

--- a/wp1/queues.py
+++ b/wp1/queues.py
@@ -103,8 +103,7 @@ def get_project_queue_status(redis, project_name):
   status = job.get_status()
   if status == 'finished':
     return {'status': status, 'ended_at': job.ended_at}
-  else:
-    return {'status': status}
+  return {'status': status}
 
 
 def set_project_update_job_id(redis, project_name, job_id):

--- a/wp1/queues.py
+++ b/wp1/queues.py
@@ -54,7 +54,7 @@ def enqueue_multiple_projects(redis, project_names):
 def enqueue_single_project(redis, project_name, manual=False):
   update_q, upload_q = _get_queues(redis, manual=manual)
 
-  enqueue_project(project_name, update_q, upload_q)
+  enqueue_project(project_name, update_q, upload_q, track_progress=manual)
 
 
 def _manual_key(project_name):
@@ -76,11 +76,12 @@ def mark_project_manual_update_time(redis, project_name):
   return ts
 
 
-def enqueue_project(project_name, update_q, upload_q):
+def enqueue_project(project_name, update_q, upload_q, track_progress=False):
   logger.warning(update_q.name)
   logger.info('Enqueuing update %s', project_name)
   update_job = update_q.enqueue(logic_project.update_project_by_name,
                                 project_name,
+                                track_progress=track_progress,
                                 job_timeout=constants.JOB_TIMEOUT)
   if ENV == Environment.PRODUCTION:
     logger.info('Enqueuing upload (dependent) %s', project_name)

--- a/wp1/queues_test.py
+++ b/wp1/queues_test.py
@@ -107,4 +107,4 @@ class QueuesTest(BaseRedisTest):
     expected = queues.mark_project_manual_update_time(self.redis,
                                                       b'Some_Project')
     actual = queues.next_update_time(self.redis, b'Some_Project')
-    self.assertEquals(expected, actual)
+    self.assertEqual(expected, actual)

--- a/wp1/redis_db.py
+++ b/wp1/redis_db.py
@@ -1,4 +1,8 @@
+import logging
+
 from redis import Redis
+
+logger = logging.getLogger(__name__)
 
 try:
   from wp1.credentials import ENV, CREDENTIALS

--- a/wp1/redis_db.py
+++ b/wp1/redis_db.py
@@ -1,0 +1,14 @@
+from redis import Redis
+
+try:
+  from wp1.credentials import ENV, CREDENTIALS
+except ImportError:
+  logger.exception('The file credentials.py must be populated manually in '
+                   'order to connect to Redis')
+  ENV = None
+  CREDENTIALS = None
+
+
+def connect():
+  creds = CREDENTIALS[ENV]['REDIS']
+  return Redis(**creds)

--- a/wp1/web/projects.py
+++ b/wp1/web/projects.py
@@ -109,8 +109,8 @@ def update(project_name):
   return flask.jsonify({'next_update_time': next_update_time})
 
 
-@projects.route('/<project_name>/nextUpdateTime')
-def next_update_time(project_name):
+@projects.route('/<project_name>/update/time')
+def update_time(project_name):
   wp10db = get_db('wp10db')
   project_name_bytes = project_name.encode('utf-8')
   project = logic_project.get_project_by_name(wp10db, project_name_bytes)

--- a/wp1/web/projects.py
+++ b/wp1/web/projects.py
@@ -142,7 +142,7 @@ def update_progress(project_name):
     try:
       progress = int(progress.decode('utf-8'))
       work = int(work.decode('utf-8'))
-    except AttributeError, ValueError:
+    except (AttributeError, ValueError):
       # AttributeError: The values are not bytes and can't be decoded.
       # ValueError: The values are not castable to int.
       progress = 0

--- a/wp1/web/projects.py
+++ b/wp1/web/projects.py
@@ -142,9 +142,9 @@ def update_progress(project_name):
     try:
       progress = int(progress.decode('utf-8'))
       work = int(work.decode('utf-8'))
-    except ValueError:
-      # Either progress or work were not ints
-      pass
+    except:
+      progress = 0
+      work = 0
     job = {'progress': progress, 'total': work}
 
   return flask.jsonify({'queue': queue_status, 'job': job})

--- a/wp1/web/projects.py
+++ b/wp1/web/projects.py
@@ -90,7 +90,7 @@ def articles(project_name):
 
 
 @projects.route('/<project_name>/update', methods=['POST'])
-def udpate(project_name):
+def update(project_name):
   wp10db = get_db('wp10db')
   project_name_bytes = project_name.encode('utf-8')
   project = logic_project.get_project_by_name(wp10db, project_name_bytes)
@@ -107,3 +107,17 @@ def udpate(project_name):
   next_update_time = queues.mark_project_manual_update_time(
       redis, project_name_bytes)
   return flask.jsonify({'next_update_time': next_update_time})
+
+
+@projects.route('/<project_name>/nextUpdateTime')
+def next_update_time(project_name):
+  wp10db = get_db('wp10db')
+  project_name_bytes = project_name.encode('utf-8')
+  project = logic_project.get_project_by_name(wp10db, project_name_bytes)
+  if project is None:
+    return flask.abort(404)
+
+  redis = get_redis()
+
+  update_time = queues.next_update_time(redis, project_name_bytes)
+  return flask.jsonify({'next_update_time': update_time}), 200

--- a/wp1/web/projects.py
+++ b/wp1/web/projects.py
@@ -134,6 +134,8 @@ def update_progress(project_name):
   redis = get_redis()
 
   progress, work = logic_project.get_project_progress(redis, project_name_bytes)
+  queue_status = queues.get_project_queue_status(redis, project_name_bytes)
+
   if progress is None or work is None:
     job = None
   else:
@@ -145,4 +147,4 @@ def update_progress(project_name):
       pass
     job = {'progress': progress, 'total': work}
 
-  return flask.jsonify({'queue': None, 'job': job})
+  return flask.jsonify({'queue': queue_status, 'job': job})

--- a/wp1/web/projects.py
+++ b/wp1/web/projects.py
@@ -142,7 +142,9 @@ def update_progress(project_name):
     try:
       progress = int(progress.decode('utf-8'))
       work = int(work.decode('utf-8'))
-    except:
+    except AttributeError, ValueError:
+      # AttributeError: The values are not bytes and can't be decoded.
+      # ValueError: The values are not castable to int.
       progress = 0
       work = 0
     job = {'progress': progress, 'total': work}

--- a/wp1/web/projects_test.py
+++ b/wp1/web/projects_test.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import json
 from unittest.mock import patch
 
+from wp1.logic import project as logic_project
 from wp1.base_db_test import get_test_connect_creds
 from wp1.web.app import create_app
 from wp1.web.base_web_testcase import BaseWebTestcase
@@ -222,3 +223,48 @@ class ProjectTest(BaseWebTestcase):
 
         data = json.loads(rv.data)
         self.assertEqual('2018-12-25 06:55 UTC', data['next_update_time'])
+
+  def test_update_progress_empty(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get('/v1/projects/Project 0/update/progress')
+      self.assertEqual('200 OK', rv.status)
+
+      data = json.loads(rv.data)
+      self.assertIsNone(data['queue'])
+      self.assertIsNone(data['job'])
+
+  @patch('wp1.queues.ENV', Environment.PRODUCTION)
+  def test_update_progress(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.post('/v1/projects/Project 0/update')
+      self.assertEqual('200 OK', rv.status)
+
+      rv = client.get('/v1/projects/Project 0/update/progress')
+      self.assertEqual('200 OK', rv.status)
+
+      data = json.loads(rv.data)
+      self.assertIsNone(data['job'])
+      self.assertEqual({'status': 'queued'}, data['queue'])
+
+  @patch('wp1.queues.ENV', Environment.PRODUCTION)
+  def test_update_progress_404(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get('/v1/projects/Foo Bar Baz/update/progress')
+      self.assertEqual('404 NOT FOUND', rv.status)
+
+  @patch('wp1.queues.ENV', Environment.PRODUCTION)
+  def test_update_progress_return_job_progress(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      expected_total = 100
+      expected_progress = 25
+
+      key = logic_project._project_progress_key(b'Project 0')
+      self.redis.hset(key, 'work', expected_total)
+      self.redis.hset(key, 'progress', expected_progress)
+
+      rv = client.get('/v1/projects/Project 0/update/progress')
+      self.assertEqual('200 OK', rv.status)
+
+      data = json.loads(rv.data)
+      self.assertEqual(expected_total, data['job']['total'])
+      self.assertEqual(expected_progress, data['job']['progress'])

--- a/wp1/web/projects_test.py
+++ b/wp1/web/projects_test.py
@@ -193,7 +193,7 @@ class ProjectTest(BaseWebTestcase):
   @patch('wp1.queues.utcnow', return_value=datetime(2018, 12, 25, 5, 55, 55))
   def test_update_time(self, patched_now):
     with self.override_db(self.app), self.app.test_client() as client:
-      rv = client.get('/v1/projects/Project 0/nextUpdateTime')
+      rv = client.get('/v1/projects/Project 0/update/time')
       self.assertEqual('200 OK', rv.status)
 
       data = json.loads(rv.data)
@@ -203,7 +203,7 @@ class ProjectTest(BaseWebTestcase):
   @patch('wp1.queues.utcnow', return_value=datetime(2018, 12, 25, 5, 55, 55))
   def test_update_time_404(self, patched_now):
     with self.override_db(self.app), self.app.test_client() as client:
-      rv = client.get('/v1/projects/Foo Bar Baz/nextUpdateTime')
+      rv = client.get('/v1/projects/Foo Bar Baz/update/time')
       self.assertEqual('404 NOT FOUND', rv.status)
 
   @patch('wp1.queues.ENV', Environment.PRODUCTION)
@@ -217,7 +217,7 @@ class ProjectTest(BaseWebTestcase):
         data = json.loads(rv.data)
         self.assertEqual('2018-12-25 06:55 UTC', data['next_update_time'])
 
-        rv = client.get('/v1/projects/Project 0/nextUpdateTime')
+        rv = client.get('/v1/projects/Project 0/update/time')
         self.assertEqual('200 OK', rv.status)
 
         data = json.loads(rv.data)

--- a/wp1/web/projects_test.py
+++ b/wp1/web/projects_test.py
@@ -268,3 +268,16 @@ class ProjectTest(BaseWebTestcase):
       data = json.loads(rv.data)
       self.assertEqual(expected_total, data['job']['total'])
       self.assertEqual(expected_progress, data['job']['progress'])
+
+  @patch('wp1.queues.ENV', Environment.PRODUCTION)
+  @patch('wp1.web.projects.logic_project.get_project_progress')
+  def test_update_progress_progress_not_ints(self, patched_progress):
+    patched_progress.return_value = (b'a', b'b')
+
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get('/v1/projects/Project 0/update/progress')
+      self.assertEqual('200 OK', rv.status)
+
+      data = json.loads(rv.data)
+      self.assertEqual(0, data['job']['progress'])
+      self.assertEqual(0, data['job']['total'])


### PR DESCRIPTION
Manual updates have two stages of progress: waiting in the RQ worker queue behind other manual updates (though this will likely be rare), and actually updating the articles that need to be updated.

This PR creates a progress bar and a status string that informs the user of the current state of their project. This information remains for 10 minutes after the job has completed.

<img width="675" alt="Screen Shot 2020-05-31 at 12 17 09 PM" src="https://user-images.githubusercontent.com/57832/83361705-ecd6f900-a33f-11ea-9a1a-bca574b28b8d.png">
