### PR TITLE
Guard against pages loading with non-existant projects and other frontend cleanups

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -28,6 +28,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Project'
+        404:
+          description: 'No project with that projectId was found'
   /projects/count:
     get:
       summary: 'Count of the total number of projects'
@@ -42,6 +44,24 @@ paths:
                 properties:
                   count:
                     type: integer
+  /projects/{projectId}/:
+    get:
+      summary: 'Retrieve the entry for a specific project'
+      operationId: getProject
+      responses:
+        200:
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Project'
+    parameters:
+      - name: projectId
+        in: path
+        required: true
+        description: 'The name of the project, with spaces replaced by "_"'
+        schema:
+          type: string
   /projects/{projectId}/table:
     get:
       summary: 'Data for building a summary table for a given project'

--- a/wp1-frontend/src/App.vue
+++ b/wp1-frontend/src/App.vue
@@ -48,24 +48,14 @@
       </div>
     </nav>
     <div id="app" class="container">
-      <div class="row">
-        <div class="col">
-          <Stats></Stats>
-        </div>
-      </div>
       <router-view></router-view>
     </div>
   </div>
 </template>
 
 <script>
-import Stats from './components/Stats.vue';
-
 export default {
-  name: 'app',
-  components: {
-    Stats
-  }
+  name: 'app'
 };
 </script>
 

--- a/wp1-frontend/src/components/ArticlePage.vue
+++ b/wp1-frontend/src/components/ArticlePage.vue
@@ -1,7 +1,10 @@
 <template>
   <div>
     <div class="row">
-      <div class="col">
+      <div class="col" v-if="notFound">
+        <h4>The project with the name {{ currentProject }} was not found.</h4>
+      </div>
+      <div class="col" v-else>
         <h4>
           {{ currentProject }} articles
           <span v-if="$route.query.importance || $route.query.quality">
@@ -40,12 +43,25 @@ export default {
     ArticleTable
   },
   props: ['currentProject'],
+  data: function() {
+    return {
+      notFound: false
+    };
+  },
   computed: {
     currentProjectId: function() {
       if (!this.currentProject) {
         return null;
       }
       return this.currentProject.replace(/ /g, '_');
+    }
+  },
+  created: async function() {
+    const response = await fetch(
+      `${process.env.VUE_APP_API_URL}/projects/${this.currentProjectId}`
+    );
+    if (response.status === 404) {
+      this.notFound = true;
     }
   },
   methods: {

--- a/wp1-frontend/src/components/ArticlePage.vue
+++ b/wp1-frontend/src/components/ArticlePage.vue
@@ -56,30 +56,28 @@ export default {
       return this.currentProject.replace(/ /g, '_');
     }
   },
-  created: async function() {
-    const response = await fetch(
-      `${process.env.VUE_APP_API_URL}/projects/${this.currentProjectId}`
+  beforeRouteUpdate(to, from, next) {
+    this.checkIfProjectExists(to.params.projectName.replace(/ /g, '_'));
+    window.console.log(
+      'before route update',
+      this.notFound,
+      this.currentProject,
+      this.currentProjectId
     );
-    if (response.status === 404) {
-      this.notFound = true;
-    }
+    next();
+  },
+  created: function() {
+    this.checkIfProjectExists(this.currentProjectId);
   },
   methods: {
     displayClass: function(cls) {
       return cls.split('-')[0];
-    }
-  },
-  watch: {
-    currentProject: function(val) {
-      if (val !== this.$route.params.projectName) {
-        this.$router.push({
-          path: `/project/${val}/articles`,
-          query: {
-            importance: this.$route.query.importance,
-            quality: this.$route.query.quality
-          }
-        });
-      }
+    },
+    checkIfProjectExists: async function(projectId) {
+      const response = await fetch(
+        `${process.env.VUE_APP_API_URL}/projects/${projectId}`
+      );
+      this.notFound = response.status === 404;
     }
   }
 };

--- a/wp1-frontend/src/components/ArticlePage.vue
+++ b/wp1-frontend/src/components/ArticlePage.vue
@@ -1,14 +1,6 @@
 <template>
   <div>
     <div class="row">
-      <div class="col-xlg-6">
-        <Autocomplete
-          :incomingSearch="incomingSearch || $route.params.projectName"
-          v-on:select-project="currentProject = $event"
-        ></Autocomplete>
-      </div>
-    </div>
-    <div class="row">
       <div class="col">
         <h4>
           {{ currentProject }} articles
@@ -40,21 +32,14 @@
 </template>
 
 <script>
-import Autocomplete from './Autocomplete.vue';
 import ArticleTable from './ArticleTable.vue';
 
 export default {
   name: 'articlepage',
   components: {
-    Autocomplete,
     ArticleTable
   },
-  data: function() {
-    return {
-      currentProject: null,
-      incomingSearch: null
-    };
-  },
+  props: ['currentProject'],
   computed: {
     currentProjectId: function() {
       if (!this.currentProject) {
@@ -80,10 +65,6 @@ export default {
         });
       }
     }
-  },
-  beforeRouteUpdate(to, from, next) {
-    this.incomingSearch = to.params.projectName;
-    next();
   }
 };
 </script>

--- a/wp1-frontend/src/components/ArticleTable.vue
+++ b/wp1-frontend/src/components/ArticleTable.vue
@@ -83,6 +83,7 @@ export default {
   },
   watch: {
     projectId: async function(projectId) {
+      window.console.log('watching projectId:', projectId);
       if (!projectId) {
         this.tableData = null;
         return;
@@ -128,6 +129,8 @@ export default {
       finishedRequest = true;
       if (response.ok) {
         this.articleData = await response.json();
+      } else {
+        this.articleData = null;
       }
       this.loading = false;
     },

--- a/wp1-frontend/src/components/ArticleTable.vue
+++ b/wp1-frontend/src/components/ArticleTable.vue
@@ -1,49 +1,67 @@
 <template>
   <div>
-    <p v-if="articleData" class="pages-cont">
-      {{ articleData.pagination.total }} articles
+    <div v-if="loading">
+      <pulse-loader
+        class="loader"
+        :loading="loading"
+        :color="loaderColor"
+        :size="loaderSize"
+      ></pulse-loader>
+    </div>
+    <div v-else>
+      <p v-if="articleData" class="pages-cont">
+        {{ articleData.pagination.total }} articles
 
-      <span v-if="articleData.pagination.total_pages > 1">
-        - Pages:
-        <span
-          v-for="i in Math.min(articleData.pagination.total_pages, 15)"
-          :key="i"
-          :class="
-            'page-indicator' +
-              (i === Number(page) || (i === 1 && !page) ? '' : ' link')
-          "
-          ><a v-on:click="updatePage(i)">{{ i }}</a></span
-        >
-        <span v-if="articleData.pagination.total_pages > 15">
-          ...(more results truncated)
+        <span v-if="articleData.pagination.total_pages > 1">
+          - Pages:
+          <span
+            v-for="i in Math.min(articleData.pagination.total_pages, 15)"
+            :key="i"
+            :class="
+              'page-indicator' +
+                (i === Number(page) || (i === 1 && !page) ? '' : ' link')
+            "
+            ><a v-on:click="updatePage(i)">{{ i }}</a></span
+          >
+          <span v-if="articleData.pagination.total_pages > 15">
+            ...(more results truncated)
+          </span>
         </span>
-      </span>
-    </p>
+      </p>
 
-    <hr />
+      <hr />
 
-    <table>
-      <tr v-for="row in tableData" :key="row.article">
-        <td>
-          <a :href="row.article_link">{{ row.article }}</a>
-        </td>
-        <td :class="row.importance">{{ row.importance }}</td>
-        <td>{{ row.importance_updated }}</td>
-        <td :class="row.quality">{{ row.quality }}</td>
-        <td>{{ row.quality_updated }}</td>
-      </tr>
-    </table>
+      <table>
+        <tr v-for="row in tableData" :key="row.article">
+          <td>
+            <a :href="row.article_link">{{ row.article }}</a>
+          </td>
+          <td :class="row.importance">{{ row.importance }}</td>
+          <td>{{ row.importance_updated }}</td>
+          <td :class="row.quality">{{ row.quality }}</td>
+          <td>{{ row.quality_updated }}</td>
+        </tr>
+      </table>
 
-    <h2 v-if="!tableData.length">No results to display</h2>
+      <h2 v-if="!tableData.length">No results to display</h2>
+    </div>
   </div>
 </template>
 
 <script>
+import PulseLoader from 'vue-spinner/src/PulseLoader.vue';
+
 export default {
   name: 'articletable',
+  components: {
+    PulseLoader
+  },
   data: function() {
     return {
-      articleData: null
+      articleData: null,
+      loading: false,
+      loaderColor: '#007bff',
+      loaderSize: '1rem'
     };
   },
   props: {
@@ -59,6 +77,9 @@ export default {
       }
       return this.articleData['articles'];
     }
+  },
+  created: function() {
+    this.updateTable();
   },
   watch: {
     projectId: async function(projectId) {
@@ -97,8 +118,18 @@ export default {
         url.searchParams.append(key, params[key])
       );
 
+      let finishedRequest = false;
+      setTimeout(() => {
+        if (!finishedRequest) {
+          this.loading = true;
+        }
+      }, 100);
       const response = await fetch(url);
-      this.articleData = await response.json();
+      finishedRequest = true;
+      if (response.ok) {
+        this.articleData = await response.json();
+      }
+      this.loading = false;
     },
     updatePage: function(page) {
       if (page === this.page) {
@@ -111,7 +142,7 @@ export default {
         query: {
           quality: this.quality,
           importance: this.importance,
-          page: page
+          page: page.toString()
         }
       });
     }
@@ -154,5 +185,10 @@ tr:nth-child(even) {
 .page-indicator.link {
   color: #007bff;
   cursor: pointer;
+}
+
+.loader {
+  margin: auto;
+  text-align: center;
 }
 </style>

--- a/wp1-frontend/src/components/Autocomplete.vue
+++ b/wp1-frontend/src/components/Autocomplete.vue
@@ -57,8 +57,8 @@ export default {
     };
   },
   created: async function() {
-    this.updateFromIncomingSearch(this.incomingSearch);
     this.projects = await this.getProjects();
+    this.updateFromIncomingSearch(this.incomingSearch);
   },
   methods: {
     filterResults: function() {
@@ -68,7 +68,7 @@ export default {
       }
       this.results = this.projects.filter(project => {
         return (
-          project.name.toLowerCase().indexOf(this.search.toLowerCase()) > -1
+          project.name.toLowerCase().indexOf(this.search.toLowerCase()) !== -1
         );
       });
     },
@@ -128,9 +128,15 @@ export default {
     },
     updateFromIncomingSearch: function(val) {
       if (!!val && val !== this.search) {
-        this.search = val;
-        this.onChange();
-        this.makeSelection();
+        const found = this.projects.filter(project => {
+          return project.name == val;
+        });
+        window.console.log(found);
+        if (found.length === 1) {
+          this.search = val;
+          this.onChange();
+          this.makeSelection();
+        }
       }
     }
   },

--- a/wp1-frontend/src/components/IndexPage.vue
+++ b/wp1-frontend/src/components/IndexPage.vue
@@ -1,11 +1,9 @@
 <template>
-  <div>
-    <div class="row">
-      <div class="col-xlg-6">
-        <Autocomplete
-          v-on:select-project="currentProject = $event"
-        ></Autocomplete>
-      </div>
+  <div class="row">
+    <div class="col-xlg-6">
+      <Autocomplete
+        v-on:select-project="currentProject = $event"
+      ></Autocomplete>
     </div>
   </div>
 </template>

--- a/wp1-frontend/src/components/ProjectPage.vue
+++ b/wp1-frontend/src/components/ProjectPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="row">
-      <div class="col-lg-6">
+      <div class="col-xlg-6">
         <Autocomplete
           :incomingSearch="incomingSearch || $route.params.projectName"
           v-on:select-project="currentProject = $event"

--- a/wp1-frontend/src/components/UpdatePage.vue
+++ b/wp1-frontend/src/components/UpdatePage.vue
@@ -10,10 +10,9 @@
     </div>
     <div class="row">
       <div class="col-xlg-6">
-        <div v-if="this.$route.params.projectName && !updateTime">
+        <div v-if="currentProject && !updateTime">
           <label class="mt-2" for="confirm"
-            >Proceed with manual update of
-            <b>{{ this.$route.params.projectName }}</b
+            >Proceed with manual update of <b>{{ currentProject }}</b
             >?</label
           >
           <div class="input-group">
@@ -22,7 +21,7 @@
             </button>
           </div>
         </div>
-        <div v-if="this.$route.params.projectName && updateTime">
+        <div v-if="currentProject && updateTime">
           <p>
             Manual update of <b>{{ this.$route.params.projectName }}</b> has
             been scheduled. It can take anywhere from 2 - 200 minutes, depending
@@ -123,7 +122,6 @@ export default {
     }
   },
   beforeRouteUpdate(to, from, next) {
-    this.incomingSearch = to.params.projectName;
     this.stopProgressPolling();
     next();
   },

--- a/wp1-frontend/src/main.js
+++ b/wp1-frontend/src/main.js
@@ -48,6 +48,9 @@ const routes = [
   {
     path: '/project/:projectName/articles',
     component: ArticlePage,
+    props: route => ({
+      currentProject: route.params.projectName
+    }),
     meta: {
       title: route =>
         BASE_TITLE + ' - ' + route.params.projectName + ' articles'

--- a/wp1/web/projects.py
+++ b/wp1/web/projects.py
@@ -26,6 +26,17 @@ def count():
   return flask.jsonify({'count': count})
 
 
+@projects.route('/<project_name>')
+def project(project_name):
+  wp10db = get_db('wp10db')
+  project_name_bytes = project_name.encode('utf-8')
+  project = logic_project.get_project_by_name(wp10db, project_name_bytes)
+  if project is None:
+    return flask.abort(404)
+
+  return flask.jsonify(project.to_web_dict())
+
+
 @projects.route('/<project_name>/table')
 def table(project_name):
   wp10db = get_db('wp10db')

--- a/wp1/web/projects_test.py
+++ b/wp1/web/projects_test.py
@@ -55,6 +55,19 @@ class ProjectTest(BaseWebTestcase):
       data = json.loads(rv.data)
       self.assertEqual(101, len(data))
 
+  def test_individual_project(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get('/v1/projects/Project 0')
+      self.assertEqual('200 OK', rv.status)
+
+      data = json.loads(rv.data)
+      self.assertEqual(2, len(data))
+
+  def test_individual_project_404(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get('/v1/projects/Fee Fa Fo Project')
+      self.assertEqual('404 NOT FOUND', rv.status)
+
   def test_count(self):
     with self.override_db(self.app), self.app.test_client() as client:
       rv = client.get('/v1/projects/count')


### PR DESCRIPTION
Fixes some alignment issues with paragraphs on a few pages. Also removes the Autocomplete box from the Article listing page to make it less busy.

If the main page is loaded with a non-existant project: (eg [http://wp1.openzim.org/#/project/Paris](http://wp1.openzim.org/#/project/Paris)), the page is simply loaded in it's default, empty state.

The same is true of the manual update page (eg [http://wp1.openzim.org/#/update/Paris](http://wp1.openzim.org/#/update/Paris)), the page simply loads as if no Project was chosen.

These two default states make sense, since the only way the page can be reached with an invalid project is through URL hacking anyways.

The article listing page also refuses to list the results for non-existant projects, and this time displays a "not found" message, in order to distinguish between existing projects with no results and non-existant projects: (see [http://wp1.openzim.org/#/project/Paris/articles?quality=Start-Class&importance=Mid-Class](http://wp1.openzim.org/#/project/Paris/articles?quality=Start-Class&importance=Mid-Class))