### PR TITLE
added absolute position to autocomplete search box

### DIFF
--- a/wp1-frontend/src/components/Autocomplete.vue
+++ b/wp1-frontend/src/components/Autocomplete.vue
@@ -168,6 +168,10 @@ export default {
   overflow: auto;
   padding: 0;
   text-align: left;
+  z-index: 1;
+  background: white;
+  position: absolute;
+  width: 95%;
 }
 
 .result {


### PR DESCRIPTION
@audiodude The autocomplete search box now overlaps the page content rather than pushing it down.
This resolves #281 