### PR TITLE
Update colors for better accessiblity contrast

### DIFF
--- a/wp1-frontend/src/App.vue
+++ b/wp1-frontend/src/App.vue
@@ -60,6 +60,17 @@ export default {
 </script>
 
 <style>
+a {
+  color: #0063cc;
+}
+
+.alert-info {
+}
+
+.btn-primary {
+  background-color: #0071eb;
+}
+
 .row {
   margin-top: 10px;
 }

--- a/wp1-frontend/src/components/ProjectTable.vue
+++ b/wp1-frontend/src/components/ProjectTable.vue
@@ -188,7 +188,6 @@ export default {
 }
 
 table {
-  background: #eee;
   border-collapse: collapse;
   border: 1px solid #aaa;
   margin: auto;
@@ -202,6 +201,10 @@ th {
   text-align: center;
 }
 
+th a {
+  color: #000;
+}
+
 td {
   border: 1px solid #aaa;
   padding-left: 0.5rem;
@@ -209,7 +212,7 @@ td {
 }
 
 .table-link {
-  color: #007bff;
+  color: #006fe6;
   cursor: pointer;
 }
 


### PR DESCRIPTION
Removed the background color of the main table, fixed the foreground for the cells with background colors, and fixed the link color overall.

<img width="1304" alt="Screen Shot 2020-06-13 at 12 30 38 PM" src="https://user-images.githubusercontent.com/57832/84577520-c7031880-ad71-11ea-8ca4-fcecc69f9543.png">

Fixes #199 