### PR TITLE
Fix article pages "back" links

### DIFF
--- a/wp1-frontend/src/components/ArticlePage.vue
+++ b/wp1-frontend/src/components/ArticlePage.vue
@@ -34,7 +34,11 @@
             quality</span
           >
         </h4>
-        <p><a :href="'#/project/' + currentProject">Back to table</a></p>
+        <p>
+          <a :href="'#/project/' + currentProject.replace(/_/g, '%20')"
+            >Back to table</a
+          >
+        </p>
       </div>
     </div>
     <div class="row">


### PR DESCRIPTION
If the user has gotten to an articles list with _ instead of space, replace the spaces on back.

Fixes #218 