### PR TITLE
Replace Travis CI with GitHub Actions: Step 1 basic Python

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,6 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: Python CI
 
 on:
@@ -10,26 +7,34 @@ on:
     branches: [$default-branch]
 
 jobs:
-  build:
+  nose:
     runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+        ports:
+          - 3306:3306
+        options: --disable_bind_address --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7.4
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.4
+          python-version: 3.7
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8
           pip install -r requirements.txt
-      - name: Lint with flake8
+
+      - name: Verify MySQL connection from host
         run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          sudo apt-get update && sudo apt-get install -y mysql-client
+          mysql --host 127.0.0.1 --port 3306 -uroot -e "SHOW DATABASES"
+
       - name: Test with nose
         run: |
           nosetests --with-coverage

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,35 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python CI
+
+on:
+  push:
+    branches: [$default-branch]
+  pull_request:
+    branches: [$default-branch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7.4
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7.4
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+          pip install -r requirements.txt
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Test with nose
+        run: |
+          nosetests --with-coverage

--- a/wp1/logic/page.py
+++ b/wp1/logic/page.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 import logging
 
+import requests
+
 from wp1.constants import TS_FORMAT, GLOBAL_TIMESTAMP
 from wp1.models.wiki.page import Page
 from wp1.models.wp10.log import Log


### PR DESCRIPTION
This is a PR to replace travis CI with GitHub Actions. I am proceeding in stages, first trying to get a basic Python build and test workflow working, then moving on to adding Codecov and Codefactor, and finally getting the Cypress test environment configured.