### PR TITLE
Add welcome banner for new WP 1.0 frontend

### DIFF
--- a/wp1-frontend/src/App.vue
+++ b/wp1-frontend/src/App.vue
@@ -1,5 +1,15 @@
 <template>
   <div>
+    <div class="alert alert-info my-0" role="alert">
+      Welcome to the latest version of the WP 1.0 tool! If you need a feature
+      that is only in the old tool, it's still running
+      <a href="https://tools.wmflabs.org/enwp10/cgi-bin/pindex.fcgi">here</a>.
+      Please provide all feedback and feature requests for this tool on
+      <a
+        href="https://en.wikipedia.org/wiki/Wikipedia_talk:Version_1.0_Editorial_Team/Index"
+        >English Wikipedia</a
+      >.
+    </div>
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
       <a class="navbar-brand" href="#">Wikipedia 1.0 Server</a>
       <button

--- a/wp1-frontend/src/components/ArticlePage.vue
+++ b/wp1-frontend/src/components/ArticlePage.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="row">
-      <div class="col-6">
+      <div class="col-xlg-6">
         <Autocomplete
           :incomingSearch="incomingSearch || $route.params.projectName"
           v-on:select-project="currentProject = $event"

--- a/wp1-frontend/src/components/IndexPage.vue
+++ b/wp1-frontend/src/components/IndexPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="row">
-      <div class="col-6">
+      <div class="col-xlg-6">
         <Autocomplete
           v-on:select-project="currentProject = $event"
         ></Autocomplete>

--- a/wp1-frontend/src/components/ProjectPage.vue
+++ b/wp1-frontend/src/components/ProjectPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="row">
-      <div class="col-6">
+      <div class="col-lg-6">
         <Autocomplete
           :incomingSearch="incomingSearch || $route.params.projectName"
           v-on:select-project="currentProject = $event"

--- a/wp1-frontend/src/components/UpdatePage.vue
+++ b/wp1-frontend/src/components/UpdatePage.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="row">
-      <div class="col-6">
+      <div class="col-xlg-6">
         <Autocomplete
           :incomingSearch="incomingSearch || $route.params.projectName"
           v-on:select-project="currentProject = $event"
@@ -9,7 +9,7 @@
       </div>
     </div>
     <div class="row">
-      <div class="col-6">
+      <div class="col-xlg-6">
         <div v-if="this.$route.params.projectName && !updateTime">
           <label class="mt-2" for="confirm"
             >Proceed with manual update of


### PR DESCRIPTION
Fixes #180.

Also resizes components to only be half page width when the viewport is "xl".

<img width="1094" alt="Screen Shot 2020-06-07 at 3 24 37 PM" src="https://user-images.githubusercontent.com/57832/83981493-21642b00-a8d3-11ea-95b0-a4847b297969.png">
