### PR TITLE
Development versions of manual update API server code

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,35 @@ If you wish to connect to a wiki replica database on toolforge, you will need
 to fill out your credentials in WIKIDB section. This is not required for
 developing the frontend.
 
+## Development overlay
+
+The API server has a built-in development overlay, currently used for manual
+update endpoints. What this means is that the endpoints defined in
+`wp1.web.dev.projects` are used with priority, instead of the production endpoints,
+**only if the credentials.py ENV == Environment.DEVELOPMENT**. This is to allow
+for easier manual and CI testing of the manual update page.
+
+If you wish to test the manual update job with a real Wikipedia replica database
+and RQ jobs, you will have to disable this overlay. The easiest way would be to
+change the following line in wp1.web.app:
+
+```
+  if ENV == environment.Environment.DEVELOPMENT:
+    # In development, override some project endpoints, mostly manual
+    # update, to provide an easier env for developing the frontend.
+    print('DEVELOPMENT: overlaying dev_projects blueprint. '
+          'Some endpoints will be replaced with development versions')
+    app.register_blueprint(dev_projects, url_prefix='/v1/projects')
+```
+
+to something like:
+
+```
+  if false:  # false while manually testing
+    # In development, override some project endpoints, mostly manual
+    ...
+```
+
 # Updating production
 
 - Log in to the box that contains the production docker images. It is

--- a/wp1/credentials.py.e2e
+++ b/wp1/credentials.py.e2e
@@ -20,6 +20,12 @@ CREDENTIALS = {
 
         'REDIS': {},
 
-        'API': {}
+        'API': {},
+
+        'OVERLAY': {
+            'update_wait_time_seconds': 40,
+            'job_elapsed_time_seconds': 10,
+            'basic_income_total_time_seconds': 60,
+        }
     },
 }

--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -71,7 +71,7 @@ CREDENTIALS = {
     #     'user': 'someuser', # EDIT this line for production.
     #     'password': 'somepass', # EDIT this line for production.
     #     'host': 'tools.db.svc.eqiad.wmflabs',
-    #     'db': 's51114_enwp10',
+    #     'db': 's51114__enwp10',
     #   },
 
     #   # Credentials for connecting to Redis. In production, this is part of

--- a/wp1/web/app.py
+++ b/wp1/web/app.py
@@ -13,7 +13,7 @@ from wp1 import environment
 from wp1.web.db import get_db, has_db
 from wp1.web.articles import articles
 from wp1.web.projects import projects
-from wp1.web.dev.projects import projects as dev_projects
+from wp1.web.dev.projects import dev_projects
 
 try:
   # The credentials module isn't checked in and may be missing

--- a/wp1/web/dev/projects.py
+++ b/wp1/web/dev/projects.py
@@ -1,3 +1,13 @@
+'''Development overrides for the /v1/projects endpoints.
+
+The functions provided in this file are API compatible with the normal
+path as far as the frontend is concerned. However this blueprint has the following features:
+
+- The "lockout" time between updates is 5 minutes instead of 1 hour.
+- All updates take 60 seconds, with the progress being 1/60, 2/60 etc as the seconds pass.
+- If the update is for the project 'Water', it will fail after 10 seconds.
+'''
+
 from datetime import datetime, timedelta
 
 import flask

--- a/wp1/web/dev/projects.py
+++ b/wp1/web/dev/projects.py
@@ -70,7 +70,7 @@ def get_project_progress(redis, project_name):
   dt = datetime.strptime(ts, '%Y-%m-%d %H:%M:%S UTC')
   progress = _progress_secs(dt)
 
-  if project_name == b'Water' and progress > 10:
+  if project_name == b'Water' and progress >= 10:
     return 10, 60
   return progress, 60
 
@@ -83,11 +83,16 @@ def get_project_queue_status(redis, project_name):
   if progress < 5:
     return {'status': 'queued'}
 
-  if progress > 10 and project_name == b'Water':
+  if progress >= 10 and project_name == b'Water':
     return {'status': 'failed'}
 
   if progress > 50:
-    return {'status': 'finished', 'ended_at': utcnow()}
+    ts = next_update_time(redis, project_name)
+    if ts is None:
+      end = utcnow()
+
+    dt = datetime.strptime(ts, '%Y-%m-%d %H:%M:%S UTC')
+    return {'status': 'finished', 'ended_at': dt - timedelta(minutes=4)}
 
   return {'status': 'started'}
 

--- a/wp1/web/dev/projects.py
+++ b/wp1/web/dev/projects.py
@@ -86,7 +86,7 @@ def get_project_queue_status(redis, project_name):
     return {'status': 'failed'}
 
   if progress > 50:
-    return {'status': 'finished', 'ended_at': datetime.now()}
+    return {'status': 'finished', 'ended_at': utcnow()}
 
   return {'status': 'started'}
 

--- a/wp1/web/dev/projects.py
+++ b/wp1/web/dev/projects.py
@@ -80,15 +80,15 @@ def get_project_queue_status(redis, project_name):
     return None
 
   if progress < 5:
-    return 'queued'
+    return {'status': 'queued'}
 
   if progress > 10 and project_name == b'Water':
-    return 'failed'
+    return {'status': 'failed'}
 
   if progress > 50:
-    return 'finished'
+    return {'status': 'finished'}
 
-  return 'started'
+  return {'status': 'started'}
 
 
 @dev_projects.route('/<project_name>/update', methods=['POST'])

--- a/wp1/web/dev/projects.py
+++ b/wp1/web/dev/projects.py
@@ -39,8 +39,9 @@ def _project_progress_key(project_name):
 
 def mark_project_manual_update_time(redis, project_name):
   key = _manual_key(project_name)
-  ts = (utcnow() +
-        timedelta(minutes=UPDATE_DURATION_MINS)).strftime('%Y-%m-%d %H:%M UTC')
+  ts = (
+      utcnow() +
+      timedelta(minutes=UPDATE_DURATION_MINS)).strftime('%Y-%m-%d %H:%M:%S UTC')
   redis.setex(key, timedelta(minutes=UPDATE_DURATION_MINS), value=ts)
   return ts
 
@@ -66,7 +67,7 @@ def get_project_progress(redis, project_name):
   if ts is None:
     return None, None
 
-  dt = datetime.strptime(ts, '%Y-%m-%d %H:%M UTC')
+  dt = datetime.strptime(ts, '%Y-%m-%d %H:%M:%S UTC')
   progress = _progress_secs(dt)
 
   if project_name == b'Water' and progress > 10:

--- a/wp1/web/dev/projects.py
+++ b/wp1/web/dev/projects.py
@@ -1,8 +1,117 @@
+from datetime import datetime, timedelta
+
 import flask
 
-projects = flask.Blueprint('dev_projects', __name__)
+from wp1.timestamp import utcnow
+from wp1.web.redis import get_redis
+
+dev_projects = flask.Blueprint('dev_projects', __name__)
+
+UPDATE_DURATION_MINS = 5
 
 
-@projects.route('/count')
-def count():
-  return flask.jsonify({'count': 42})
+def clear_project_progress(redis, project_name):
+  key = _project_progress_key(project_name)
+  redis.delete(key)
+
+
+def enqueue_single_project(redis, project_name):
+  clear_project_progress(redis, project_name)
+
+
+def _manual_key(project_name):
+  return b'DEV_manual_key:%s' % project_name
+
+
+def _project_progress_key(project_name):
+  return b'DEV_progress:%s' % project_name
+
+
+def mark_project_manual_update_time(redis, project_name):
+  key = _manual_key(project_name)
+  ts = (utcnow() +
+        timedelta(minutes=UPDATE_DURATION_MINS)).strftime('%Y-%m-%d %H:%M UTC')
+  redis.setex(key, timedelta(minutes=UPDATE_DURATION_MINS), value=ts)
+  return ts
+
+
+def next_update_time(redis, project_name):
+  key = _manual_key(project_name)
+  ts = redis.get(key)
+  if ts is not None:
+    ts = ts.decode('utf-8')
+  return ts
+
+
+def _progress_secs(dt):
+  # The progress is the number of seconds that have passed in the first minute of update time
+  secs = (dt - timedelta(minutes=UPDATE_DURATION_MINS - 1)) - utcnow()
+  if secs.seconds > 60 or secs.seconds < 0:
+    return 60
+  return 60 - secs.seconds
+
+
+def get_project_progress(redis, project_name):
+  ts = next_update_time(redis, project_name)
+  if ts is None:
+    return None, None
+
+  dt = datetime.strptime(ts, '%Y-%m-%d %H:%M UTC')
+  progress = _progress_secs(dt)
+
+  if project_name == b'Water' and progress > 10:
+    return 10, 60
+  return progress, 60
+
+
+def get_project_queue_status(redis, project_name):
+  progress, work = get_project_progress(redis, project_name)
+  if not progress:
+    return None
+  elif progress < 5:
+    return 'queued'
+  elif progress > 10 and project_name == b'Water':
+    return 'failed'
+  if progress > 50:
+    return 'finished'
+
+  return 'started'
+
+
+@dev_projects.route('/<project_name>/update', methods=['POST'])
+def update(project_name):
+  project_name_bytes = project_name.encode('utf-8')
+  redis = get_redis()
+
+  update_time = next_update_time(redis, project_name_bytes)
+  if update_time is not None:
+    return flask.jsonify({'next_update_time': update_time}), 400
+
+  enqueue_single_project(redis, project_name_bytes)
+  next_time = mark_project_manual_update_time(redis, project_name_bytes)
+  return flask.jsonify({'next_update_time': next_time})
+
+
+@dev_projects.route('/<project_name>/update/time')
+def update_time(project_name):
+  project_name_bytes = project_name.encode('utf-8')
+  redis = get_redis()
+
+  update_time = next_update_time(redis, project_name_bytes)
+  return flask.jsonify({'next_update_time': update_time}), 200
+
+
+@dev_projects.route('/<project_name>/update/progress')
+def update_progress(project_name):
+  project_name_bytes = project_name.encode('utf-8')
+  redis = get_redis()
+
+  progress, work = get_project_progress(redis, project_name_bytes)
+  queue_status = get_project_queue_status(redis, project_name_bytes)
+
+  if progress is None or work is None:
+    job = None
+  else:
+    job = {'progress': progress, 'total': work}
+
+  return flask.jsonify({'queue': queue_status, 'job': job})

--- a/wp1/web/dev/projects.py
+++ b/wp1/web/dev/projects.py
@@ -1,0 +1,8 @@
+import flask
+
+projects = flask.Blueprint('dev_projects', __name__)
+
+
+@projects.route('/count')
+def count():
+  return flask.jsonify({'count': 42})

--- a/wp1/web/dev/projects.py
+++ b/wp1/web/dev/projects.py
@@ -16,8 +16,8 @@ from wp1.environment import Environment
 from wp1.timestamp import utcnow
 from wp1.web.redis import get_redis
 
-UPDATE_DURATION_SECS = 5 * 60
-ELAPSED_TIME_SECS = 60
+UPDATE_DURATION_SECS = 5 * 30
+ELAPSED_TIME_SECS = 30
 BI_DURATION_SECS = UPDATE_DURATION_SECS + ELAPSED_TIME_SECS // 2
 
 try:
@@ -30,7 +30,6 @@ try:
   BI_DURATION_SECS = overlay_settings.get('basic_income_total_time_seconds',
                                           BI_DURATION_SECS)
 except (ImportError, KeyError):
-  print(CREDENTIALS)
   # The default values were already set before the attempted import so nothing to do
   pass
 

--- a/wp1/web/dev/projects.py
+++ b/wp1/web/dev/projects.py
@@ -78,10 +78,13 @@ def get_project_queue_status(redis, project_name):
   progress, work = get_project_progress(redis, project_name)
   if not progress:
     return None
-  elif progress < 5:
+
+  if progress < 5:
     return 'queued'
-  elif progress > 10 and project_name == b'Water':
+
+  if progress > 10 and project_name == b'Water':
     return 'failed'
+
   if progress > 50:
     return 'finished'
 

--- a/wp1/web/dev/projects.py
+++ b/wp1/web/dev/projects.py
@@ -76,9 +76,9 @@ def _progress_secs(dt, project_name):
     secs = (dt + timedelta(minutes=2)) - utcnow()
     bi = BI_DURATION_SECS - secs.seconds
     return bi if bi > 0 else BI_DURATION_SECS
-  else:
-    secs = (dt - timedelta(seconds=UPDATE_DURATION_SECS -
-                           ELAPSED_TIME_SECS)) - utcnow()
+
+  secs = (dt - timedelta(seconds=UPDATE_DURATION_SECS -
+                         ELAPSED_TIME_SECS)) - utcnow()
   if project_name == b'Aesthetics' and secs.seconds >= ELAPSED_TIME_SECS:
     if secs.seconds >= ELAPSED_TIME_SECS * 2 or secs.seconds < 0:
       return ELAPSED_TIME_SECS * 2

--- a/wp1/web/dev/projects.py
+++ b/wp1/web/dev/projects.py
@@ -86,7 +86,7 @@ def get_project_queue_status(redis, project_name):
     return {'status': 'failed'}
 
   if progress > 50:
-    return {'status': 'finished'}
+    return {'status': 'finished', 'ended_at': datetime.now()}
 
   return {'status': 'started'}
 


### PR DESCRIPTION
This PR introduces a `dev_projects` blueprint. If the code is running where ENV == Environment.DEVELOPMENT (as is the case in the example credentials, and is NOT the case in production), the Flask application setup will include dev_projects first, and then the regular projects blueprint.

The effect of this is that endpoints defined in `dev_projects` are used instead of/before the regular ones. This allows us to mock out the manual update process in development, which is what it is immediately used for.

As provided in this PR, the manual update is API compatible with the normal path as far as the frontend is concerned. However it has the following features:

- The "lockout" time between updates is 5 minutes instead of 1 hour.
- All updates take 60 seconds, with the progress being 1/60, 2/60 etc as the seconds pass.
- If the update is for the project 'Water', it will fail after 10 seconds.

Future work would be to make the update duration and wait time configurable. Once that is done, this could be used in CI  to test the manual update page.