### PR TITLE
Drastically reduce the number of logins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ venv
 
 # Don't commit credentials!
 wp1/credentials.py
+cookies.txt

--- a/wp1/api_test.py
+++ b/wp1/api_test.py
@@ -11,19 +11,34 @@ class ApiWithCredsTest(unittest.TestCase):
 
   @patch('wp1.api.get_credentials')
   @patch('wp1.api.mwclient.Site')
-  def test_login(self, patched_mwsite, patched_credentials):
+  @patch('http.cookiejar.MozillaCookieJar')
+  def test_login(self, patched_cookies, patched_mwsite, patched_credentials):
     site = patched_mwsite()
     wp1.api.login()
     self.assertEqual(1, site.login.call_count)
 
   @patch('wp1.api.get_credentials')
   @patch('wp1.api.mwclient.Site')
-  @patch('wp1.api.logger')
-  def test_login_exception(self, patched_logger, patched_mwsite,
-                           patched_credentials):
+  @patch('http.cookiejar.MozillaCookieJar')
+  def test_login(self, patched_cookies, patched_mwsite, patched_credentials):
     site = patched_mwsite()
+    actual = wp1.api.login()
+    self.assertTrue(actual)
+    self.assertEqual(0, site.login.call_count)
+
+  @patch('wp1.api.get_credentials')
+  @patch('wp1.api.mwclient.Site')
+  @patch('wp1.api.site')
+  @patch('wp1.api.logger')
+  @patch('http.cookiejar.MozillaCookieJar')
+  def test_login_exception(self, patched_cookies, patched_logger, patched_site,
+                           patched_mwsite, patched_credentials):
+    patched_site.logged_in = False
+    site = patched_mwsite()
+    site.logged_in = False
     site.login.side_effect = mwclient.errors.LoginError()
-    wp1.api.login()
+    actual = wp1.api.login()
+    self.assertFalse(actual)
     self.assertEqual(1, patched_logger.exception.call_count)
 
 
@@ -39,21 +54,13 @@ class ApiTest(unittest.TestCase):
     self.assertEqual(1, self.page.save.call_count)
     self.assertEqual(('<code>', 'edit summary'), self.page.save.call_args[0])
 
-  @patch('wp1.api.site')
   @patch('wp1.api.login')
   @patch('wp1.api.get_page')
-  def test_save_page_retries_on_exception(self, patched_get_page, patched_login,
-                                          patched_site):
-    self.page.save.side_effect = mwclient.errors.AssertUserFailedError()
-    wp1.api.save_page(self.page, '<code>', 'edit summary')
+  def test_save_page_tries_login_on_none_site(self, patched_get_page,
+                                              patched_login):
+    self.original_save_page(self.page, '<code>', 'edit summary')
     self.assertEqual(1, patched_login.call_count)
     self.assertEqual(1, patched_get_page.call_count)
-
-  @patch('wp1.api')
-  def test_save_page_skips_login_on_none_site(self, patched_api):
-    patched_api.site = None
-    actual = self.original_save_page(self.page, '<code>', 'edit summary')
-    self.assertFalse(actual)
 
   def test_get_revision_id_present(self):
     self.page.revisions.return_value = iter(({'revid': 10},))


### PR DESCRIPTION
Change login so that it:

1. Does not happen automatically on startup/import and
2. Persists the cookies between worker processes so that login can happen drastically less often

Fixes #226 