### PR TITLE
Display proper category names in article table

### DIFF
--- a/wp1-frontend/src/components/ArticleTable.vue
+++ b/wp1-frontend/src/components/ArticleTable.vue
@@ -43,11 +43,8 @@
             <a :href="row.article_talk_link">t</a> ·
             <a :href="row.article_history_link">h</a> )
           </td>
-          <td :class="row.importance">
-            {{
-              categoryLinks[row.importance].text ||
-                categoryLinks[row.importance]
-            }}
+          <td :class="classLabel(row.importance)">
+            {{ classLabel(row.importance) }}
           </td>
           <td>
             <a :href="timestampLink(row.article, row.importance_updated)">{{
@@ -59,8 +56,8 @@
             >
             )
           </td>
-          <td :class="row.quality">
-            {{ categoryLinks[row.quality].text || categoryLinks[row.quality] }}
+          <td :class="classLabel(row.quality)">
+            {{ classLabel(row.quality) }}
           </td>
           <td>
             <a :href="timestampLink(row.article, row.quality_updated)">{{
@@ -180,6 +177,11 @@ export default {
           numRows: this.numRows
         }
       });
+    },
+    classLabel: function(qualOrImp) {
+      return (
+        this.categoryLinks[qualOrImp].text || this.categoryLinks[qualOrImp]
+      );
     },
     getCategoryLinks: async function() {
       const response = await fetch(

--- a/wp1-frontend/src/components/ArticleTable.vue
+++ b/wp1-frontend/src/components/ArticleTable.vue
@@ -43,7 +43,12 @@
             <a :href="row.article_talk_link">t</a> ·
             <a :href="row.article_history_link">h</a> )
           </td>
-          <td :class="row.importance">{{ row.importance }}</td>
+          <td :class="row.importance">
+            {{
+              categoryLinks[row.importance].text ||
+                categoryLinks[row.importance]
+            }}
+          </td>
           <td>
             <a :href="timestampLink(row.article, row.importance_updated)">{{
               formatTimestamp(row.importance_updated)
@@ -54,7 +59,9 @@
             >
             )
           </td>
-          <td :class="row.quality">{{ row.quality }}</td>
+          <td :class="row.quality">
+            {{ categoryLinks[row.quality].text || categoryLinks[row.quality] }}
+          </td>
           <td>
             <a :href="timestampLink(row.article, row.quality_updated)">{{
               formatTimestamp(row.quality_updated)
@@ -104,6 +111,7 @@ export default {
   data: function() {
     return {
       articleData: null,
+      categoryLinks: {},
       loading: false,
       loaderColor: '#007bff',
       loaderSize: '1rem'
@@ -173,6 +181,12 @@ export default {
         }
       });
     },
+    getCategoryLinks: async function() {
+      const response = await fetch(
+        `${process.env.VUE_APP_API_URL}/projects/${this.projectId}/category_links`
+      );
+      this.categoryLinks = await response.json();
+    },
     updateTable: async function() {
       const url = new URL(
         `${process.env.VUE_APP_API_URL}/projects/${this.projectId}/articles`
@@ -208,6 +222,7 @@ export default {
         this.articleData = null;
       }
       this.loading = false;
+      await this.getCategoryLinks();
     },
     formatTimestamp: function(ts) {
       return ts.split('T')[0];

--- a/wp1/models/wp10/rating.py
+++ b/wp1/models/wp10/rating.py
@@ -49,9 +49,6 @@ class Rating:
       return
     self.r_importance_timestamp = dt.strftime(TS_FORMAT).encode('utf-8')
 
-  def _web_label(self, cls):
-    return cls.split('-')[0]
-
   def _get_namespace_prefix(self, wp10db, ns=None):
     if ns is None:
       ns = self.r_namespace
@@ -92,11 +89,11 @@ class Rating:
         'article_history_link':
             self._make_article_history_link(wp10db, article_name),
         'quality':
-            self._web_label(self.r_quality.decode('utf-8')),
+            self.r_quality.decode('utf-8'),
         'quality_updated':
             self.r_quality_timestamp.decode('utf-8'),
         'importance':
-            self._web_label(self.r_importance.decode('utf-8')),
+            self.r_importance.decode('utf-8'),
         'importance_updated':
             self.r_importance_timestamp.decode('utf-8'),
     }

--- a/wp1/web/projects_test.py
+++ b/wp1/web/projects_test.py
@@ -106,7 +106,7 @@ class ProjectTest(BaseWebTestcase):
       # Currently limited to 100 items
       self.assertEqual(50, len(data['articles']))
       for article in data['articles']:
-        self.assertEqual('FA', article['quality'])
+        self.assertEqual('FA-Class', article['quality'])
 
   def test_articles_importance_only(self):
     with self.override_db(self.app), self.app.test_client() as client:
@@ -115,7 +115,7 @@ class ProjectTest(BaseWebTestcase):
 
       self.assertEqual(75, len(data['articles']))
       for article in data['articles']:
-        self.assertEqual('High', article['importance'])
+        self.assertEqual('High-Class', article['importance'])
 
   def test_articles_quality_importance(self):
     with self.override_db(self.app), self.app.test_client() as client:
@@ -126,8 +126,8 @@ class ProjectTest(BaseWebTestcase):
 
       self.assertEqual(25, len(data['articles']))
       for article in data['articles']:
-        self.assertEqual('Low', article['importance'])
-        self.assertEqual('A', article['quality'])
+        self.assertEqual('Low-Class', article['importance'])
+        self.assertEqual('A-Class', article['quality'])
 
   def test_articles_no_results(self):
     with self.override_db(self.app), self.app.test_client() as client:


### PR DESCRIPTION
Instead of just randomly chopping off '-Class' for the category names in the article table, use the database mappings, which are already available at the /categoryLinks endpoint.

Fixes #209.