### PR TITLE
Update new tool welcome message

### DIFF
--- a/wp1-frontend/src/App.vue
+++ b/wp1-frontend/src/App.vue
@@ -1,10 +1,8 @@
 <template>
   <div>
     <div class="alert alert-info my-0" role="alert">
-      Welcome to the latest version of the WP 1.0 tool! If you need a feature
-      that is only in the old tool, it's still running
-      <a href="https://tools.wmflabs.org/enwp10/cgi-bin/pindex.fcgi">here</a>.
-      Please provide all feedback and feature requests for this tool on
+      Welcome to the latest version of the WP 1.0 tool! Please provide all
+      feedback and feature requests for this tool on
       <a
         href="https://en.wikipedia.org/wiki/Wikipedia_talk:Version_1.0_Editorial_Team/Index"
         >English Wikipedia</a


### PR DESCRIPTION
Remove line about old tool being available. It has been shut down and now redirects only to the new tool.