### PR TITLE
User login with OAuth via mwoauth library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ croniter==0.3.30
 distlib==0.3.1
 fakeredis==1.4.1
 filelock==3.0.12
+Flask-Session==0.3.2
 Flask==1.1.1
 Flask-Cors==3.0.9
 Flask-gzip==0.2
@@ -24,6 +25,7 @@ Jinja2==2.11.3
 MarkupSafe==1.1.1
 meld3==1.0.2
 more-itertools==7.2.0
+mwoauth==0.3.7
 mwclient==0.9.3
 mwparserfromhell==0.5.2
 nodeenv==1.3.3

--- a/wp1-frontend/cypress/integration/article_page.spec.js
+++ b/wp1-frontend/cypress/integration/article_page.spec.js
@@ -12,9 +12,7 @@ describe('the article page', () => {
     cy.get('input')
       .eq(2)
       .type('Predator');
-    cy.get('button')
-      .eq(3)
-      .click();
+    cy.get('#updateName').click();
 
     // Don't continue until the table has been updated.
     cy.wait('@predatorArticles');
@@ -68,9 +66,7 @@ describe('the article page', () => {
         .clear()
         .type('2');
 
-      cy.get('button')
-        .eq(1)
-        .click();
+      cy.get('#updatePagination').click();
 
       cy.wait('@Pagination');
       cy.get('tr')
@@ -104,9 +100,7 @@ describe('the article page', () => {
         .eq(1)
         .select('Top');
 
-      cy.get('button')
-        .eq(2)
-        .click();
+      cy.get('#updateRating').click();
 
       cy.wait('@TopBArticles');
 

--- a/wp1-frontend/src/App.vue
+++ b/wp1-frontend/src/App.vue
@@ -56,6 +56,15 @@
             >
           </li>
         </ul>
+        <div>
+          <div v-if="this.token">
+            <button @click="logout">Logout</button>
+            <span>Username</span>
+          </div>
+          <a v-else href="http://127.0.0.1:5000/v1/oauth/initiate"
+            ><button>Login</button></a
+          >
+        </div>
       </div>
     </nav>
     <div id="app" class="container">
@@ -66,7 +75,38 @@
 
 <script>
 export default {
-  name: 'app'
+  name: 'app',
+  data: function() {
+    return {
+      token: null
+    };
+  },
+  methods: {
+    logout: async function() {
+      localStorage.removeItem('token');
+      window.location.href = 'http://localhost:3000/#/';
+      await fetch(`${process.env.VUE_APP_API_URL}/oauth/logout`, {
+        method: 'POST',
+        body: JSON.stringify(this.token)
+      });
+      this.token = null;
+      localStorage.removeItem('token', this.token);
+    }
+  },
+  created: async function() {
+    if (!window.location.hash.split('?')[1]) {
+      return;
+    }
+    this.token = window.location.hash.split('?')[1];
+    console.log(this.token);
+    const response = await fetch(`${process.env.VUE_APP_API_URL}/oauth/token`, {
+      credentials: 'include',
+      method: 'GET',
+      body: JSON.stringify(this.token)
+    });
+    this.token = await response.json();
+    localStorage.setItem('token', this.token);
+  }
 };
 </script>
 

--- a/wp1-frontend/src/App.vue
+++ b/wp1-frontend/src/App.vue
@@ -59,9 +59,10 @@
         <div>
           <div v-if="this.username">
             <button @click="logout">Logout</button>
+            <span style="font-size:20px"> | </span>
             <span> {{ this.username }} </span>
           </div>
-          <a v-else @click="login"><button>Login</button> </a>
+          <a v-else :href="this.loginInitiateUrl"><button>Login</button> </a>
         </div>
       </div>
     </nav>
@@ -76,41 +77,40 @@ export default {
   name: 'app',
   data: function() {
     return {
-      username: null
+      username: null,
+      loginInitiateUrl: `${process.env.VUE_APP_API_URL}/oauth/initiate`
     };
   },
   methods: {
     logout: async function() {
-      await fetch(`${process.env.VUE_APP_API_URL}/oauth/logout`);
-      this.username = null;
-    },
-    login: async function() {
-      await fetch(`${process.env.VUE_APP_API_URL}/oauth/initiate`, {
+      await fetch(`${process.env.VUE_APP_API_URL}/oauth/logout`, {
         credentials: 'include'
       });
-      this.identify();
+      this.username = null;
     },
     identify: async function() {
       if (this.username) {
         return;
       }
-      const response = await fetch(
-        `${process.env.VUE_APP_API_URL}/oauth/identify`
+      const data = await fetch(
+        `${process.env.VUE_APP_API_URL}/oauth/identify`,
+        {
+          credentials: 'include'
+        }
       )
         .then(response => {
-          if (response.status === 200) {
+          if (response.ok) {
             return response.json();
           } else {
             throw new Error(response.status);
           }
         })
-        .then(data => {
-          return data;
-        })
         .catch(err => {
           console.error(err);
         });
-      this.username = response;
+      if (data) {
+        this.username = data.username;
+      }
     }
   },
   created: function() {

--- a/wp1-frontend/src/components/ArticleTableNameFilter.vue
+++ b/wp1-frontend/src/components/ArticleTableNameFilter.vue
@@ -35,7 +35,11 @@
                   :value="filterValue"
                 />
               </div>
-              <button v-on:click="onButtonClick()" class="btn btn-primary">
+              <button
+                v-on:click="onButtonClick()"
+                id="updateName"
+                class="btn btn-primary"
+              >
                 Update View
               </button>
             </div>

--- a/wp1-frontend/src/components/ArticleTablePageSelect.vue
+++ b/wp1-frontend/src/components/ArticleTablePageSelect.vue
@@ -56,7 +56,11 @@
                   v-model="page"
                 />
               </div>
-              <button v-on:click="onButtonClick()" class="btn btn-primary">
+              <button
+                v-on:click="onButtonClick()"
+                id="updatePagination"
+                class="btn btn-primary"
+              >
                 Update View
               </button>
             </div>

--- a/wp1-frontend/src/components/ArticleTableRatingSelect.vue
+++ b/wp1-frontend/src/components/ArticleTableRatingSelect.vue
@@ -51,7 +51,11 @@
                   >
                 </select>
               </div>
-              <button v-on:click="onButtonClick()" class="btn btn-primary">
+              <button
+                v-on:click="onButtonClick()"
+                id="updateRating"
+                class="btn btn-primary"
+              >
                 Update View
               </button>
             </div>

--- a/wp1/base_db_test.py
+++ b/wp1/base_db_test.py
@@ -120,15 +120,6 @@ def get_test_connect_creds():
               'host': 'localhost',
               'port': 55555
           },
-          'API': {},
-          'MWOAUTH': {
-              'consumer_key': 'consumer_key',
-              'consumer_secret': 'consumer_secret'
-          },
-          'SESSION': {
-              'secret_key': 'wp1_secret'
-          },
-          'CLIENT_URL': 'http://localhost:3000/#/'
       },
       Environment.PRODUCTION: {}
   }

--- a/wp1/base_db_test.py
+++ b/wp1/base_db_test.py
@@ -120,6 +120,15 @@ def get_test_connect_creds():
               'host': 'localhost',
               'port': 55555
           },
+          'API': {},
+          'MWOAUTH': {
+              'consumer_key': 'consumer_key',
+              'consumer_secret': 'consumer_secret'
+          },
+          'SESSION': {
+              'secret_key': 'wp1_secret'
+          },
+          'CLIENT_URL': 'http://localhost:3000/#/'
       },
       Environment.PRODUCTION: {}
   }

--- a/wp1/credentials.py.e2e
+++ b/wp1/credentials.py.e2e
@@ -29,7 +29,7 @@ CREDENTIALS = {
             'update_wait_time_seconds': 40,
             'job_elapsed_time_seconds': 10,
             'basic_income_total_time_seconds': 60,
-        }
+        },
         'MWOAUTH': {
             'consumer_key': 'consumer_key',
             'consumer_secret': 'consumer_secret'

--- a/wp1/credentials.py.e2e
+++ b/wp1/credentials.py.e2e
@@ -30,5 +30,13 @@ CREDENTIALS = {
             'job_elapsed_time_seconds': 10,
             'basic_income_total_time_seconds': 60,
         }
+        'MWOAUTH': {
+            'consumer_key': 'consumer_key',
+            'consumer_secret': 'consumer_secret'
+        },
+        'SESSION': {
+            'secret_key': 'WP1'
+        },
+        'CLIENT_URL': 'http://localhost:3000/#/'
     },
 }

--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -52,12 +52,16 @@ CREDENTIALS = {
         'API': {}
 
         # Credentials for authentication through mwoauth.
+        # To register the app go to 'https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration/propose'
         'MWOAUTH': {
             'consumer_key': '',
             'consumer_secret': ''
         },
 
         # Secret key for session.
+        # To get your random secret key for production use the following script
+        # python3
+        # import os
         'SESSION': {
             'secret_key': 'WP1_secret_key'
         },

--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -50,15 +50,16 @@ CREDENTIALS = {
         # WMF wiki OAuth credentials. Used to edit English Wikipedia.
         # These don't exist in development.
         'API': {}
+
+        # Credentials for authentication through mwoauth
         'MWOAUTH': {
             'consumer_key': '',
             'consumer_secret': ''
         },
+        # secret key for session
         'SESSION': {
-            'secret_key': 'wp1',
-            'domain': 'api.wp1.openzim.org'
-        },
-        'CLIENT_URL': 'http://localhost:3000/#/'
+            'secret_key': 'WP1_secret_key'
+        }
     },
 
     # EDIT: Remove the next line after you've provided actual credentials.

--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -51,15 +51,19 @@ CREDENTIALS = {
         # These don't exist in development.
         'API': {}
 
-        # Credentials for authentication through mwoauth
+        # Credentials for authentication through mwoauth.
         'MWOAUTH': {
             'consumer_key': '',
             'consumer_secret': ''
         },
-        # secret key for session
+
+        # Secret key for session.
         'SESSION': {
             'secret_key': 'WP1_secret_key'
-        }
+        },
+
+        # Client side url used for redirection in login process.
+        'CLIENT_URL': 'http://localhost:3000/#/'
     },
 
     # EDIT: Remove the next line after you've provided actual credentials.

--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -62,6 +62,7 @@ CREDENTIALS = {
         # To get your random secret key for production use the following script
         # python3
         # import os
+        # os.urandom(24)
         'SESSION': {
             'secret_key': 'WP1_secret_key'
         },

--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -50,6 +50,15 @@ CREDENTIALS = {
         # WMF wiki OAuth credentials. Used to edit English Wikipedia.
         # These don't exist in development.
         'API': {}
+        'MWOAUTH': {
+            'consumer_key': '',
+            'consumer_secret': ''
+        },
+        'SESSION': {
+            'secret_key': 'wp1',
+            'domain': 'api.wp1.openzim.org'
+        },
+        'CLIENT_URL': 'http://localhost:3000/#/'
     },
 
     # EDIT: Remove the next line after you've provided actual credentials.

--- a/wp1/web/app.py
+++ b/wp1/web/app.py
@@ -112,12 +112,12 @@ def create_app():
   app.register_blueprint(projects, url_prefix='/v1/projects')
   app.register_blueprint(articles, url_prefix='/v1/articles')
 
-  if CREDENTIALS is None or CREDENTIALS[ENV].get(
-      'MWOAUTH') is None or CREDENTIALS[ENV]['MWOAUTH'].get(
-          'consumer_key') is None or CREDENTIALS[ENV]['MWOAUTH'].get(
-              'consumer_secret') is None:
-    print('No MWOAUTH credentials, not attaching OAuth endpoints')
-  else:
+  missing_credentials = CREDENTIALS is None or ENV is None
+  if not missing_credentials:
+    mwoauth = CREDENTIALS.get(ENV, {}).get('MWOAUTH', {})
+  if not (missing_credentials or mwoauth.get('consumer_key') is None or
+          mwoauth.get('consumer_secret') is None):
     from wp1.web.oauth import oauth
     app.register_blueprint(oauth, url_prefix='/v1/oauth')
+
   return app

--- a/wp1/web/app.py
+++ b/wp1/web/app.py
@@ -76,12 +76,14 @@ def create_app():
     if redis_creds is not None:
       app.config.update({'RQ_DASHBOARD_REDIS_HOST': redis_creds['host']})
       app.config.update({'RQ_DASHBOARD_REDIS_PORT': redis_creds['port']})
-      app.config['SESSION_REDIS'] = redis.from_url('redis://{}:{}'.format(
-          redis_creds['host'], redis_creds['port']))
     add_basic_auth(rq_dashboard.blueprint, rq_user, rq_pass)
     app.register_blueprint(rq_dashboard.blueprint, url_prefix="/rq")
   else:
     print('No RQ_USER/RQ_PASS found in env. RQ dashboard not created.')
+
+  if redis_creds is not None:
+    app.config['SESSION_REDIS'] = redis.from_url('redis://{}:{}'.format(
+        redis_creds['host'], redis_creds['port']))
 
   app.config['SECRET_KEY'] = get_secret_key()
   app.config['SESSION_TYPE'] = 'redis'

--- a/wp1/web/app.py
+++ b/wp1/web/app.py
@@ -20,8 +20,8 @@ try:
   # The credentials module isn't checked in and may be missing
   from wp1.credentials import ENV, CREDENTIALS
 except ImportError:
-  print('''No credentials.py file found, Development overlay
-         will not be enabled.''')
+  print('No credentials.py file found. Development overlay will '
+        'not be enabled.')
   ENV = None
 
 

--- a/wp1/web/app.py
+++ b/wp1/web/app.py
@@ -79,6 +79,8 @@ def create_app():
   except ImportError:
     print('No secret_key found, using defaults.')
     app.config['SECRET_KEY'] = 'WP1'
+    ENV = None
+    CREDENTIALS = None
 
   app.config['SESSION_TYPE'] = 'redis'
   Session(app)

--- a/wp1/web/app.py
+++ b/wp1/web/app.py
@@ -11,7 +11,6 @@ from rq_dashboard.cli import add_basic_auth
 
 import wp1.logic.project as logic_project
 from wp1 import environment
-from wp1.credentials import ENV, CREDENTIALS
 from wp1.web.db import get_db, has_db
 from wp1.web.articles import articles
 from wp1.web.oauth import oauth
@@ -20,7 +19,7 @@ from wp1.web.dev.projects import dev_projects
 
 try:
   # The credentials module isn't checked in and may be missing
-  from wp1.credentials import ENV
+  from wp1.credentials import ENV, CREDENTIALS
 except ImportError:
   print(
       'No credentials.py file found, Development overlay will not be enabled.')

--- a/wp1/web/app.py
+++ b/wp1/web/app.py
@@ -23,6 +23,7 @@ except ImportError:
   print('No credentials.py file found. Development overlay will '
         'not be enabled.')
   ENV = None
+  CREDENTIALS = None
 
 
 def get_redis_creds():
@@ -32,6 +33,15 @@ def get_redis_creds():
   except ImportError:
     print('No REDIS_CREDS found, using defaults.')
     return None
+
+
+def get_secret_key():
+  try:
+    from wp1.credentials import ENV, CREDENTIALS
+    return CREDENTIALS[ENV]['SESSION']['secret_key']
+  except ImportError:
+    print('No secret_key found, using defaults.')
+    return 'WP1'
 
 
 # We use this to prevent caching of `/swagger.yml`
@@ -73,15 +83,7 @@ def create_app():
   else:
     print('No RQ_USER/RQ_PASS found in env. RQ dashboard not created.')
 
-  try:
-    from wp1.credentials import ENV, CREDENTIALS
-    app.config['SECRET_KEY'] = CREDENTIALS[ENV]['SESSION']['secret_key']
-  except ImportError:
-    print('No secret_key found, using defaults.')
-    app.config['SECRET_KEY'] = 'WP1'
-    ENV = None
-    CREDENTIALS = None
-
+  app.config['SECRET_KEY'] = get_secret_key()
   app.config['SESSION_TYPE'] = 'redis'
   Session(app)
 

--- a/wp1/web/oauth.py
+++ b/wp1/web/oauth.py
@@ -39,7 +39,14 @@ def complete():
   access_token = handshaker.complete(session['request_token'], query_string)
   session.pop('request_token')
   identity = handshaker.identify(access_token)
-  session['user'] = {'access_token': access_token, 'identity': identity}
+
+  session['user'] = {
+      'access_token': access_token,
+      'identity': {
+          'username': identity['username'],
+          'sub': identity['sub']
+      }
+  }
   return flask.redirect(client_url)
 
 

--- a/wp1/web/oauth.py
+++ b/wp1/web/oauth.py
@@ -13,8 +13,8 @@ try:
                           consumer_token)
   client_url = CREDENTIALS[ENV]['CLIENT_URL']
 except ImportError:
-  print('''No credentials.py file found,
-       Please add your mwoauth credentials in credentials.py''')
+  print('No credentials.py file found, Please add your '
+        'mwoauth credentials in credentials.py')
   ENV = None
   CREDENTIALS = None
   handshaker = None

--- a/wp1/web/oauth.py
+++ b/wp1/web/oauth.py
@@ -1,52 +1,54 @@
 import flask
-import jwt
-from flask import request, jsonify, session
-from mwoauth import ConsumerToken, Handshaker, RequestToken
-from wp1.credentials import ENV, CREDENTIALS
+from flask import jsonify, session
+from mwoauth import ConsumerToken, Handshaker
 
 oauth = flask.Blueprint('oauth', __name__)
 
-consumer_token = ConsumerToken(CREDENTIALS[ENV]['MWOAUTH']['consumer_key'],
-                               CREDENTIALS[ENV]['MWOAUTH']['consumer_secret'])
-
-handshaker = Handshaker("https://en.wikipedia.org/w/index.php", consumer_token)
+try:
+  # The credentials module isn't checked in and may be missing
+  from wp1.credentials import ENV, CREDENTIALS
+  consumer_token = ConsumerToken(CREDENTIALS[ENV]['MWOAUTH']['consumer_key'],
+                                 CREDENTIALS[ENV]['MWOAUTH']['consumer_secret'])
+  handshaker = Handshaker("https://en.wikipedia.org/w/index.php",
+                          consumer_token)
+except ImportError:
+  print(
+      'No credentials.py file found, Please add your mwoauth credentials in credentials.py'
+  )
 
 
 @oauth.route('/initiate')
 def initiate():
   redirect, request_token = handshaker.initiate()
-  session[str(request_token.key)] = dict(
-      zip(request_token._fields, request_token))
+  session['request_token'] = request_token
   return flask.redirect(redirect)
 
 
 @oauth.route('/complete')
 def complete():
-  request_token_key = str(flask.request.args.get('oauth_token', 'None'))
-  query_string = str(flask.request.query_string.decode('utf-8'))
-  access_token = handshaker.complete(RequestToken(**session[request_token_key]),
-                                     query_string)
-  session.pop(request_token_key)
-  session[request_token_key] = dict(zip(access_token._fields, access_token))
-  return flask.redirect('{}?{}'.format(CREDENTIALS[ENV]['CLIENT_URL'],
-                                       request_token_key))
+  try:
+    query_string = str(flask.request.query_string.decode('utf-8'))
+    access_token = handshaker.complete(session['request_token'], query_string)
+    session.pop('request_token')
+    session['access_token'] = access_token
+    return {'status:': '200'}
+  except KeyError:
+    flask.abort(404, 'User does not exist')
 
 
-@oauth.route('/token')
-def token():
-  request_token = request.get_json(force=True)
-  access_token = session[request_token]
-  encoded_jwt = jwt.encode({"access": access_token},
-                           CREDENTIALS[ENV]['SESSION']['secret_key'],
-                           algorithm="HS256")
-  return jsonify(encoded_jwt)
+@oauth.route('/identify')
+def identify():
+  try:
+    username = handshaker.identify(session['access_token'])['username']
+    return jsonify(username)
+  except KeyError:
+    flask.abort(401, 'Unauthorized')
 
 
-# @oauth.route('/identify')
-
-
-@oauth.route('/logout', methods=['POST'])
+@oauth.route('/logout')
 def logout():
-  request_token = request.get_json(force=True)
-  session.pop(request_token)
-  return {'status': '200'}
+  try:
+    session.pop('access_token')
+    return {'status': '200'}
+  except KeyError:
+    flask.abort(404, 'User does not exist')

--- a/wp1/web/oauth.py
+++ b/wp1/web/oauth.py
@@ -16,6 +16,8 @@ except ImportError:
   print(
       'No credentials.py file found, Please add your mwoauth credentials in credentials.py'
   )
+  ENV = None
+  CREDENTIALS = None
 
 
 @oauth.route('/initiate')

--- a/wp1/web/oauth.py
+++ b/wp1/web/oauth.py
@@ -13,11 +13,12 @@ try:
                           consumer_token)
   client_url = CREDENTIALS[ENV]['CLIENT_URL']
 except ImportError:
-  print(
-      'No credentials.py file found, Please add your mwoauth credentials in credentials.py'
-  )
+  print('''No credentials.py file found,
+       Please add your mwoauth credentials in credentials.py''')
   ENV = None
   CREDENTIALS = None
+  handshaker = None
+  client_url = None
 
 
 @oauth.route('/initiate')
@@ -47,7 +48,6 @@ def identify():
   user = session.get('user')
   if user is None:
     flask.abort(401, 'Unauthorized')
-    return
   return jsonify({'username': user['identity']['username']})
 
 

--- a/wp1/web/oauth.py
+++ b/wp1/web/oauth.py
@@ -1,7 +1,6 @@
 import flask
 from flask import jsonify, session
 from mwoauth import ConsumerToken, Handshaker
-from oauthlib.oauth1.rfc5849 import Client
 
 oauth = flask.Blueprint('oauth', __name__)
 

--- a/wp1/web/oauth.py
+++ b/wp1/web/oauth.py
@@ -1,0 +1,52 @@
+import flask
+import jwt
+from flask import request, jsonify, session
+from mwoauth import ConsumerToken, Handshaker, RequestToken
+from wp1.credentials import ENV, CREDENTIALS
+
+oauth = flask.Blueprint('oauth', __name__)
+
+consumer_token = ConsumerToken(CREDENTIALS[ENV]['MWOAUTH']['consumer_key'],
+                               CREDENTIALS[ENV]['MWOAUTH']['consumer_secret'])
+
+handshaker = Handshaker("https://en.wikipedia.org/w/index.php", consumer_token)
+
+
+@oauth.route('/initiate')
+def initiate():
+  redirect, request_token = handshaker.initiate()
+  session[str(request_token.key)] = dict(
+      zip(request_token._fields, request_token))
+  return flask.redirect(redirect)
+
+
+@oauth.route('/complete')
+def complete():
+  request_token_key = str(flask.request.args.get('oauth_token', 'None'))
+  query_string = str(flask.request.query_string.decode('utf-8'))
+  access_token = handshaker.complete(RequestToken(**session[request_token_key]),
+                                     query_string)
+  session.pop(request_token_key)
+  session[request_token_key] = dict(zip(access_token._fields, access_token))
+  return flask.redirect('{}?{}'.format(CREDENTIALS[ENV]['CLIENT_URL'],
+                                       request_token_key))
+
+
+@oauth.route('/token')
+def token():
+  request_token = request.get_json(force=True)
+  access_token = session[request_token]
+  encoded_jwt = jwt.encode({"access": access_token},
+                           CREDENTIALS[ENV]['SESSION']['secret_key'],
+                           algorithm="HS256")
+  return jsonify(encoded_jwt)
+
+
+# @oauth.route('/identify')
+
+
+@oauth.route('/logout', methods=['POST'])
+def logout():
+  request_token = request.get_json(force=True)
+  session.pop(request_token)
+  return {'status': '200'}

--- a/wp1/web/oauth_test.py
+++ b/wp1/web/oauth_test.py
@@ -1,0 +1,47 @@
+from wp1.web.app import create_app
+from wp1.web.oauth import identify
+from wp1.web.base_web_testcase import BaseWebTestcase
+from unittest import mock
+
+from unittest.mock import patch
+
+
+class IdentifyTest(BaseWebTestcase):
+
+  def test_identify(self):
+    self.app = create_app()
+    self.app.testing = True
+    with self.override_db(self.app), self.app.test_client() as c:
+      with c.session_transaction() as sess:
+        sess['user'] = {
+            'access_token': 'abcd',
+            'identity': {
+                'username': 'mahakporwal02'
+            }
+        }
+        assert identify() == {"username": 'mahakporwal02'}
+
+  @mock.patch("wp1.web.oauth.session.get")
+  def identify_test(self, mock_session_get):
+    self.app = create_app()
+    with self.override_db(self.app), self.app.test_client() as client:
+      mock_session_get.return_value = mock.Mock({
+          "access_code": 'abcd',
+          "user": {
+              "username": 'mahakporwal02'
+          }
+      })
+      assert identify() == {"username": 'mahakporwal02'}
+
+  def identify_test(self):
+    self.app = create_app()
+    self.app.testing = True
+    with self.override_db(self.app), self.app.test_client() as client:
+      with client.session_transaction() as sess:
+        sess['user'] = {
+            "access_code": 'abcd',
+            "identity": {
+                "username": 'mahakporwal02'
+            }
+        }
+        rv = client.get('/v1/oauth/identify')

--- a/wp1/web/oauth_test.py
+++ b/wp1/web/oauth_test.py
@@ -22,7 +22,13 @@ class IdentifyTest(unittest.TestCase):
       Environment.PRODUCTION: {}
   }
   REDIRECT = 'https://en.wikipedia.org/w/index.php?oauth_token=token&oauth_consumer_key=key'
-  USER = {'access_token': 'access_token', 'identity': {'username': 'WP1_user'}}
+  USER = {
+      'access_token': 'access_token',
+      'identity': {
+          'username': 'WP1_user',
+          'sub': '1234'
+      }
+  }
   REQUEST_TOKEN = {'key': 'request_token', 'secret': 'request_token_secret'}
   handshaker = Mock(
       **{

--- a/wp1/web/oauth_test.py
+++ b/wp1/web/oauth_test.py
@@ -9,15 +9,12 @@ except ImportError:
   ENV = None
   CREDENTIALS = None
 
-if (CREDENTIALS is None or CREDENTIALS[ENV].get('MWOAUTH') is None or
-    CREDENTIALS[ENV]['MWOAUTH'].get('consumer_key') is None or
-    CREDENTIALS[ENV]['MWOAUTH'].get('consumer_secret') is None):
-  Skip = True
-else:
-  Skip = False
+skip = bool(CREDENTIALS is None or CREDENTIALS[ENV].get('MWOAUTH') is None or
+            CREDENTIALS[ENV]['MWOAUTH'].get('consumer_key') is None or
+            CREDENTIALS[ENV]['MWOAUTH'].get('consumer_secret') is None)
 
 
-@unittest.skipIf(Skip, 'Cannot find Credentials.py')
+@unittest.skipIf(skip, 'Cannot find Credentials.py')
 class IdentifyTest(BaseWebTestcase):
 
   def test_identify(self):

--- a/wp1/web/oauth_test.py
+++ b/wp1/web/oauth_test.py
@@ -1,26 +1,14 @@
-from wp1.web.app import create_app
-from wp1.web.base_web_testcase import BaseWebTestcase
 import unittest
-
-try:
-  from wp1.credentials import ENV, CREDENTIALS
-except ImportError:
-  ENV = None
-  CREDENTIALS = None
-
-missing_credentials = CREDENTIALS is None or ENV is None
-if not missing_credentials:
-  mwoauth = CREDENTIALS.get("ENV", {}).get("MWOAUTH", {})
-if missing_credentials or mwoauth.get('consumer_key') is None or mwoauth.get(
-    'consumer_secret') is None:
-  mwoauth = {
-      'consumer_key': 'consumer_key',
-      'consumer_secret': 'consumer_secret'
-  }
+from wp1.web.app import create_app
+from wp1.environment import Environment
+from wp1.base_db_test import get_test_connect_creds
+from unittest.mock import patch
 
 
-class IdentifyTest(BaseWebTestcase):
+class IdentifyTest(unittest.TestCase):
 
+  @patch('wp1.web.app.CREDENTIALS', get_test_connect_creds())
+  @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
   def test_identify_authorized_user(self):
     self.app = create_app()
     with self.app.test_client() as client:
@@ -34,12 +22,16 @@ class IdentifyTest(BaseWebTestcase):
       rv = client.get('/v1/oauth/identify')
       self.assertEqual({"username": 'WP1_user'}, rv.get_json())
 
+  @patch('wp1.web.app.CREDENTIALS', get_test_connect_creds())
+  @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
   def test_identify_unauthorized_user(self):
     self.app = create_app()
     with self.app.test_client() as client:
       rv = client.get('/v1/oauth/identify')
       self.assertEqual('401 UNAUTHORIZED', rv.status)
 
+  @patch('wp1.web.app.CREDENTIALS', get_test_connect_creds())
+  @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
   def test_logout_authorized_user(self):
     self.app = create_app()
     with self.app.test_client() as client:
@@ -53,6 +45,8 @@ class IdentifyTest(BaseWebTestcase):
       rv = client.get('/v1/oauth/logout')
       self.assertEqual({'status': '204'}, rv.get_json())
 
+  @patch('wp1.web.app.CREDENTIALS', get_test_connect_creds())
+  @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
   def test_logout_unauthorized_user(self):
     self.app = create_app()
     with self.app.test_client() as client:

--- a/wp1/web/oauth_test.py
+++ b/wp1/web/oauth_test.py
@@ -1,11 +1,12 @@
 import unittest
 from wp1.web.app import create_app
 from wp1.environment import Environment
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 
 class IdentifyTest(unittest.TestCase):
 
+  ENV = Environment.DEVELOPMENT
   TEST_OAUTH_CREDS = {
       Environment.DEVELOPMENT: {
           'API': {},
@@ -20,6 +21,62 @@ class IdentifyTest(unittest.TestCase):
       },
       Environment.PRODUCTION: {}
   }
+  REDIRECT = 'https://en.wikipedia.org/w/index.php?oauth_token=token&oauth_consumer_key=key'
+  USER = {'access_token': 'access_token', 'identity': {'username': 'WP1_user'}}
+  REQUEST_TOKEN = {'key': 'request_token', 'secret': 'request_token_secret'}
+  handshaker = Mock(
+      **{
+          'initiate.return_value': (REDIRECT, REQUEST_TOKEN),
+          'complete.return_value': {
+              'key': 'access_token',
+              'secret': 'access_secret'
+          },
+          'identify.return_value': USER['identity']
+      })
+
+  @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
+  @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
+  @patch('wp1.web.oauth.client_url', TEST_OAUTH_CREDS[ENV]['CLIENT_URL'])
+  def test_initiate_authorized_user(self):
+    self.app = create_app()
+    with self.app.test_client() as client:
+      with client.session_transaction() as sess:
+        sess['user'] = self.USER
+      rv = client.get('/v1/oauth/initiate')
+      self.assertEqual(self.TEST_OAUTH_CREDS[self.ENV]['CLIENT_URL'],
+                       rv.location)
+
+  @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
+  @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
+  @patch('wp1.web.oauth.handshaker', handshaker)
+  def test_initiate_unauthorized_user(self):
+    self.app = create_app()
+    with self.app.test_client() as client:
+      with client.session_transaction() as sess:
+        sess['request_token'] = self.REQUEST_TOKEN
+      rv = client.get('/v1/oauth/initiate')
+      self.assertEqual(self.REDIRECT, rv.location)
+
+  @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
+  @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
+  def test_complete_unauthorized_user(self):
+    self.app = create_app()
+    with self.app.test_client() as client:
+      rv = client.get('/v1/oauth/complete')
+      self.assertEqual('404 NOT FOUND', rv.status)
+
+  @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
+  @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
+  @patch('wp1.web.oauth.client_url', TEST_OAUTH_CREDS[ENV]['CLIENT_URL'])
+  @patch('wp1.web.oauth.handshaker', handshaker)
+  def test_complete_authorized_user(self):
+    self.app = create_app()
+    with self.app.test_client() as client:
+      with client.session_transaction() as sess:
+        sess['request_token'] = self.REQUEST_TOKEN
+      rv = client.get('/v1/oauth/complete?query_string')
+      self.assertEqual(self.TEST_OAUTH_CREDS[self.ENV]['CLIENT_URL'],
+                       rv.location)
 
   @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
   @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
@@ -27,12 +84,7 @@ class IdentifyTest(unittest.TestCase):
     self.app = create_app()
     with self.app.test_client() as client:
       with client.session_transaction() as sess:
-        sess['user'] = {
-            'access_token': 'access_token',
-            'identity': {
-                'username': 'WP1_user'
-            }
-        }
+        sess['user'] = self.USER
       rv = client.get('/v1/oauth/identify')
       self.assertEqual({"username": 'WP1_user'}, rv.get_json())
 
@@ -50,12 +102,7 @@ class IdentifyTest(unittest.TestCase):
     self.app = create_app()
     with self.app.test_client() as client:
       with client.session_transaction() as sess:
-        sess['user'] = {
-            'access_token': 'access_token',
-            'identity': {
-                'username': 'WP1_user'
-            }
-        }
+        sess['user'] = self.USER
       rv = client.get('/v1/oauth/logout')
       self.assertEqual({'status': '204'}, rv.get_json())
 

--- a/wp1/web/oauth_test.py
+++ b/wp1/web/oauth_test.py
@@ -1,13 +1,27 @@
 import unittest
 from wp1.web.app import create_app
 from wp1.environment import Environment
-from wp1.base_db_test import get_test_connect_creds
 from unittest.mock import patch
 
 
 class IdentifyTest(unittest.TestCase):
 
-  @patch('wp1.web.app.CREDENTIALS', get_test_connect_creds())
+  TEST_OAUTH_CREDS = {
+      Environment.DEVELOPMENT: {
+          'API': {},
+          'MWOAUTH': {
+              'consumer_key': 'consumer_key',
+              'consumer_secret': 'consumer_secret'
+          },
+          'SESSION': {
+              'secret_key': 'wp1_secret'
+          },
+          'CLIENT_URL': 'http://localhost:3000/#/'
+      },
+      Environment.PRODUCTION: {}
+  }
+
+  @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
   @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
   def test_identify_authorized_user(self):
     self.app = create_app()
@@ -22,7 +36,7 @@ class IdentifyTest(unittest.TestCase):
       rv = client.get('/v1/oauth/identify')
       self.assertEqual({"username": 'WP1_user'}, rv.get_json())
 
-  @patch('wp1.web.app.CREDENTIALS', get_test_connect_creds())
+  @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
   @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
   def test_identify_unauthorized_user(self):
     self.app = create_app()
@@ -30,7 +44,7 @@ class IdentifyTest(unittest.TestCase):
       rv = client.get('/v1/oauth/identify')
       self.assertEqual('401 UNAUTHORIZED', rv.status)
 
-  @patch('wp1.web.app.CREDENTIALS', get_test_connect_creds())
+  @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
   @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
   def test_logout_authorized_user(self):
     self.app = create_app()
@@ -45,7 +59,7 @@ class IdentifyTest(unittest.TestCase):
       rv = client.get('/v1/oauth/logout')
       self.assertEqual({'status': '204'}, rv.get_json())
 
-  @patch('wp1.web.app.CREDENTIALS', get_test_connect_creds())
+  @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
   @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
   def test_logout_unauthorized_user(self):
     self.app = create_app()

--- a/wp1/web/oauth_test.py
+++ b/wp1/web/oauth_test.py
@@ -1,47 +1,53 @@
 from wp1.web.app import create_app
-from wp1.web.oauth import identify
 from wp1.web.base_web_testcase import BaseWebTestcase
-from unittest import mock
+import unittest
 
-from unittest.mock import patch
+try:
+  # The credentials module isn't checked in and may be missing
+  from wp1.credentials import ENV, CREDENTIALS
+except ImportError:
+  ENV = None
+  CREDENTIALS = None
+
+if (CREDENTIALS is None or CREDENTIALS[ENV].get('MWOAUTH') is None or
+    CREDENTIALS[ENV]['MWOAUTH'].get('consumer_key') is None or
+    CREDENTIALS[ENV]['MWOAUTH'].get('consumer_secret') is None):
+  Skip = True
+else:
+  Skip = False
 
 
+@unittest.skipIf(Skip, 'Cannot find Credentials.py')
 class IdentifyTest(BaseWebTestcase):
 
   def test_identify(self):
     self.app = create_app()
     self.app.testing = True
-    with self.override_db(self.app), self.app.test_client() as c:
-      with c.session_transaction() as sess:
-        sess['user'] = {
-            'access_token': 'abcd',
-            'identity': {
-                'username': 'mahakporwal02'
-            }
-        }
-        assert identify() == {"username": 'mahakporwal02'}
-
-  @mock.patch("wp1.web.oauth.session.get")
-  def identify_test(self, mock_session_get):
-    self.app = create_app()
-    with self.override_db(self.app), self.app.test_client() as client:
-      mock_session_get.return_value = mock.Mock({
-          "access_code": 'abcd',
-          "user": {
-              "username": 'mahakporwal02'
-          }
-      })
-      assert identify() == {"username": 'mahakporwal02'}
-
-  def identify_test(self):
-    self.app = create_app()
-    self.app.testing = True
-    with self.override_db(self.app), self.app.test_client() as client:
+    with self.app.test_client() as client:
+      rv = client.get('/v1/oauth/identify')
+      self.assertEqual('401 UNAUTHORIZED', rv.status)
       with client.session_transaction() as sess:
         sess['user'] = {
-            "access_code": 'abcd',
-            "identity": {
-                "username": 'mahakporwal02'
+            'access_token': 'access_token',
+            'identity': {
+                'username': 'WP1_user'
             }
         }
-        rv = client.get('/v1/oauth/identify')
+      rv = client.get('/v1/oauth/identify')
+      self.assertEqual({"username": 'WP1_user'}, rv.get_json())
+
+  def test_logout(self):
+    self.app = create_app()
+    self.app.testing = True
+    with self.app.test_client() as client:
+      rv = client.get('/v1/oauth/logout')
+      self.assertEqual('404 NOT FOUND', rv.status)
+      with client.session_transaction() as sess:
+        sess['user'] = {
+            'access_token': 'access_token',
+            'identity': {
+                'username': 'WP1_user'
+            }
+        }
+      rv = client.get('/v1/oauth/logout')
+      self.assertEqual({'status': '204'}, rv.get_json())

--- a/wp1/web/oauth_test.py
+++ b/wp1/web/oauth_test.py
@@ -3,26 +3,27 @@ from wp1.web.base_web_testcase import BaseWebTestcase
 import unittest
 
 try:
-  # The credentials module isn't checked in and may be missing
   from wp1.credentials import ENV, CREDENTIALS
 except ImportError:
   ENV = None
   CREDENTIALS = None
 
-skip = bool(CREDENTIALS is None or CREDENTIALS[ENV].get('MWOAUTH') is None or
-            CREDENTIALS[ENV]['MWOAUTH'].get('consumer_key') is None or
-            CREDENTIALS[ENV]['MWOAUTH'].get('consumer_secret') is None)
+missing_credentials = CREDENTIALS is None or ENV is None
+if not missing_credentials:
+  mwoauth = CREDENTIALS.get("ENV", {}).get("MWOAUTH", {})
+if missing_credentials or mwoauth.get('consumer_key') is None or mwoauth.get(
+    'consumer_secret') is None:
+  mwoauth = {
+      'consumer_key': 'consumer_key',
+      'consumer_secret': 'consumer_secret'
+  }
 
 
-@unittest.skipIf(skip, 'Cannot find Credentials.py')
 class IdentifyTest(BaseWebTestcase):
 
-  def test_identify(self):
+  def test_identify_authorized_user(self):
     self.app = create_app()
-    self.app.testing = True
     with self.app.test_client() as client:
-      rv = client.get('/v1/oauth/identify')
-      self.assertEqual('401 UNAUTHORIZED', rv.status)
       with client.session_transaction() as sess:
         sess['user'] = {
             'access_token': 'access_token',
@@ -33,12 +34,15 @@ class IdentifyTest(BaseWebTestcase):
       rv = client.get('/v1/oauth/identify')
       self.assertEqual({"username": 'WP1_user'}, rv.get_json())
 
-  def test_logout(self):
+  def test_identify_unauthorized_user(self):
     self.app = create_app()
-    self.app.testing = True
     with self.app.test_client() as client:
-      rv = client.get('/v1/oauth/logout')
-      self.assertEqual('404 NOT FOUND', rv.status)
+      rv = client.get('/v1/oauth/identify')
+      self.assertEqual('401 UNAUTHORIZED', rv.status)
+
+  def test_logout_authorized_user(self):
+    self.app = create_app()
+    with self.app.test_client() as client:
       with client.session_transaction() as sess:
         sess['user'] = {
             'access_token': 'access_token',
@@ -48,3 +52,9 @@ class IdentifyTest(BaseWebTestcase):
         }
       rv = client.get('/v1/oauth/logout')
       self.assertEqual({'status': '204'}, rv.get_json())
+
+  def test_logout_unauthorized_user(self):
+    self.app = create_app()
+    with self.app.test_client() as client:
+      rv = client.get('/v1/oauth/logout')
+      self.assertEqual('404 NOT FOUND', rv.status)


### PR DESCRIPTION
This PR adds a new `oauth` blueprint to the backend API server that initiates and completes the OAuth login flow with the Meta Wikipedia server. The end result is that our app receives a username and user id for the user, and they are "logged in" to our app, via a session cookie which stores the same.