### PR TITLE
Make the cron jobs all executable and update log location

### DIFF
--- a/docker/workers/Dockerfile
+++ b/docker/workers/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 RUN pip3 install -r app/requirements.txt
 
+RUN chmod -R u+x /usr/src/app/cron/
+
 # Schedule tasks through cron
 RUN echo "0 0 * * * root /usr/src/app/cron/enqueue-all.sh > /var/log/wp1bot/enqueue-all.cron.log 2>&1" > /etc/cron.d/enqueue-all
 RUN echo "0 4 * * * root /usr/src/app/cron/update-global-articles.sh > /var/log/wp1bot/update-global-articles.cron.log 2>&1" > /etc/cron.d/update-global-articles

--- a/docker/workers/Dockerfile
+++ b/docker/workers/Dockerfile
@@ -13,9 +13,9 @@ RUN apt-get update && \
 RUN pip3 install -r app/requirements.txt
 
 # Schedule tasks through cron
-RUN echo "0 0 * * * root /usr/src/app/cron/enqueue-all.sh > /var/log/enqueue-all.cron.log 2>&1" > /etc/cron.d/enqueue-all
-RUN echo "0 4 * * * root /usr/src/app/cron/update-global-articles.sh > /var/log/update-global-articles.cron.log 2>&1" > /etc/cron.d/update-global-articles
-RUN echo "0 5 * * * root /usr/src/app/cron/enqueue-global.sh > /var/log/enqueue-global.cron.log 2>&1" > /etc/cron.d/enqueue-global
+RUN echo "0 0 * * * root /usr/src/app/cron/enqueue-all.sh > /var/log/wp1bot/enqueue-all.cron.log 2>&1" > /etc/cron.d/enqueue-all
+RUN echo "0 4 * * * root /usr/src/app/cron/update-global-articles.sh > /var/log/wp1bot/update-global-articles.cron.log 2>&1" > /etc/cron.d/update-global-articles
+RUN echo "0 5 * * * root /usr/src/app/cron/enqueue-global.sh > /var/log/wp1bot/enqueue-global.cron.log 2>&1" > /etc/cron.d/enqueue-global
 
 # Start
 CMD cron && supervisord -c /usr/src/app/supervisord.conf -n


### PR DESCRIPTION
The `update-global-articles.sh` script somehow became non-executable in the Docker container, which meant it couldn't be run daily, which was causing #249 (since the article counts weren't being updated, the global table was identical).

Also, write the log files for the cron jobs to the proper wp1bot directory so they can be read from the host.

Fixes #249 
Fixes #250 