### PR TITLE
Add Redis to Cypress CI job

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -62,6 +62,12 @@ jobs:
           - 6300:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
 
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
We were already using a Redis service in the `python-nose` job, but it's also required in the `frontend-cypress` job.