### PR TITLE
Add talk, history and old revision/old revision talk links to the article listing page

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -15,6 +15,28 @@ info:
     name: 'GPL v2 or greater'
     url: 'https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html'
 paths:
+  /articles/{articleName}/{timestamp}/redirect:
+    get:
+      summary: 'Redirect to the given Wikipedia article at the revision indicated by the timestamp'
+      operationId: articleRedirect
+      responses:
+        302:
+          description: 'Successful operation'
+        404:
+          description: 'The article with that name could not be found'
+      parameters:
+        - name: timestamp
+          in: path
+          required: true
+          description: 'A timestamp like 2020-06-22T10:55:10Z which represents the time of the revision to be redirected to'
+          schema:
+            type: string
+        - name: articleName
+          in: path
+          required: true
+          description: 'The name of the article, with namespace if required, as it appears on Wikipedia'
+          schema:
+            type: string
   /projects:
     get:
       summary: 'List all projects that the WP 1.0 bot updates'
@@ -250,10 +272,19 @@ components:
       properties:
         article:
           type: string
-          description: 'The name of the article, as it appears on Wikipedia'
+          description: 'The name of the article, as it appears on Wikipedia, with its namespace prefix included'
+        article_talk:
+          type: string
+          description: 'The name of fthe article, with the appropriate talk namespace prepended'
         article_link:
           type: string
           description: 'A link to the article on Wikipedia'
+        article_talk_link:
+          type: string
+          description: 'A link to the talk page o the article on Wikipedia'
+        article_history_link:
+          type: string
+          description: 'A link to the history listing of the article on Wikipedia'
         importance:
           type: string
           description: 'The importance class of the article'
@@ -263,8 +294,8 @@ components:
         importance_updated:
           type: string
           format: date
-          description: 'The date on which the article importance classification was updated'
+          description: 'The date on which the article importance classification was updated, the format is 2020-01-30T15:55:55Z'
         quality_updated:
           type: string
           format: date
-          description: 'The date on which the article quality classification was updated'
+          description: 'The date on which the article quality classification was updated, the format is 2020-01-30T15:55:55Z'

--- a/wp1-frontend/src/components/ArticleTable.vue
+++ b/wp1-frontend/src/components/ArticleTable.vue
@@ -34,12 +34,32 @@
       <table>
         <tr v-for="row in tableData" :key="row.article">
           <td>
-            <a :href="row.article_link">{{ row.article }}</a>
+            <a :href="row.article_link">{{ row.article }}</a> (
+            <a :href="row.article_talk_link">t</a> ·
+            <a :href="row.article_history_link">h</a> )
           </td>
           <td :class="row.importance">{{ row.importance }}</td>
-          <td>{{ row.importance_updated }}</td>
+          <td>
+            <a :href="timestampLink(row.article, row.importance_updated)">{{
+              formatTimestamp(row.importance_updated)
+            }}</a>
+            (
+            <a :href="timestampLink(row.article_talk, row.importance_updated)"
+              >t</a
+            >
+            )
+          </td>
           <td :class="row.quality">{{ row.quality }}</td>
-          <td>{{ row.quality_updated }}</td>
+          <td>
+            <a :href="timestampLink(row.article, row.quality_updated)">{{
+              formatTimestamp(row.quality_updated)
+            }}</a>
+            (
+            <a :href="timestampLink(row.article_talk, row.quality_updated)"
+              >t</a
+            >
+            )
+          </td>
         </tr>
       </table>
 
@@ -148,6 +168,14 @@ export default {
           page: page.toString()
         }
       });
+    },
+    formatTimestamp: function(ts) {
+      return ts.split('T')[0];
+    },
+    timestampLink: function(articleName, ts) {
+      return `${process.env.VUE_APP_API_URL}/articles/${encodeURIComponent(
+        articleName
+      )}/${encodeURIComponent(ts)}/redirect`;
     }
   }
 };

--- a/wp1/api.py
+++ b/wp1/api.py
@@ -61,3 +61,11 @@ def save_page(page, wikicode, msg):
     page = get_page(page.name)
     page.save(wikicode, msg)
   return True
+
+
+def get_revision_id_by_timestamp(page, timestamp):
+  try:
+    rev = next(page.revisions(start=timestamp, limit=1, prop='ids'))
+  except StopIteration:
+    return None
+  return rev['revid']

--- a/wp1/api_test.py
+++ b/wp1/api_test.py
@@ -54,3 +54,15 @@ class ApiTest(unittest.TestCase):
     patched_api.site = None
     actual = self.original_save_page(self.page, '<code>', 'edit summary')
     self.assertFalse(actual)
+
+  def test_get_revision_id_present(self):
+    self.page.revisions.return_value = iter(({'revid': 10},))
+    actual = wp1.api.get_revision_id_by_timestamp(self.page,
+                                                  '2015-05-05T15:55:55Z')
+    self.assertEquals(10, actual)
+
+  def test_get_revision_id_absent(self):
+    self.page.revisions.return_value = iter(())
+    actual = wp1.api.get_revision_id_by_timestamp(self.page,
+                                                  '2015-05-05T15:55:55Z')
+    self.assertIsNone(actual)

--- a/wp1/api_test.py
+++ b/wp1/api_test.py
@@ -59,7 +59,7 @@ class ApiTest(unittest.TestCase):
     self.page.revisions.return_value = iter(({'revid': 10},))
     actual = wp1.api.get_revision_id_by_timestamp(self.page,
                                                   '2015-05-05T15:55:55Z')
-    self.assertEquals(10, actual)
+    self.assertEqual(10, actual)
 
   def test_get_revision_id_absent(self):
     self.page.revisions.return_value = iter(())

--- a/wp1/models/wp10/rating_test.py
+++ b/wp1/models/wp10/rating_test.py
@@ -6,28 +6,35 @@ class RatingModelTest(BaseWpOneDbTest):
 
   def setUp(self):
     super().setUp()
+    self.maxDiff = None
     self.rating = Rating(r_project=b'Test Project',
                          r_namespace=4,
                          r_article=b'Test article pages',
                          r_importance=b'NotAClass',
-                         r_importance_timestamp=b'2020-04-05T08:04:20Z',
+                         r_importance_timestamp=b'2020-04-04T15:55:55Z',
                          r_quality=b'NotAClass',
-                         r_quality_timestamp=b'2020-04-05T08:04:20Z')
+                         r_quality_timestamp=b'2020-01-13T08:04:20Z')
 
   def test_to_web_dict_namespace(self):
     expected = {
         'article':
-            'Test article pages',
+            'Wikipedia:Test article pages',
         'article_link':
             'https://en.wikipedia.org/w/index.php?title=Wikipedia:Test%20article%20pages',
+        'article_talk':
+            'Wikipedia talk:Test article pages',
+        'article_talk_link':
+            'https://en.wikipedia.org/w/index.php?title=Wikipedia talk:Test%20article%20pages',
+        'article_history_link':
+            'https://en.wikipedia.org/w/index.php?title=Wikipedia:Test%20article%20pages&action=history',
         'importance':
             'NotAClass',
         'importance_updated':
-            '2020-04-05',
+            '2020-04-04T15:55:55Z',
         'quality':
             'NotAClass',
         'quality_updated':
-            '2020-04-05'
+            '2020-01-13T08:04:20Z'
     }
 
     actual = self.rating.to_web_dict(self.wp10db)
@@ -40,14 +47,20 @@ class RatingModelTest(BaseWpOneDbTest):
             'Test article pages',
         'article_link':
             'https://en.wikipedia.org/w/index.php?title=Test%20article%20pages',
+        'article_talk':
+            'Talk:Test article pages',
+        'article_talk_link':
+            'https://en.wikipedia.org/w/index.php?title=Talk:Test%20article%20pages',
+        'article_history_link':
+            'https://en.wikipedia.org/w/index.php?title=Test%20article%20pages&action=history',
         'importance':
             'NotAClass',
         'importance_updated':
-            '2020-04-05',
+            '2020-04-04T15:55:55Z',
         'quality':
             'NotAClass',
         'quality_updated':
-            '2020-04-05'
+            '2020-01-13T08:04:20Z'
     }
 
     actual = self.rating.to_web_dict(self.wp10db)

--- a/wp1/web/app.py
+++ b/wp1/web/app.py
@@ -10,6 +10,7 @@ from rq_dashboard.cli import add_basic_auth
 
 import wp1.logic.project as logic_project
 from wp1.web.db import get_db, has_db
+from wp1.web.articles import articles
 from wp1.web.projects import projects
 
 
@@ -74,5 +75,5 @@ def create_app():
     return flask.send_from_directory(".", "openapi.yml")
 
   app.register_blueprint(projects, url_prefix='/v1/projects')
-
+  app.register_blueprint(articles, url_prefix='/v1/articles')
   return app

--- a/wp1/web/articles.py
+++ b/wp1/web/articles.py
@@ -1,0 +1,18 @@
+import flask
+
+from wp1.api import get_page, get_revision_id_by_timestamp
+from wp1.constants import FRONTEND_WIKI_BASE
+
+articles = flask.Blueprint('articles', __name__)
+
+
+@articles.route('<name>/<timestamp>/redirect')
+def redirect(name, timestamp):
+  page = get_page(name)
+  revid = get_revision_id_by_timestamp(page, timestamp)
+
+  if revid:
+    return flask.redirect('%sindex.php?title=%s&oldid=%s' %
+                          (FRONTEND_WIKI_BASE, name, revid))
+  else:
+    return flask.abort(404)

--- a/wp1/web/articles.py
+++ b/wp1/web/articles.py
@@ -14,5 +14,5 @@ def redirect(name, timestamp):
   if revid:
     return flask.redirect('%sindex.php?title=%s&oldid=%s' %
                           (FRONTEND_WIKI_BASE, name, revid))
-  else:
-    return flask.abort(404)
+
+  return flask.abort(404)

--- a/wp1/web/articles_test.py
+++ b/wp1/web/articles_test.py
@@ -19,3 +19,13 @@ class ArticlesTest(BaseWebTestcase):
       expected_url = ('%sindex.php?title=%s&oldid=%s' %
                       (FRONTEND_WIKI_BASE, 'Web%20development', 5555))
       self.assertEqual(expected_url, rv.headers['Location'])
+
+  @patch('wp1.web.articles.get_page')
+  @patch('wp1.web.articles.get_revision_id_by_timestamp')
+  def test_404(self, patched_get_revision, patched_get_page):
+    patched_get_revision.return_value = None
+
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get(
+          '/v1/articles/Web%20development/2020-01-13T10:00:00Z/redirect')
+      self.assertEqual('404 NOT FOUND', rv.status)

--- a/wp1/web/articles_test.py
+++ b/wp1/web/articles_test.py
@@ -1,0 +1,21 @@
+from unittest.mock import patch
+
+from wp1.web.base_web_testcase import BaseWebTestcase
+from wp1.constants import FRONTEND_WIKI_BASE
+
+
+class ArticlesTest(BaseWebTestcase):
+
+  @patch('wp1.web.articles.get_page')
+  @patch('wp1.web.articles.get_revision_id_by_timestamp')
+  def test_redirect_response(self, patched_get_revision, patched_get_page):
+    patched_get_revision.return_value = 5555
+
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get(
+          '/v1/articles/Web%20development/2020-01-13T10:00:00Z/redirect')
+      self.assertEqual('302 FOUND', rv.status)
+
+      expected_url = ('%sindex.php?title=%s&oldid=%s' %
+                      (FRONTEND_WIKI_BASE, 'Web%20development', 5555))
+      self.assertEqual(expected_url, rv.headers['Location'])


### PR DESCRIPTION
This now looks like this:

<img width="1156" alt="Screen Shot 2020-06-22 at 13 08 57" src="https://user-images.githubusercontent.com/57832/85330625-9e71d180-b489-11ea-80e9-1e336206612c.png">

The ( t ) and ( h ) in parenthesis are links to the current talk and history pages of the article. The timestamps for quality and importance now link to the revisions on Wikipedia that were active at that time. And the ( t ) next to the timestamps links to the talk page at that revision.

Fixes #175 