### PR TITLE
Implement page for comparing articles across projects

### DIFF
--- a/wp1-frontend/src/App.vue
+++ b/wp1-frontend/src/App.vue
@@ -29,7 +29,10 @@
           <li
             :class="
               'nav-item ' +
-                (!this.$route.path.startsWith('/update') ? 'active' : '')
+                (!this.$route.path.startsWith('/update') &&
+                !this.$route.path.startsWith('/compare')
+                  ? 'active'
+                  : '')
             "
           >
             <router-link class="nav-link" to="/">Projects</router-link>
@@ -42,6 +45,16 @@
           >
             <router-link class="nav-link" to="/update"
               >Manual Update</router-link
+            >
+          </li>
+          <li
+            :class="
+              'nav-item ' +
+                (this.$route.path.startsWith('/compare') ? 'active' : '')
+            "
+          >
+            <router-link class="nav-link" to="/compare"
+              >Compare Projects</router-link
             >
           </li>
         </ul>

--- a/wp1-frontend/src/components/ArticlePage.vue
+++ b/wp1-frontend/src/components/ArticlePage.vue
@@ -50,6 +50,10 @@
           :page="$route.query.page"
           :numRows="$route.query.numRows"
           :articlePattern="$route.query.articlePattern"
+          v-on:page-select="onPageSelect($event)"
+          v-on:rating-select="onRatingSelect($event)"
+          v-on:name-filter="onNameFilter($event)"
+          v-on:update-page="onUpdatePage($event)"
         ></ArticleTable>
       </div>
     </div>
@@ -117,6 +121,54 @@ export default {
         `${process.env.VUE_APP_API_URL}/projects/${projectId}`
       );
       this.notFound = response.status === 404;
+    },
+    onPageSelect: function(selection) {
+      this.$router.push({
+        path: `/project/${this.currentProject}/articles`,
+        query: {
+          quality: this.$route.query.quality,
+          importance: this.$route.query.importance,
+          page: selection.page,
+          numRows: selection.rows,
+          articlePattern: this.$route.query.articlePattern
+        }
+      });
+    },
+    onRatingSelect: function(selection) {
+      this.$router.push({
+        path: `/project/${this.currentProject}/articles`,
+        query: {
+          quality: selection.quality,
+          importance: selection.importance,
+          page: this.$route.query.page,
+          numRows: this.$route.query.numRows,
+          articlePattern: this.$route.query.articlePattern
+        }
+      });
+    },
+    onNameFilter: function(selection) {
+      this.$router.push({
+        path: `/project/${this.currentProject}/articles`,
+        query: {
+          quality: this.$route.query.quality,
+          importance: this.$route.query.importance,
+          page: this.$route.query.page,
+          numRows: this.$route.query.numRows,
+          articlePattern: selection
+        }
+      });
+    },
+    onUpdatePage: function(page) {
+      this.$router.push({
+        path: `/project/${this.currentProject}/articles`,
+        query: {
+          quality: this.$route.query.quality,
+          importance: this.$route.query.importance,
+          page: page.toString(),
+          numRows: this.$route.query.numRows,
+          articlePattern: this.$route.query.articlePattern
+        }
+      });
     }
   }
 };

--- a/wp1-frontend/src/components/ArticleTable.vue
+++ b/wp1-frontend/src/components/ArticleTable.vue
@@ -16,6 +16,8 @@
       ></ArticleTablePageSelect>
       <ArticleTableRatingSelect
         v-if="!hideRatingSelect"
+        :initialQuality="quality"
+        :initialImportance="importance"
         :projectId="projectId"
         v-on:rating-select="onRatingSelect($event)"
       ></ArticleTableRatingSelect>

--- a/wp1-frontend/src/components/ArticleTable.vue
+++ b/wp1-frontend/src/components/ArticleTable.vue
@@ -15,6 +15,7 @@
         v-on:page-select="onPageSelect($event)"
       ></ArticleTablePageSelect>
       <ArticleTableRatingSelect
+        v-if="!hideRatingSelect"
         :projectId="projectId"
         v-on:rating-select="onRatingSelect($event)"
       ></ArticleTableRatingSelect>
@@ -128,11 +129,13 @@ export default {
   },
   props: [
     'projectId',
+    'projectIdB',
     'importance',
     'quality',
     'page',
     'numRows',
-    'articlePattern'
+    'articlePattern',
+    'hideRatingSelect'
   ],
   computed: {
     tableData: function() {

--- a/wp1-frontend/src/components/ArticleTable.vue
+++ b/wp1-frontend/src/components/ArticleTable.vue
@@ -216,55 +216,16 @@ export default {
   },
   methods: {
     onPageSelect: function(selection) {
-      const projectName = this.projectId.replace(/_/g, ' ');
-      this.$router.push({
-        path: `/project/${projectName}/articles`,
-        query: {
-          quality: this.quality,
-          importance: this.importance,
-          page: selection.page,
-          numRows: selection.rows,
-          articlePattern: this.articlePattern
-        }
-      });
+      this.$emit('page-select', selection);
     },
     onRatingSelect: function(selection) {
-      const projectName = this.projectId.replace(/_/g, ' ');
-      this.$router.push({
-        path: `/project/${projectName}/articles`,
-        query: {
-          quality: selection.quality,
-          importance: selection.importance,
-          page: this.page,
-          numRows: this.numRows,
-          articlePattern: this.articlePattern
-        }
-      });
+      this.$emit('rating-select', selection);
     },
     onNameFilter: function(selection) {
-      const projectName = this.projectId.replace(/_/g, ' ');
-      this.$router.push({
-        path: `/project/${projectName}/articles`,
-        query: {
-          quality: this.quality,
-          importance: this.importance,
-          page: this.page,
-          numRows: this.numRows,
-          articlePattern: selection
-        }
-      });
+      this.$emit('name-filter', selection);
     },
     onUpdatePage: function(page) {
-      const projectName = this.projectId.replace(/_/g, ' ');
-      this.$router.push({
-        path: `/project/${projectName}/articles`,
-        query: {
-          quality: this.quality,
-          importance: this.importance,
-          page: page.toString(),
-          numRows: this.numRows
-        }
-      });
+      this.$emit('update-page', page);
     },
     classLabel: function(qualOrImp) {
       if (!this.categoryLinks[qualOrImp]) {

--- a/wp1-frontend/src/components/ArticleTable.vue
+++ b/wp1-frontend/src/components/ArticleTable.vue
@@ -126,14 +126,14 @@ export default {
       loaderSize: '1rem'
     };
   },
-  props: {
-    projectId: String,
-    importance: String,
-    quality: String,
-    page: String,
-    numRows: String,
-    articlePattern: String
-  },
+  props: [
+    'projectId',
+    'importance',
+    'quality',
+    'page',
+    'numRows',
+    'articlePattern'
+  ],
   computed: {
     tableData: function() {
       if (this.articleData === null) {

--- a/wp1-frontend/src/components/ArticleTable.vue
+++ b/wp1-frontend/src/components/ArticleTable.vue
@@ -44,7 +44,7 @@
 
       <hr class="mt-0" />
 
-      <table>
+      <table v-if="!projectIdB">
         <tr v-for="(row, index) in tableData" :key="index">
           <td>{{ articleData.pagination.display.start + index }}</td>
           <td>
@@ -77,6 +77,37 @@
               >t</a
             >
             )
+          </td>
+        </tr>
+      </table>
+
+      <table v-else-if="tableData.length">
+        <tr>
+          <th colspan="2"></th>
+          <th colspan="2">{{ projectId.replace(/_/g, ' ') }}</th>
+          <th></th>
+          <th colspan="2">{{ projectIdB.replace(/_/g, ' ') }}</th>
+        </tr>
+
+        <tr v-for="(row, index) in tableData" :key="index">
+          <td>{{ articleData.pagination.display.start + index }}</td>
+          <td>
+            <a :href="row[0].article_link">{{ row[0].article }}</a> (
+            <a :href="row[0].article_talk_link">t</a> ·
+            <a :href="row[0].article_history_link">h</a> )
+          </td>
+          <td :class="classLabel(row[0].importance)">
+            {{ classLabel(row[0].importance) }}
+          </td>
+          <td :class="classLabel(row[0].quality)">
+            {{ classLabel(row[0].quality) }}
+          </td>
+          <td class="spacer"></td>
+          <td :class="classLabel(row[1].importance)">
+            {{ classLabel(row[1].importance) }}
+          </td>
+          <td :class="classLabel(row[1].quality)">
+            {{ classLabel(row[1].quality) }}
           </td>
         </tr>
       </table>
@@ -132,6 +163,8 @@ export default {
     'projectIdB',
     'importance',
     'quality',
+    'importanceB',
+    'qualityB',
     'page',
     'numRows',
     'articlePattern',
@@ -156,10 +189,19 @@ export default {
       }
       await this.updateTable();
     },
+    projectIdB: async function() {
+      await this.updateTable();
+    },
     importance: async function() {
       await this.updateTable();
     },
     quality: async function() {
+      await this.updateTable();
+    },
+    importanceB: async function() {
+      await this.updateTable();
+    },
+    qualityB: async function() {
       await this.updateTable();
     },
     page: async function() {
@@ -249,6 +291,15 @@ export default {
       if (this.quality) {
         params.quality = this.quality;
       }
+      if (this.projectIdB) {
+        params.projectB = this.projectIdB;
+      }
+      if (this.importanceB) {
+        params.importanceB = this.importanceB;
+      }
+      if (this.qualityB) {
+        params.qualityB = this.qualityB;
+      }
       if (this.page) {
         params.page = this.page;
       }
@@ -306,6 +357,10 @@ table {
 td {
   border: 1px solid #aaa;
   padding: 0 0.5rem;
+}
+
+.spacer {
+  width: 1rem;
 }
 
 tr:nth-child(even) {

--- a/wp1-frontend/src/components/ArticleTableRatingSelect.vue
+++ b/wp1-frontend/src/components/ArticleTableRatingSelect.vue
@@ -34,7 +34,7 @@
                     v-for="(item, key) in categoryLinks.quality"
                     :value="key"
                     v-bind:key="key"
-                    :selected="$route.query.quality == key"
+                    :selected="selectedQuality == key"
                     >{{ item.text ? item.text : item }}</option
                   >
                 </select>
@@ -44,7 +44,7 @@
                     v-for="(item, key) in categoryLinks.importance"
                     :value="key"
                     v-bind:key="key"
-                    :selected="$route.query.importance == key"
+                    :selected="selectedImportance == key"
                     >{{ item.text ? item.text : item }}</option
                   >
                 </select>
@@ -70,7 +70,7 @@
             v-for="(item, key) in categoryLinks.quality"
             :value="key"
             v-bind:key="key"
-            :selected="$route.query.quality == key"
+            :selected="selectedQuality == key"
             >{{ item.text ? item.text : item }}</option
           >
         </select>
@@ -85,7 +85,7 @@
             v-for="(item, key) in categoryLinks.importance"
             :value="key"
             v-bind:key="key"
-            :selected="$route.query.importance == key"
+            :selected="selectedImportance == key"
             >{{ item.text ? item.text : item }}</option
           >
         </select>
@@ -97,7 +97,7 @@
 <script>
 export default {
   name: 'articletableratingselect',
-  props: ['projectId', 'layout'],
+  props: ['initialQuality', 'initialImportance', 'projectId', 'layout'],
   data: function() {
     return {
       categoryLinks: {}
@@ -106,10 +106,23 @@ export default {
   created: function() {
     this.getCategoryLinks();
   },
+  computed: {
+    selectedQuality: function() {
+      return this.initialQuality || '';
+    },
+    selectedImportance: function() {
+      return this.initialImportance || '';
+    }
+  },
   watch: {
     projectId: async function() {
       await this.getCategoryLinks();
       this.onSelectChange();
+    },
+    $route: function(to) {
+      if (to.path == '/compare') {
+        this.categoryLinks = {};
+      }
     }
   },
   methods: {
@@ -128,6 +141,7 @@ export default {
       links.importance[''] = 'None Selected';
       this.categoryLinks = links;
     },
+
     // Only used for alternate view on Compare pages.
     onSelectChange: function() {
       const quality = this.$refs.qualitySelect.value;

--- a/wp1-frontend/src/components/ArticleTableRatingSelect.vue
+++ b/wp1-frontend/src/components/ArticleTableRatingSelect.vue
@@ -1,98 +1,94 @@
 <template>
   <div class="row">
-    <div v-if="layout != 'alternate'">
-      <div class="select-cont col-7">
-        <div
-          class="accordion"
-          id="accordion-rs"
-          role="tablist"
-          aria-multiselectable="true"
-        >
-          <div class="card mb-2">
-            <div class="card-header p-0" role="tab" id="collapse-rating-select">
-              <a
-                data-toggle="collapse"
-                data-parent="#accordion-rs"
-                href="#collapseRating"
-                aria-expanded="true"
-                aria-controls="collapseRating"
-              >
-                Select Quality/Importance
-              </a>
-            </div>
-
-            <!-- Card body -->
-            <div
-              id="collapseRating"
-              :class="['collapse', startOpen() ? 'show' : '']"
+    <div v-if="layout != 'alternate'" class="select-cont col-xl-7">
+      <div
+        class="accordion"
+        id="accordion-rs"
+        role="tablist"
+        aria-multiselectable="true"
+      >
+        <div class="card mb-2">
+          <div class="card-header p-0" role="tab" id="collapse-rating-select">
+            <a
+              data-toggle="collapse"
               data-parent="#accordion-rs"
+              href="#collapseRating"
+              aria-expanded="true"
+              aria-controls="collapseRating"
             >
-              <div class="card-body form-inline p-2">
-                <div class="card-form">
-                  Quality
-                  <select class="custom-select" ref="qualitySelect">
-                    <option
-                      v-for="(item, key) in categoryLinks.quality"
-                      :value="key"
-                      v-bind:key="key"
-                      :selected="$route.query.quality == key"
-                      >{{ item.text ? item.text : item }}</option
-                    >
-                  </select>
-                  Rating
-                  <select class="custom-select" ref="importanceSelect">
-                    <option
-                      v-for="(item, key) in categoryLinks.importance"
-                      :value="key"
-                      v-bind:key="key"
-                      :selected="$route.query.importance == key"
-                      >{{ item.text ? item.text : item }}</option
-                    >
-                  </select>
-                </div>
-                <button v-on:click="onButtonClick()" class="btn-primary ml-4">
-                  Update View
-                </button>
+              Select Quality/Importance
+            </a>
+          </div>
+
+          <!-- Card body -->
+          <div
+            id="collapseRating"
+            :class="['collapse', startOpen() ? 'show' : '']"
+            data-parent="#accordion-rs"
+          >
+            <div class="card-body form-inline p-2">
+              <div class="card-form">
+                Quality
+                <select class="custom-select" ref="qualitySelect">
+                  <option
+                    v-for="(item, key) in categoryLinks.quality"
+                    :value="key"
+                    v-bind:key="key"
+                    :selected="$route.query.quality == key"
+                    >{{ item.text ? item.text : item }}</option
+                  >
+                </select>
+                Importance
+                <select class="custom-select" ref="importanceSelect">
+                  <option
+                    v-for="(item, key) in categoryLinks.importance"
+                    :value="key"
+                    v-bind:key="key"
+                    :selected="$route.query.importance == key"
+                    >{{ item.text ? item.text : item }}</option
+                  >
+                </select>
               </div>
+              <button v-on:click="onButtonClick()" class="btn-primary ml-4">
+                Update View
+              </button>
             </div>
           </div>
         </div>
       </div>
     </div>
-    <div v-else>
-      <div class="col">
-        <div class="form-inline">
-          Quality
-          <select
-            :disabled="!projectId"
-            @change="onSelectChange()"
-            class="custom-select"
-            ref="qualitySelect"
+    <div v-else class="col">
+      <div class="form-inline">
+        Quality
+        <select
+          :disabled="!projectId"
+          @change="onSelectChange()"
+          class="custom-select"
+          ref="qualitySelect"
+        >
+          <option
+            v-for="(item, key) in categoryLinks.quality"
+            :value="key"
+            v-bind:key="key"
+            :selected="$route.query.quality == key"
+            >{{ item.text ? item.text : item }}</option
           >
-            <option
-              v-for="(item, key) in categoryLinks.quality"
-              :value="key"
-              v-bind:key="key"
-              :selected="$route.query.quality == key"
-              >{{ item.text ? item.text : item }}</option
-            >
-          </select>
-          Rating
-          <select
-            :disabled="!projectId"
-            @change="onSelectChange()"
-            class="custom-select"
-            ref="importanceSelect"
+        </select>
+        Importance
+        <select
+          :disabled="!projectId"
+          @change="onSelectChange()"
+          class="custom-select"
+          ref="importanceSelect"
+        >
+          <option
+            v-for="(item, key) in categoryLinks.importance"
+            :value="key"
+            v-bind:key="key"
+            :selected="$route.query.importance == key"
+            >{{ item.text ? item.text : item }}</option
           >
-            <option
-              v-for="(item, key) in categoryLinks.importance"
-              :value="key"
-              v-bind:key="key"
-              :selected="$route.query.importance == key"
-              >{{ item.text ? item.text : item }}</option
-            >
-          </select>
-        </div>
+        </select>
       </div>
     </div>
   </div>
@@ -107,6 +103,9 @@ export default {
       categoryLinks: {}
     };
   },
+  created: function() {
+    this.getCategoryLinks();
+  },
   watch: {
     projectId: async function() {
       await this.getCategoryLinks();
@@ -118,10 +117,16 @@ export default {
       return !!this.$route.query.quality || !!this.$route.query.importance;
     },
     getCategoryLinks: async function() {
+      if (!this.projectId) {
+        return;
+      }
       const response = await fetch(
         `${process.env.VUE_APP_API_URL}/projects/${this.projectId}/category_links/sorted`
       );
-      this.categoryLinks = await response.json();
+      const links = await response.json();
+      links.quality[''] = 'None Selected';
+      links.importance[''] = 'None Selected';
+      this.categoryLinks = links;
     },
     // Only used for alternate view on Compare pages.
     onSelectChange: function() {

--- a/wp1-frontend/src/components/ArticleTableRatingSelect.vue
+++ b/wp1-frontend/src/components/ArticleTableRatingSelect.vue
@@ -1,59 +1,97 @@
 <template>
   <div class="row">
-    <div class="select-cont col-7">
-      <div
-        class="accordion"
-        id="accordion-rs"
-        role="tablist"
-        aria-multiselectable="true"
-      >
-        <div class="card mb-2">
-          <div class="card-header p-0" role="tab" id="collapse-rating-select">
-            <a
-              data-toggle="collapse"
-              data-parent="#accordion-rs"
-              href="#collapseRating"
-              aria-expanded="true"
-              aria-controls="collapseRating"
-            >
-              Select Quality/Importance
-            </a>
-          </div>
+    <div v-if="layout != 'alternate'">
+      <div class="select-cont col-7">
+        <div
+          class="accordion"
+          id="accordion-rs"
+          role="tablist"
+          aria-multiselectable="true"
+        >
+          <div class="card mb-2">
+            <div class="card-header p-0" role="tab" id="collapse-rating-select">
+              <a
+                data-toggle="collapse"
+                data-parent="#accordion-rs"
+                href="#collapseRating"
+                aria-expanded="true"
+                aria-controls="collapseRating"
+              >
+                Select Quality/Importance
+              </a>
+            </div>
 
-          <!-- Card body -->
-          <div
-            id="collapseRating"
-            :class="['collapse', startOpen() ? 'show' : '']"
-            data-parent="#accordion-rs"
-          >
-            <div class="card-body form-inline p-2">
-              <div class="card-form">
-                Quality
-                <select class="custom-select" ref="qualitySelect">
-                  <option
-                    v-for="(item, key) in categoryLinks.quality"
-                    :value="key"
-                    v-bind:key="key"
-                    :selected="$route.query.quality == key"
-                    >{{ item.text ? item.text : item }}</option
-                  >
-                </select>
-                Rating
-                <select class="custom-select" ref="importanceSelect">
-                  <option
-                    v-for="(item, key) in categoryLinks.importance"
-                    :value="key"
-                    v-bind:key="key"
-                    :selected="$route.query.importance == key"
-                    >{{ item.text ? item.text : item }}</option
-                  >
-                </select>
+            <!-- Card body -->
+            <div
+              id="collapseRating"
+              :class="['collapse', startOpen() ? 'show' : '']"
+              data-parent="#accordion-rs"
+            >
+              <div class="card-body form-inline p-2">
+                <div class="card-form">
+                  Quality
+                  <select class="custom-select" ref="qualitySelect">
+                    <option
+                      v-for="(item, key) in categoryLinks.quality"
+                      :value="key"
+                      v-bind:key="key"
+                      :selected="$route.query.quality == key"
+                      >{{ item.text ? item.text : item }}</option
+                    >
+                  </select>
+                  Rating
+                  <select class="custom-select" ref="importanceSelect">
+                    <option
+                      v-for="(item, key) in categoryLinks.importance"
+                      :value="key"
+                      v-bind:key="key"
+                      :selected="$route.query.importance == key"
+                      >{{ item.text ? item.text : item }}</option
+                    >
+                  </select>
+                </div>
+                <button v-on:click="onButtonClick()" class="btn-primary ml-4">
+                  Update View
+                </button>
               </div>
-              <button v-on:click="onButtonClick()" class="btn-primary ml-4">
-                Update View
-              </button>
             </div>
           </div>
+        </div>
+      </div>
+    </div>
+    <div v-else>
+      <div class="col">
+        <div class="form-inline">
+          Quality
+          <select
+            :disabled="!projectId"
+            @change="onSelectChange()"
+            class="custom-select"
+            ref="qualitySelect"
+          >
+            <option
+              v-for="(item, key) in categoryLinks.quality"
+              :value="key"
+              v-bind:key="key"
+              :selected="$route.query.quality == key"
+              >{{ item.text ? item.text : item }}</option
+            >
+          </select>
+          Rating
+          <select
+            :disabled="!projectId"
+            @change="onSelectChange()"
+            class="custom-select"
+            ref="importanceSelect"
+          >
+            <option
+              v-for="(item, key) in categoryLinks.importance"
+              :value="key"
+              v-bind:key="key"
+              :selected="$route.query.importance == key"
+              >{{ item.text ? item.text : item }}</option
+            >
+          </select>
         </div>
       </div>
     </div>
@@ -63,16 +101,17 @@
 <script>
 export default {
   name: 'articletableratingselect',
-  props: {
-    projectId: String
-  },
+  props: ['projectId', 'layout'],
   data: function() {
     return {
       categoryLinks: {}
     };
   },
-  created: function() {
-    this.getCategoryLinks();
+  watch: {
+    projectId: async function() {
+      await this.getCategoryLinks();
+      this.onSelectChange();
+    }
   },
   methods: {
     startOpen: function() {
@@ -83,6 +122,13 @@ export default {
         `${process.env.VUE_APP_API_URL}/projects/${this.projectId}/category_links/sorted`
       );
       this.categoryLinks = await response.json();
+    },
+    // Only used for alternate view on Compare pages.
+    onSelectChange: function() {
+      const quality = this.$refs.qualitySelect.value;
+      const importance = this.$refs.importanceSelect.value;
+
+      this.$emit('rating-select', { quality, importance });
     },
     onButtonClick: function() {
       const quality = this.$refs.qualitySelect.value;

--- a/wp1-frontend/src/components/ArticleTableRatingSelect.vue
+++ b/wp1-frontend/src/components/ArticleTableRatingSelect.vue
@@ -156,5 +156,6 @@ export default {
 
 .custom-select {
   margin: 0 0.5rem;
+  max-width: 8.45rem;
 }
 </style>

--- a/wp1-frontend/src/components/Autocomplete.vue
+++ b/wp1-frontend/src/components/Autocomplete.vue
@@ -131,7 +131,6 @@ export default {
         const found = this.projects.filter(project => {
           return project.name == val;
         });
-        window.console.log(found);
         if (found.length === 1) {
           this.search = val;
           this.onChange();
@@ -143,6 +142,11 @@ export default {
   watch: {
     incomingSearch: function(val) {
       this.updateFromIncomingSearch(val);
+    },
+    $route: function(to) {
+      if (to.path == '/compare') {
+        this.search = '';
+      }
     }
   }
 };

--- a/wp1-frontend/src/components/Autocomplete.vue
+++ b/wp1-frontend/src/components/Autocomplete.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <p v-if="!this.$route.path.startsWith('/update')">
+    <p v-if="!hideInstructions">
       Use the autocomplete search box below to search for a project in order to
       display it's summary table.
     </p>
@@ -23,7 +23,7 @@
         type="text"
         placeholder="Project name"
       />
-      <button v-on:click="onButtonClick()" class="btn-primary">
+      <button v-on:click="onButtonClick()" class="btn btn-primary">
         Select Project
       </button>
     </div>
@@ -47,7 +47,7 @@
 <script>
 export default {
   name: 'autocomplete',
-  props: ['incomingSearch'],
+  props: ['incomingSearch', 'hideInstructions'],
   data: function() {
     return {
       isOpen: false,

--- a/wp1-frontend/src/components/ComparePage.vue
+++ b/wp1-frontend/src/components/ComparePage.vue
@@ -1,0 +1,88 @@
+<template>
+  <div>
+    <div class="row">
+      <div clas="col-xl-6">
+        Select two projects to compare the articles that are in both, with
+        optional quality and importance filters for each.
+      </div>
+    </div>
+    <div class="row mt-4">
+      <div class="col-xl-6">
+        <Autocomplete
+          :incomingSearch="incomingSearchA || $route.params.projectNameA"
+          :hideInstructions="true"
+          v-on:select-project="projectA = $event"
+        ></Autocomplete>
+      </div>
+    </div>
+    <div class="row mt-4">
+      <div class="col-xl-6">
+        <Autocomplete
+          :incomingSearch="incomingSearchB || $route.params.projectNameB"
+          :hideInstructions="true"
+          v-on:select-project="projectB = $event"
+        ></Autocomplete>
+      </div>
+    </div>
+    <div class="row mt-4">
+      <div class="col-xl-6">
+        <div class="input-group">
+          <button
+            v-on:click="onCompareClick()"
+            :disabled="!projectsSelected"
+            class="btn btn-primary form-control"
+          >
+            Compare
+          </button>
+        </div>
+      </div>
+    </div>
+    <div class="row mt-4">
+      <div class="col">
+        <div v-if="projectsSelected">
+          The projects are {{ projectA }} and {{ projectB }}.
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import Autocomplete from './Autocomplete.vue';
+
+export default {
+  name: 'updatepage',
+  components: {
+    Autocomplete
+  },
+  props: ['incomingSearchA', 'incomingSearchB'],
+  data: function() {
+    return {
+      projectA: null,
+      projectB: null
+    };
+  },
+  computed: {
+    currentProjectIdA: function() {
+      if (!this.projectA) {
+        return null;
+      }
+      return this.currentProjectA.replace(/ /g, '_');
+    },
+    currentProjectIdB: function() {
+      if (!this.projectB) {
+        return null;
+      }
+      return this.currentProjectB.replace(/ /g, '_');
+    },
+    projectsSelected: function() {
+      return !!this.projectA && !!this.projectB;
+    }
+  },
+  methods: {
+    onCompareClick: async function() {}
+  }
+};
+</script>
+
+<style></style>

--- a/wp1-frontend/src/components/ComparePage.vue
+++ b/wp1-frontend/src/components/ComparePage.vue
@@ -9,7 +9,7 @@
     <div class="row mt-4">
       <div class="col-xl-6">
         <Autocomplete
-          :incomingSearch="incomingSearchA || $route.params.projectNameA"
+          :incomingSearch="incomingSearchA"
           :hideInstructions="true"
           v-on:select-project="projectA = $event"
         ></Autocomplete>
@@ -20,6 +20,8 @@
         <ArticleTableRatingSelect
           :projectId="projectIdA"
           :layout="'alternate'"
+          :initialQuality="this.$route.query.quality"
+          :initialImportance="this.$route.query.importance"
           v-on:rating-select="onProjectARatingSelect($event)"
         ></ArticleTableRatingSelect>
       </div>
@@ -27,7 +29,7 @@
     <div class="row mt-4">
       <div class="col-xl-6">
         <Autocomplete
-          :incomingSearch="incomingSearchB || $route.params.projectNameB"
+          :incomingSearch="incomingSearchB"
           :hideInstructions="true"
           v-on:select-project="projectB = $event"
         ></Autocomplete>
@@ -38,11 +40,13 @@
         <ArticleTableRatingSelect
           :projectId="projectIdB"
           :layout="'alternate'"
+          :initialQuality="this.$route.query.qualityB"
+          :initialImportance="this.$route.query.importanceB"
           v-on:rating-select="onProjectBRatingSelect($event)"
         ></ArticleTableRatingSelect>
       </div>
     </div>
-    <div class="row mt-4">
+    <div v-if="showCompareButton" class="row mt-4">
       <div class="col-xl-6">
         <div class="input-group">
           <button
@@ -55,7 +59,7 @@
         </div>
       </div>
     </div>
-    <div v-if="projectsSelected && compareClicked" class="row mt-4">
+    <div v-if="projectsSelected && !showCompareButton" class="row mt-4">
       <div class="col">
         <ArticleTable
           :hideRatingSelect="true"
@@ -68,6 +72,9 @@
           :page="$route.query.page"
           :numRows="$route.query.numRows"
           :articlePattern="$route.query.articlePattern"
+          v-on:page-select="onPageSelect($event)"
+          v-on:name-filter="onNameFilter($event)"
+          v-on:update-page="onUpdatePage($event)"
         ></ArticleTable>
       </div>
     </div>
@@ -99,6 +106,11 @@ export default {
     };
   },
   computed: {
+    showCompareButton: function() {
+      return (
+        !this.compareClicked && (!this.incomingSearchA || !this.incomingSearchB)
+      );
+    },
     projectIdA: function() {
       if (!this.projectA) {
         return null;
@@ -115,9 +127,94 @@ export default {
       return !!this.projectA && !!this.projectB;
     }
   },
+  watch: {
+    $route: function(to) {
+      window.console.log(to.path);
+      if (to.path == '/compare') {
+        this.reset();
+      }
+    },
+    projectAQuality: function(quality) {
+      if (this.showCompareButton) {
+        return;
+      }
+      this.$router.push({
+        path: `/compare/${this.projectA}/${this.projectB}`,
+        query: {
+          quality,
+          importance: this.$route.query.importance,
+          qualityB: this.$route.query.qualityB,
+          importanceB: this.$route.query.importanceB,
+          page: this.$route.query.page,
+          numRows: this.$route.query.numRows,
+          articlePattern: this.$route.query.articlePattern
+        }
+      });
+    },
+    projectAImportance: function(importance) {
+      if (this.showCompareButton) {
+        return;
+      }
+      this.$router.push({
+        path: `/compare/${this.projectA}/${this.projectB}`,
+        query: {
+          quality: this.$route.query.quality,
+          importance,
+          qualityB: this.$route.query.qualityB,
+          importanceB: this.$route.query.importanceB,
+          page: this.$route.query.page,
+          numRows: this.$route.query.numRows,
+          articlePattern: this.$route.query.articlePattern
+        }
+      });
+    },
+    projectBQuality: function(qualityB) {
+      if (this.showCompareButton) {
+        return;
+      }
+      this.$router.push({
+        path: `/compare/${this.projectA}/${this.projectB}`,
+        query: {
+          quality: this.$route.query.quality,
+          importance: this.$route.query.importance,
+          qualityB,
+          importanceB: this.$route.query.importanceB,
+          page: this.$route.query.page,
+          numRows: this.$route.query.numRows,
+          articlePattern: this.$route.query.articlePattern
+        }
+      });
+    },
+    projectBImportance: function(importanceB) {
+      if (this.showCompareButton) {
+        return;
+      }
+      this.$router.push({
+        path: `/compare/${this.projectA}/${this.projectB}`,
+        query: {
+          quality: this.$route.query.quality,
+          importance: this.$route.query.importance,
+          qualityB: this.$route.query.qualityB,
+          importanceB,
+          page: this.$route.query.page,
+          numRows: this.$route.query.numRows,
+          articlePattern: this.$route.query.articlePattern
+        }
+      });
+    }
+  },
   methods: {
     onCompareClick: async function() {
       this.compareClicked = true;
+      this.$router.push({
+        path: `/compare/${this.projectA}/${this.projectB}`,
+        query: {
+          quality: this.projectAQuality,
+          importance: this.projectAImportance,
+          qualityB: this.projectBQuality,
+          importanceB: this.projectBImportance
+        }
+      });
     },
     onProjectARatingSelect: function(event) {
       this.projectAQuality = event.quality;
@@ -126,6 +223,59 @@ export default {
     onProjectBRatingSelect: function(event) {
       this.projectBQuality = event.quality;
       this.projectBImportance = event.importance;
+    },
+    onPageSelect: function(selection) {
+      this.$router.push({
+        path: `/compare/${this.projectA}/${this.projectB}`,
+        query: {
+          quality: this.$route.query.quality,
+          importance: this.$route.query.importance,
+          qualityB: this.$route.query.qualityB,
+          importanceB: this.$route.query.importanceB,
+          page: selection.page,
+          numRows: selection.rows,
+          articlePattern: this.$route.query.articlePattern
+        }
+      });
+    },
+    onNameFilter: function(selection) {
+      this.$router.push({
+        path: `/compare/${this.projectA}/${this.projectB}`,
+        query: {
+          quality: this.$route.query.quality,
+          importance: this.$route.query.importance,
+          qualityB: this.$route.query.qualityB,
+          importanceB: this.$route.query.importanceB,
+          page: this.$route.query.page,
+          numRows: this.$route.query.numRows,
+          articlePattern: selection
+        }
+      });
+    },
+    onUpdatePage: function(page) {
+      this.$router.push({
+        path: `/compare/${this.projectA}/${this.projectB}`,
+        query: {
+          quality: this.$route.query.quality,
+          importance: this.$route.query.importance,
+          qualityB: this.$route.query.qualityB,
+          importanceB: this.$route.query.importanceB,
+          page: page.toString(),
+          numRows: this.$route.query.numRows,
+          articlePattern: this.$route.query.articlePattern
+        }
+      });
+    },
+    reset: function() {
+      this.incomingSearchA = null;
+      this.incomingSearchB = null;
+      this.projectA = null;
+      this.projectB = null;
+      this.projectAQuality = null;
+      this.projectAImportance = null;
+      this.projectBQuality = null;
+      this.projectBImportance = null;
+      this.compareClicked = false;
     }
   }
 };

--- a/wp1-frontend/src/components/ComparePage.vue
+++ b/wp1-frontend/src/components/ComparePage.vue
@@ -15,6 +15,15 @@
         ></Autocomplete>
       </div>
     </div>
+    <div class="row">
+      <div class="col-xl-6">
+        <ArticleTableRatingSelect
+          :projectId="projectIdA"
+          :layout="'alternate'"
+          v-on:rating-select="onProjectARatingSelect($event)"
+        ></ArticleTableRatingSelect>
+      </div>
+    </div>
     <div class="row mt-4">
       <div class="col-xl-6">
         <Autocomplete
@@ -22,6 +31,15 @@
           :hideInstructions="true"
           v-on:select-project="projectB = $event"
         ></Autocomplete>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-xl-6">
+        <ArticleTableRatingSelect
+          :projectId="projectIdB"
+          :layout="'alternate'"
+          v-on:rating-select="onProjectBRatingSelect($event)"
+        ></ArticleTableRatingSelect>
       </div>
     </div>
     <div class="row mt-4">
@@ -37,50 +55,75 @@
         </div>
       </div>
     </div>
-    <div class="row mt-4">
+    <div v-if="projectsSelected" class="row mt-4">
       <div class="col">
-        <div v-if="projectsSelected">
-          The projects are {{ projectA }} and {{ projectB }}.
-        </div>
+        <ArticleTable
+          :hideRatingSelect="true"
+          :projectId="projectIdA"
+          :projectIdB="projectIdB"
+          :importance="projectAImportance"
+          :quality="projectAQuality"
+          :page="$route.query.page"
+          :numRows="$route.query.numRows"
+          :articlePattern="$route.query.articlePattern"
+        ></ArticleTable>
       </div>
     </div>
   </div>
 </template>
 
 <script>
+import ArticleTable from './ArticleTable.vue';
+import ArticleTableRatingSelect from './ArticleTableRatingSelect';
 import Autocomplete from './Autocomplete.vue';
 
 export default {
   name: 'updatepage',
   components: {
+    ArticleTable,
+    ArticleTableRatingSelect,
     Autocomplete
   },
   props: ['incomingSearchA', 'incomingSearchB'],
   data: function() {
     return {
       projectA: null,
-      projectB: null
+      projectB: null,
+      projectAQuality: null,
+      projectAImportance: null,
+      projectBQuality: null,
+      projectBImportance: null
     };
   },
   computed: {
-    currentProjectIdA: function() {
+    projectIdA: function() {
       if (!this.projectA) {
         return null;
       }
-      return this.currentProjectA.replace(/ /g, '_');
+      return this.projectA.replace(/ /g, '_');
     },
-    currentProjectIdB: function() {
+    projectIdB: function() {
       if (!this.projectB) {
         return null;
       }
-      return this.currentProjectB.replace(/ /g, '_');
+      return this.projectB.replace(/ /g, '_');
     },
     projectsSelected: function() {
       return !!this.projectA && !!this.projectB;
     }
   },
   methods: {
-    onCompareClick: async function() {}
+    onCompareClick: async function() {},
+    onProjectARatingSelect: function(event) {
+      window.console.log('a', event);
+      this.projectAQuality = event.quality;
+      this.projectAImportance = event.importance;
+    },
+    onProjectBRatingSelect: function(event) {
+      window.console.log('b', event);
+      this.projectBQuality = event.quality;
+      this.projectBImportance = event.importance;
+    }
   }
 };
 </script>

--- a/wp1-frontend/src/components/ComparePage.vue
+++ b/wp1-frontend/src/components/ComparePage.vue
@@ -55,7 +55,7 @@
         </div>
       </div>
     </div>
-    <div v-if="projectsSelected" class="row mt-4">
+    <div v-if="projectsSelected && compareClicked" class="row mt-4">
       <div class="col">
         <ArticleTable
           :hideRatingSelect="true"
@@ -63,6 +63,8 @@
           :projectIdB="projectIdB"
           :importance="projectAImportance"
           :quality="projectAQuality"
+          :importanceB="projectBImportance"
+          :qualityB="projectBQuality"
           :page="$route.query.page"
           :numRows="$route.query.numRows"
           :articlePattern="$route.query.articlePattern"
@@ -92,7 +94,8 @@ export default {
       projectAQuality: null,
       projectAImportance: null,
       projectBQuality: null,
-      projectBImportance: null
+      projectBImportance: null,
+      compareClicked: false
     };
   },
   computed: {
@@ -113,14 +116,14 @@ export default {
     }
   },
   methods: {
-    onCompareClick: async function() {},
+    onCompareClick: async function() {
+      this.compareClicked = true;
+    },
     onProjectARatingSelect: function(event) {
-      window.console.log('a', event);
       this.projectAQuality = event.quality;
       this.projectAImportance = event.importance;
     },
     onProjectBRatingSelect: function(event) {
-      window.console.log('b', event);
       this.projectBQuality = event.quality;
       this.projectBImportance = event.importance;
     }

--- a/wp1-frontend/src/components/IndexPage.vue
+++ b/wp1-frontend/src/components/IndexPage.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="row">
-    <div class="col-xlg-6">
+    <div class="col-xl-6">
       <Autocomplete
         v-on:select-project="currentProject = $event"
       ></Autocomplete>

--- a/wp1-frontend/src/components/ProjectPage.vue
+++ b/wp1-frontend/src/components/ProjectPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="row">
-      <div class="col-xlg-6">
+      <div class="col-xl-6">
         <Autocomplete
           :incomingSearch="incomingSearch || $route.params.projectName"
           v-on:select-project="currentProject = $event"

--- a/wp1-frontend/src/components/UpdatePage.vue
+++ b/wp1-frontend/src/components/UpdatePage.vue
@@ -1,26 +1,34 @@
 <template>
   <div>
     <div class="row">
-      <div class="col-xlg-6">
+      <div class="col-xl-6">
         <Autocomplete
           :incomingSearch="incomingSearch || $route.params.projectName"
+          :hideInstructions="true"
           v-on:select-project="currentProject = $event"
         ></Autocomplete>
       </div>
     </div>
     <div class="row">
-      <div class="col-xlg-6">
+      <div class="col-xl-4">
         <div v-if="currentProject && !updateTime">
           <label class="mt-2" for="confirm"
             >Proceed with manual update of <b>{{ currentProject }}</b
             >?</label
           >
           <div class="input-group">
-            <button v-on:click="onUpdateClick()" class="btn-primary">
+            <button
+              v-on:click="onUpdateClick()"
+              class="btn-primary form-control"
+            >
               Manual Update
             </button>
           </div>
         </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-xl-6">
         <div v-if="currentProject && updateTime">
           <p>
             Manual update of <b>{{ this.$route.params.projectName }}</b> has

--- a/wp1-frontend/src/main.js
+++ b/wp1-frontend/src/main.js
@@ -6,6 +6,7 @@ import VueRouter from 'vue-router';
 
 import App from './App.vue';
 import ArticlePage from './components/ArticlePage.vue';
+import ComparePage from './components/ComparePage.vue';
 import IndexPage from './components/IndexPage.vue';
 import ProjectPage from './components/ProjectPage.vue';
 import UpdatePage from './components/UpdatePage.vue';
@@ -54,6 +55,29 @@ const routes = [
     meta: {
       title: route =>
         BASE_TITLE + ' - ' + route.params.projectName + ' articles'
+    }
+  },
+  {
+    path: '/compare/',
+    component: ComparePage,
+    meta: {
+      title: () => BASE_TITLE + ' - Comparing projects'
+    }
+  },
+  {
+    path: '/compare/:projectNameA/:projectNameB',
+    component: ComparePage,
+    props: route => ({
+      incomingSearchA: route.params.projectNameA,
+      incomingSearchB: route.params.projectNameB
+    }),
+    meta: {
+      title: route =>
+        BASE_TITLE +
+        ' - Comparing ' +
+        route.params.projectNameA +
+        ' and ' +
+        route.params.projectNameB
     }
   }
 ];

--- a/wp1/logic/rating.py
+++ b/wp1/logic/rating.py
@@ -53,9 +53,9 @@ def _project_rating_query(project_name,
           ' FROM ' + Rating.table_name + ' as rating_a')
 
   if project_b_name is not None:
-    query += (' JOIN ' + Rating.table_name +
-              ' as rating_b ON rating_a.r_article ='
-              ' rating_b.r_article')
+    query += (' JOIN ' + Rating.table_name + ' as rating_b'
+              ' ON rating_a.r_article = rating_b.r_article'
+              ' AND rating_a.r_namespace = rating_b.r_namespace')
 
   if project_b_name is None:
     if importance is None:

--- a/wp1/logic/rating.py
+++ b/wp1/logic/rating.py
@@ -193,17 +193,17 @@ def get_project_rating_by_type(wp10db,
     cursor.execute(query, params)
     if project_b_name is None:
       return [Rating(**db_rating) for db_rating in cursor.fetchall()]
-    else:
-      results = []
-      for res in cursor.fetchall():
-        rating_b = Rating(r_project=res.pop('rating_b.r_project'),
-                          r_article=res.pop('rating_b.r_article'),
-                          r_namespace=res.pop('rating_b.r_namespace'),
-                          r_quality=res.pop('rating_b.r_quality'),
-                          r_importance=res.pop('rating_b.r_importance'))
-        rating_a = Rating(**res)
-        results.append((rating_a, rating_b))
-      return results
+
+    results = []
+    for res in cursor.fetchall():
+      rating_b = Rating(r_project=res.pop('rating_b.r_project'),
+                        r_article=res.pop('rating_b.r_article'),
+                        r_namespace=res.pop('rating_b.r_namespace'),
+                        r_quality=res.pop('rating_b.r_quality'),
+                        r_importance=res.pop('rating_b.r_importance'))
+      rating_a = Rating(**res)
+      results.append((rating_a, rating_b))
+    return results
 
 
 def get_all_ratings_count_for_project(wp10db, project_name):

--- a/wp1/logic/rating.py
+++ b/wp1/logic/rating.py
@@ -27,44 +27,76 @@ def get_project_ratings(wp10db, project_name):
 def _project_rating_query(project_name,
                           quality=None,
                           importance=None,
+                          project_b_name=None,
+                          quality_b=None,
+                          importance_b=None,
                           pattern=None,
                           page=None,
                           count=False,
                           limit=100):
   if count:
-    query = 'SELECT COUNT(*) as count FROM ' + Rating.table_name
+
+    query = 'SELECT COUNT(*) as count FROM ' + Rating.table_name + ' as rating_a'
   else:
-    query = ('SELECT r_project, r_namespace, r_article, r_score, r_quality,'
-             ' r_quality_timestamp, r_importance, r_importance_timestamp'
-             ' FROM ' + Rating.table_name)
+    if project_b_name is None:
+      query = ('SELECT r_project, r_namespace, r_article,'
+               ' r_score, r_quality, r_quality_timestamp,'
+               ' r_importance, r_importance_timestamp'
+               ' FROM ' + Rating.table_name + ' as rating_a')
+    else:
+      query = (
+          'SELECT rating_a.r_project, rating_a.r_namespace, rating_a.r_article,'
+          ' rating_a.r_score, rating_a.r_quality, rating_a.r_quality_timestamp,'
+          ' rating_a.r_importance, rating_a.r_importance_timestamp, '
+          ' rating_b.r_project, rating_b.r_article, rating_b.r_namespace,'
+          ' rating_b.r_quality, rating_b.r_importance'
+          ' FROM ' + Rating.table_name + ' as rating_a')
 
-  if importance is None:
-    query += (' JOIN global_rankings gri ON gri.gr_type = "importance" AND'
-              ' (gri.gr_rating = r_importance OR r_importance = "NotA-Class")')
-  if quality is None:
-    query += (' JOIN global_rankings grq ON grq.gr_type = "quality" AND'
-              ' grq.gr_rating = r_quality')
+  if project_b_name is not None:
+    query += (' JOIN ' + Rating.table_name +
+              ' as rating_b ON rating_a.r_article ='
+              ' rating_b.r_article')
 
-  query += ' WHERE r_project = %(r_project)s'
+  if project_b_name is None:
+    if importance is None:
+      query += (
+          ' JOIN global_rankings gri ON gri.gr_type = "importance" AND'
+          ' (gri.gr_rating = r_importance OR r_importance = "NotA-Class")')
+    if quality is None:
+      query += (' JOIN global_rankings grq ON grq.gr_type = "quality" AND'
+                ' grq.gr_rating = rating_a.r_quality')
+
+  query += ' WHERE rating_a.r_project = %(r_project)s'
+  if project_b_name is not None:
+    query += ' AND rating_b.r_project = %(r_project_b)s'
 
   if pattern is not None:
-    query += ' AND r_article LIKE %(article_pattern_compiled)s'
+    query += ' AND rating_a.r_article LIKE %(article_pattern_compiled)s'
 
   if quality is not None:
     if quality == b'Assessed-Class':
-      print('Assessed-Class triggered')
-      query += ' AND r_quality != "Unassessed-Class"'
+      query += ' AND rating_a.r_quality != "Unassessed-Class"'
     else:
-      query += ' AND r_quality = %(r_quality)s'
+      query += ' AND rating_a.r_quality = %(r_quality)s'
   if importance is not None:
-    query += ' AND r_importance = %(r_importance)s'
+    query += ' AND rating_a.r_importance = %(r_importance)s'
 
-  if quality is None and importance is None:
-    query += ' ORDER BY grq.gr_ranking DESC, gri.gr_ranking DESC'
-  elif quality is None:
-    query += ' ORDER BY grq.gr_ranking DESC'
-  elif importance is None:
-    query += ' ORDER BY gri.gr_ranking DESC'
+  if project_b_name is not None:
+    if quality_b is not None:
+      if quality_b == b'Assessed-Class':
+        query += ' AND rating_b.r_quality != "Unassessed-Class"'
+      else:
+        query += ' AND rating_b.r_quality = %(r_quality_b)s'
+    if importance_b is not None:
+      query += ' AND rating_b.r_importance = %(r_importance_b)s'
+
+  if project_b_name is None:
+    if quality is None and importance is None:
+      query += ' ORDER BY grq.gr_ranking DESC, gri.gr_ranking DESC'
+    elif quality is None:
+      query += ' ORDER BY grq.gr_ranking DESC'
+    elif importance is None:
+      query += ' ORDER BY gri.gr_ranking DESC'
 
   if page is not None:
     page = int(page) - 1
@@ -80,10 +112,16 @@ def get_project_rating_count_by_type(wp10db,
                                      project_name,
                                      quality=None,
                                      importance=None,
+                                     project_b_name=None,
+                                     quality_b=None,
+                                     importance_b=None,
                                      pattern=None):
   query = _project_rating_query(project_name,
                                 quality=quality,
                                 importance=importance,
+                                project_b_name=project_b_name,
+                                quality_b=quality_b,
+                                importance_b=importance_b,
                                 pattern=pattern,
                                 count=True)
 
@@ -92,8 +130,16 @@ def get_project_rating_count_by_type(wp10db,
       'r_quality': quality,
       'r_importance': importance,
   }
+
   if pattern is not None:
     params['article_pattern_compiled'] = '%' + pattern + '%'
+  if project_b_name is not None:
+    params['r_project_b'] = project_b_name
+  if quality_b is not None:
+    params['r_quality_b'] = quality_b
+  if importance_b is not None:
+    params['r_importance_b'] = importance_b
+
   with wp10db.cursor() as cursor:
     cursor.execute(query, params)
     res = cursor.fetchone()
@@ -104,6 +150,9 @@ def get_project_rating_by_type(wp10db,
                                project_name,
                                quality=None,
                                importance=None,
+                               project_b_name=None,
+                               quality_b=None,
+                               importance_b=None,
                                pattern=None,
                                page=None,
                                limit=100):
@@ -119,6 +168,9 @@ def get_project_rating_by_type(wp10db,
   query = _project_rating_query(project_name,
                                 quality=quality,
                                 importance=importance,
+                                project_b_name=project_b_name,
+                                quality_b=quality_b,
+                                importance_b=importance_b,
                                 pattern=pattern,
                                 page=page,
                                 limit=limit)
@@ -127,11 +179,31 @@ def get_project_rating_by_type(wp10db,
       'r_quality': quality,
       'r_importance': importance,
   }
+
   if pattern is not None:
     params['article_pattern_compiled'] = '%' + pattern + '%'
+  if project_b_name is not None:
+    params['r_project_b'] = project_b_name
+  if quality_b is not None:
+    params['r_quality_b'] = quality_b
+  if importance_b is not None:
+    params['r_importance_b'] = importance_b
+
   with wp10db.cursor() as cursor:
     cursor.execute(query, params)
-    return [Rating(**db_rating) for db_rating in cursor.fetchall()]
+    if project_b_name is None:
+      return [Rating(**db_rating) for db_rating in cursor.fetchall()]
+    else:
+      results = []
+      for res in cursor.fetchall():
+        rating_b = Rating(r_project=res.pop('rating_b.r_project'),
+                          r_article=res.pop('rating_b.r_article'),
+                          r_namespace=res.pop('rating_b.r_namespace'),
+                          r_quality=res.pop('rating_b.r_quality'),
+                          r_importance=res.pop('rating_b.r_importance'))
+        rating_a = Rating(**res)
+        results.append((rating_a, rating_b))
+      return results
 
 
 def get_all_ratings_count_for_project(wp10db, project_name):

--- a/wp1/logic/rating_test.py
+++ b/wp1/logic/rating_test.py
@@ -78,8 +78,18 @@ class GetProjectRatingByTypeTest(BaseWpOneDbTest):
               'r_importance': importance,
               'r_importance_timestamp': '20191226T00:00:00',
           })
+          ratings.append({
+              'r_project': 'Project 1',
+              'r_namespace': 0,
+              'r_article': '%s_%s_%s' % (quality, importance, i),
+              'r_score': 0,
+              'r_quality': quality,
+              'r_quality_timestamp': '20191225T00:00:00',
+              'r_importance': importance,
+              'r_importance_timestamp': '20191226T00:00:00',
+          })
 
-    for i in range(1, 10):
+    for i in range(2, 10):
       ratings.append({
           'r_project': 'Project %s' % i,
           'r_namespace': 0,
@@ -241,3 +251,162 @@ class GetProjectRatingByTypeTest(BaseWpOneDbTest):
                                                       limit=500)
 
     self.assertEqual(0, len(ratings))
+
+  def test_with_project_b_no_quality_importance(self):
+    self._add_ratings()
+    ratings = logic_rating.get_project_rating_by_type(
+        self.wp10db, b'Project 0', project_b_name=b'Project 1', limit=10)
+    self.assertEqual(10, len(ratings))
+    for r in ratings:
+      self.assertEqual(r[0].r_article, r[1].r_article)
+      self.assertEqual(b'Project 0', r[0].r_project)
+      self.assertEqual(b'Project 1', r[1].r_project)
+
+  def test_with_project_b_left_quality_only(self):
+    self._add_ratings()
+    ratings = logic_rating.get_project_rating_by_type(
+        self.wp10db,
+        b'Project 0',
+        quality='A-Class',
+        project_b_name=b'Project 1',
+        limit=10)
+    self.assertEqual(10, len(ratings))
+    for r in ratings:
+      self.assertEqual(r[0].r_article, r[1].r_article)
+      self.assertEqual(b'A-Class', r[0].r_quality)
+      self.assertEqual(b'Project 0', r[0].r_project)
+      self.assertEqual(b'Project 1', r[1].r_project)
+
+  def test_with_project_b_right_quality_only(self):
+    self._add_ratings()
+    ratings = logic_rating.get_project_rating_by_type(
+        self.wp10db,
+        b'Project 0',
+        project_b_name=b'Project 1',
+        quality_b='A-Class',
+        limit=10)
+    self.assertEqual(10, len(ratings))
+    for r in ratings:
+      self.assertEqual(r[0].r_article, r[1].r_article)
+      self.assertEqual(b'A-Class', r[1].r_quality)
+      self.assertEqual(b'Project 0', r[0].r_project)
+      self.assertEqual(b'Project 1', r[1].r_project)
+
+  def test_with_project_b_quality(self):
+    self._add_ratings()
+    ratings = logic_rating.get_project_rating_by_type(
+        self.wp10db,
+        b'Project 0',
+        quality='A-Class',
+        project_b_name=b'Project 1',
+        quality_b='A-Class',
+        limit=10)
+    self.assertEqual(10, len(ratings))
+    for r in ratings:
+      self.assertEqual(r[0].r_article, r[1].r_article)
+      self.assertEqual(b'A-Class', r[1].r_quality)
+      self.assertEqual(b'A-Class', r[0].r_quality)
+      self.assertEqual(b'Project 0', r[0].r_project)
+      self.assertEqual(b'Project 1', r[1].r_project)
+
+  def test_with_project_b_left_importance_only(self):
+    self._add_ratings()
+    ratings = logic_rating.get_project_rating_by_type(
+        self.wp10db,
+        b'Project 0',
+        importance='High-Class',
+        project_b_name=b'Project 1',
+        limit=10)
+    self.assertEqual(10, len(ratings))
+    for r in ratings:
+      self.assertEqual(r[0].r_article, r[1].r_article)
+      self.assertEqual(b'High-Class', r[0].r_importance)
+      self.assertEqual(b'Project 0', r[0].r_project)
+      self.assertEqual(b'Project 1', r[1].r_project)
+
+  def test_with_project_b_right_importance_only(self):
+    self._add_ratings()
+    ratings = logic_rating.get_project_rating_by_type(
+        self.wp10db,
+        b'Project 0',
+        project_b_name=b'Project 1',
+        importance_b='High-Class',
+        limit=10)
+    self.assertEqual(10, len(ratings))
+    for r in ratings:
+      self.assertEqual(r[0].r_article, r[1].r_article)
+      self.assertEqual(b'High-Class', r[1].r_importance)
+      self.assertEqual(b'Project 0', r[0].r_project)
+      self.assertEqual(b'Project 1', r[1].r_project)
+
+  def test_with_project_b_importance(self):
+    self._add_ratings()
+    ratings = logic_rating.get_project_rating_by_type(
+        self.wp10db,
+        b'Project 0',
+        importance='High-Class',
+        project_b_name=b'Project 1',
+        importance_b='High-Class',
+        limit=10)
+    self.assertEqual(10, len(ratings))
+    for r in ratings:
+      self.assertEqual(r[0].r_article, r[1].r_article)
+      self.assertEqual(b'High-Class', r[1].r_importance)
+      self.assertEqual(b'High-Class', r[0].r_importance)
+      self.assertEqual(b'Project 0', r[0].r_project)
+      self.assertEqual(b'Project 1', r[1].r_project)
+
+  def test_with_project_b_left_both(self):
+    self._add_ratings()
+    ratings = logic_rating.get_project_rating_by_type(
+        self.wp10db,
+        b'Project 0',
+        quality='A-Class',
+        importance='High-Class',
+        project_b_name=b'Project 1',
+        limit=10)
+    self.assertEqual(10, len(ratings))
+    for r in ratings:
+      self.assertEqual(r[0].r_article, r[1].r_article)
+      self.assertEqual(b'A-Class', r[0].r_quality)
+      self.assertEqual(b'High-Class', r[0].r_importance)
+      self.assertEqual(b'Project 0', r[0].r_project)
+      self.assertEqual(b'Project 1', r[1].r_project)
+
+  def test_with_project_b_right_both(self):
+    self._add_ratings()
+    ratings = logic_rating.get_project_rating_by_type(
+        self.wp10db,
+        b'Project 0',
+        project_b_name=b'Project 1',
+        quality_b='A-Class',
+        importance_b='High-Class',
+        limit=10)
+    self.assertEqual(10, len(ratings))
+    for r in ratings:
+      self.assertEqual(r[0].r_article, r[1].r_article)
+      self.assertEqual(b'High-Class', r[1].r_importance)
+      self.assertEqual(b'A-Class', r[1].r_quality)
+      self.assertEqual(b'Project 0', r[0].r_project)
+      self.assertEqual(b'Project 1', r[1].r_project)
+
+  def test_with_project_b_both(self):
+    self._add_ratings()
+    ratings = logic_rating.get_project_rating_by_type(
+        self.wp10db,
+        b'Project 0',
+        quality='A-Class',
+        importance='High-Class',
+        project_b_name=b'Project 1',
+        quality_b='A-Class',
+        importance_b='High-Class',
+        limit=10)
+    self.assertEqual(10, len(ratings))
+    for r in ratings:
+      self.assertEqual(r[0].r_article, r[1].r_article)
+      self.assertEqual(b'High-Class', r[1].r_importance)
+      self.assertEqual(b'High-Class', r[0].r_importance)
+      self.assertEqual(b'A-Class', r[1].r_quality)
+      self.assertEqual(b'A-Class', r[0].r_quality)
+      self.assertEqual(b'Project 0', r[0].r_project)
+      self.assertEqual(b'Project 1', r[1].r_project)

--- a/wp1/models/wp10/rating.py
+++ b/wp1/models/wp10/rating.py
@@ -91,9 +91,11 @@ class Rating:
         'quality':
             self.r_quality.decode('utf-8'),
         'quality_updated':
-            self.r_quality_timestamp.decode('utf-8'),
+            self.r_quality_timestamp.decode('utf-8')
+            if self.r_quality_timestamp else None,
         'importance':
             self.r_importance.decode('utf-8'),
         'importance_updated':
-            self.r_importance_timestamp.decode('utf-8'),
+            self.r_importance_timestamp.decode('utf-8')
+            if self.r_importance_timestamp else None,
     }

--- a/wp1/web/projects_test.py
+++ b/wp1/web/projects_test.py
@@ -112,6 +112,16 @@ class ProjectTest(BaseWebTestcase):
               'r_importance': importance,
               'r_importance_timestamp': '20191226T00:00:00',
           })
+          ratings.append({
+              'r_project': 'Project 1',
+              'r_namespace': 0,
+              'r_article': '%s_%s_%s' % (quality, importance, i),
+              'r_score': 0,
+              'r_quality': quality,
+              'r_quality_timestamp': '20191225T00:00:00',
+              'r_importance': importance,
+              'r_importance_timestamp': '20191226T00:00:00',
+          })
 
     with self.wp10db.cursor() as cursor:
       cursor.executemany(
@@ -256,6 +266,56 @@ class ProjectTest(BaseWebTestcase):
     with self.override_db(self.app), self.app.test_client() as client:
       rv = client.get('/v1/projects/Project 0/articles?page=-5')
       self.assertEqual('400 BAD REQUEST', rv.status)
+
+  def test_articles_404_project_b(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get('/v1/projects/Project 0/articles?projectB=Foo')
+      self.assertEqual('404 NOT FOUND', rv.status)
+
+  def test_articles_project_b(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get('/v1/projects/Project 0/articles?projectB=Project 1')
+      self.assertEqual('200 OK', rv.status)
+
+  def test_articles_project_b_quality_left(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get(
+          '/v1/projects/Project 0/articles?quality=A-Class&projectB=Project 1')
+      self.assertEqual('200 OK', rv.status)
+
+  def test_articles_project_b_quality_right(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get(
+          '/v1/projects/Project 0/articles?qualityB=A-Class&projectB=Project 1')
+      self.assertEqual('200 OK', rv.status)
+
+  def test_articles_project_b_quality_both(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get(
+          '/v1/projects/Project 0/articles?quality=A-Class&qualityB=A-Class&projectB=Project 1'
+      )
+      self.assertEqual('200 OK', rv.status)
+
+  def test_articles_project_b_importance_left(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get(
+          '/v1/projects/Project 0/articles?importance=A-Class&projectB=Project 1'
+      )
+      self.assertEqual('200 OK', rv.status)
+
+  def test_articles_project_b_importance_right(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get(
+          '/v1/projects/Project 0/articles?importanceB=A-Class&projectB=Project 1'
+      )
+      self.assertEqual('200 OK', rv.status)
+
+  def test_articles_project_b_importance_both(self):
+    with self.override_db(self.app), self.app.test_client() as client:
+      rv = client.get(
+          '/v1/projects/Project 0/articles?importance=A-Class&importanceB=A-Class&projectB=Project 1'
+      )
+      self.assertEqual('200 OK', rv.status)
 
   @patch('wp1.queues.ENV', Environment.PRODUCTION)
   @patch('wp1.queues.utcnow', return_value=datetime(2018, 12, 25, 5, 55, 55))


### PR DESCRIPTION
Fixes #237.

An implementation of a separate page for comparing articles across projects, at the /compare URL. Each project is selected from a separate autocomplete drop down. An ArticleTable is displayed once the project and quality/importance selections has been made. Pagination, custom pagination, and article name filtering all work for the returned ArticleTable.

Additionally, changes to the settings of the page are reflected in the URL, so pages with certain listings can be bookmarked and navigated through.