### PR TITLE
Configure CORS for supports_credentials=True

### DIFF
--- a/wp1/credentials.py.e2e
+++ b/wp1/credentials.py.e2e
@@ -37,6 +37,9 @@ CREDENTIALS = {
         'SESSION': {
             'secret_key': 'WP1'
         },
-        'CLIENT_URL': 'http://localhost:3000/#/'
+        'CLIENT_URL': {
+            'domains': ['http://localhost:3000'],
+            'homepage': 'http://localhost:3000/#/',
+        },
     },
 }

--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -73,7 +73,10 @@ CREDENTIALS = {
         },
 
         # Client side url used for redirection in login process.
-        'CLIENT_URL': 'http://localhost:3000/#/',
+        'CLIENT_URL': {
+            'domains': ['http://localhost:3000'],
+            'homepage': 'http://localhost:3000/#/',
+        },
     },
 
     # EDIT: Remove the next line after you've provided actual credentials.
@@ -129,5 +132,8 @@ CREDENTIALS = {
     #   },
 
     #   # Client side url used for redirection in login process.
-    #   'CLIENT_URL': 'https://wp1.openzim.org/#/',
+    #   'CLIENT_URL': {
+    #       'domains': ['http://wp1.openzim.org', 'https://wp1.openzim.org'],
+    #       'homepage': 'https://wp1.openzim.org/#/',
+    #   }
 }

--- a/wp1/web/app.py
+++ b/wp1/web/app.py
@@ -73,7 +73,7 @@ def create_app():
 
   cors = flask_cors.CORS(app,
                          resources='*',
-                         origins=cors_origin,
+                         origins=cors_origins,
                          supports_credentials=True)
   gzip = flask_gzip.Gzip(app, minimum_size=256)
 

--- a/wp1/web/app.py
+++ b/wp1/web/app.py
@@ -63,8 +63,18 @@ def nocache(view):
 
 def create_app():
   app = flask.Flask(__name__)
+  missing_credentials = CREDENTIALS is None or ENV is None
 
-  cors = flask_cors.CORS(app)
+  cors_origins = None
+  if not missing_credentials:
+    cors_origins = CREDENTIALS[ENV].get('CLIENT_URL', {}).get('domains')
+  if cors_origins is None:
+    cors_origins = '*'
+
+  cors = flask_cors.CORS(app,
+                         resources='*',
+                         origins=cors_origin,
+                         supports_credentials=True)
   gzip = flask_gzip.Gzip(app, minimum_size=256)
 
   rq_user = os.environ.get('RQ_USER')
@@ -114,7 +124,6 @@ def create_app():
   app.register_blueprint(projects, url_prefix='/v1/projects')
   app.register_blueprint(articles, url_prefix='/v1/articles')
 
-  missing_credentials = CREDENTIALS is None or ENV is None
   if not missing_credentials:
     mwoauth = CREDENTIALS.get(ENV, {}).get('MWOAUTH', {})
   if not (missing_credentials or mwoauth.get('consumer_key') is None or

--- a/wp1/web/oauth.py
+++ b/wp1/web/oauth.py
@@ -11,20 +11,20 @@ try:
                                  CREDENTIALS[ENV]['MWOAUTH']['consumer_secret'])
   handshaker = Handshaker("https://en.wikipedia.org/w/index.php",
                           consumer_token)
-  client_url = CREDENTIALS[ENV]['CLIENT_URL']
+  homepage_url = CREDENTIALS[ENV]['CLIENT_URL']['homepage']
 except ImportError:
   print('No credentials.py file found, Please add your '
         'mwoauth credentials in credentials.py')
   ENV = None
   CREDENTIALS = None
   handshaker = None
-  client_url = None
+  homepage_url = None
 
 
 @oauth.route('/initiate')
 def initiate():
   if session.get('user'):
-    return flask.redirect(client_url)
+    return flask.redirect(homepage_url)
   redirect, request_token = handshaker.initiate()
   session['request_token'] = request_token
   return flask.redirect(redirect)
@@ -47,7 +47,7 @@ def complete():
           'sub': identity['sub']
       }
   }
-  return flask.redirect(client_url)
+  return flask.redirect(homepage_url)
 
 
 @oauth.route('/identify')

--- a/wp1/web/oauth_test.py
+++ b/wp1/web/oauth_test.py
@@ -45,15 +45,17 @@ class IdentifyTest(unittest.TestCase):
 
   @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
   @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
-  @patch('wp1.web.oauth.client_url', TEST_OAUTH_CREDS[ENV]['CLIENT_URL'])
+  @patch('wp1.web.oauth.homepage_url',
+         TEST_OAUTH_CREDS[ENV]['CLIENT_URL']['homepage'])
   def test_initiate_authorized_user(self):
     self.app = create_app()
     with self.app.test_client() as client:
       with client.session_transaction() as sess:
         sess['user'] = self.USER
       rv = client.get('/v1/oauth/initiate')
-      self.assertEqual(self.TEST_OAUTH_CREDS[self.ENV]['CLIENT_URL'],
-                       rv.location)
+      self.assertEqual(
+          self.TEST_OAUTH_CREDS[self.ENV]['CLIENT_URL']['homepage'],
+          rv.location)
 
   @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
   @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
@@ -76,7 +78,8 @@ class IdentifyTest(unittest.TestCase):
 
   @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
   @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
-  @patch('wp1.web.oauth.client_url', TEST_OAUTH_CREDS[ENV]['CLIENT_URL'])
+  @patch('wp1.web.oauth.homepage_url',
+         TEST_OAUTH_CREDS[ENV]['CLIENT_URL']['homepage'])
   @patch('wp1.web.oauth.handshaker', handshaker)
   def test_complete_authorized_user(self):
     self.app = create_app()
@@ -84,8 +87,9 @@ class IdentifyTest(unittest.TestCase):
       with client.session_transaction() as sess:
         sess['request_token'] = self.REQUEST_TOKEN
       rv = client.get('/v1/oauth/complete?query_string')
-      self.assertEqual(self.TEST_OAUTH_CREDS[self.ENV]['CLIENT_URL'],
-                       rv.location)
+      self.assertEqual(
+          self.TEST_OAUTH_CREDS[self.ENV]['CLIENT_URL']['homepage'],
+          rv.location)
 
   @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
   @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)

--- a/wp1/web/oauth_test.py
+++ b/wp1/web/oauth_test.py
@@ -17,7 +17,10 @@ class IdentifyTest(unittest.TestCase):
           'SESSION': {
               'secret_key': 'wp1_secret'
           },
-          'CLIENT_URL': 'http://localhost:3000/#/'
+          'CLIENT_URL': {
+              'domain': 'localhost:3000',
+              'homepage': 'http://localhost:3000/#/'
+          }
       },
       Environment.PRODUCTION: {}
   }


### PR DESCRIPTION
The client side call to `/identify` uses `credentials: include` in the fetch request. However, this is only supported by a cross domain server (such as wp1.openzim.org -> api.wp1.openzim.org) if the `supports_credentials=True` is configured for Flask-CORS. This parameter requires that the list of origins be explicitly listed, so we add an additional configuration to credentials.py 