### PR TITLE
Use Git LFS to store dev database dump

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -8,7 +8,7 @@ services:
     restart: always
 
   dev-database:
-    image: openzim/wp1-dev-database
+    build: docker/dev-db/
     container_name: wp1bot-db-dev
     ports:
       - '6300:3306'

--- a/docker/dev-db/.gitattributes
+++ b/docker/dev-db/.gitattributes
@@ -1,0 +1,1 @@
+*.dump.sql filter=lfs diff=lfs merge=lfs -text

--- a/docker/dev-db/Dockerfile
+++ b/docker/dev-db/Dockerfile
@@ -1,4 +1,4 @@
 FROM mariadb:10.1
 
 ENV MYSQL_ROOT_PASSWORD wikipedia
-COPY enwp10_dev.sample.sql /docker-entrypoint-initdb.d
+COPY enwp10_dev.dump.sql /docker-entrypoint-initdb.d

--- a/docker/dev-db/Dockerfile
+++ b/docker/dev-db/Dockerfile
@@ -1,0 +1,4 @@
+FROM mariadb:10.1
+
+ENV MYSQL_ROOT_PASSWORD wikipedia
+COPY enwp10_dev.sample.sql /docker-entrypoint-initdb.d

--- a/docker/dev-db/enwp10_dev.dump.sql
+++ b/docker/dev-db/enwp10_dev.dump.sql
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd230cc19543acbd168ba40d87b6c471b98a8c9b30a8562c87d485b479063aec
+size 31073684


### PR DESCRIPTION
In this PR, we store the dev database locally instead of on Docker Hub. This will allow us better control of the versioning of the file, specifically with regards to migrations (see #341).

Fixes #278.

