### PR TITLE
Database migration and model for Selections

### DIFF
--- a/db/migrations/20210705_01_TgcHL-add-selections-table.py
+++ b/db/migrations/20210705_01_TgcHL-add-selections-table.py
@@ -9,7 +9,7 @@ __depends__ = {'20210528_01_xt830-add-users-table'}
 steps = [
     step(
         "CREATE TABLE selections ("
-        "s_id INTEGER NOT NULL PRIMARY KEY, "
+        "s_id INTEGER NOT NULL PRIMARY KEY AUTO_INCREMENT, "
         "s_name VARBINARY(255) NOT NULL, "
         "s_user_id INTEGER NOT NULL, "
         "s_hash VARBINARY(255), "

--- a/db/migrations/20210705_01_TgcHL-add-selections-table.py
+++ b/db/migrations/20210705_01_TgcHL-add-selections-table.py
@@ -1,0 +1,23 @@
+"""
+Add selections table
+"""
+
+from yoyo import step
+
+__depends__ = {'20210528_01_xt830-add-users-table'}
+
+steps = [
+    step(
+        "CREATE TABLE selections ("
+        "s_id INTEGER NOT NULL PRIMARY KEY, "
+        "s_name VARBINARY(255) NOT NULL, "
+        "s_user_id INTEGER NOT NULL, "
+        "s_hash VARBINARY(255), "
+        "s_project VARBINARY(255) NOT NULL, "
+        "s_model VARBINARY(255), "
+        "s_region VARBINARY(255), "
+        "s_bucket VARBINARY(255), "
+        "s_object_key VARBINARY(255), "
+        "s_last_generated BINARY(20)"
+        ")", "DROP TABLE selections")
+]

--- a/wp1/models/wp10/selection.py
+++ b/wp1/models/wp10/selection.py
@@ -1,0 +1,39 @@
+import datetime
+
+import attr
+
+from wp1.constants import TS_FORMAT_WP10
+from wp1.timestamp import utcnow
+
+
+@attr.s
+class Selection:
+  table_name = 'selections'
+
+  s_name = attr.ib()
+  s_user_id = attr.ib()
+  s_project = attr.ib()
+  s_id = attr.ib(default=None)
+  s_hash = attr.ib(default=None)
+  s_model = attr.ib(default=None)
+  s_region = attr.ib(default=None)
+  s_bucket = attr.ib(default=None)
+  s_object_key = attr.ib(default=None)
+  s_last_generated = attr.ib(default=None)
+
+  # The timestamp parsed into a datetime.datetime object.
+  @property
+  def last_generated_dt(self):
+    return datetime.datetime.strptime(self.s_last_generated.decode('utf-8'),
+                                      TS_FORMAT_WP10)
+
+  def set_last_generated_dt(self, dt):
+    """Sets the last_generated field using a datetime.datetime object"""
+    if dt is None:
+      logger.warning('Attempt to set selection last_generated to None ignored')
+      return
+    self.s_last_generated = dt.strftime(TS_FORMAT_WP10).encode('utf-8')
+
+  def set_last_generated_now(self):
+    """Sets the last_generated field to a timestamp that is equal to now"""
+    self.set_last_generated_dt(utcnow())

--- a/wp1/models/wp10/selection_test.py
+++ b/wp1/models/wp10/selection_test.py
@@ -1,0 +1,37 @@
+import datetime
+from unittest.mock import patch
+
+from wp1.base_db_test import BaseWpOneDbTest
+from wp1.models.wp10.selection import Selection
+
+
+class ModelsSelectionTest(BaseWpOneDbTest):
+
+  def setUp(self):
+    super().setUp()
+    self.selection = Selection(s_name='My List',
+                               s_user_id=100,
+                               s_project='en.wikipedia.org',
+                               s_last_generated=b'20180929123055')
+
+  def test_last_generated_dt(self):
+    dt = self.selection.last_generated_dt
+    self.assertEqual(2018, dt.year)
+    self.assertEqual(9, dt.month)
+    self.assertEqual(29, dt.day)
+    self.assertEqual(12, dt.hour)
+    self.assertEqual(30, dt.minute)
+    self.assertEqual(55, dt.second)
+
+  def test_set_last_generated_dt(self):
+    dt = datetime.datetime(2020, 12, 15, 9, 30, 55)
+    self.selection.set_last_generated_dt(dt)
+
+    self.assertEqual(b'20201215093055', self.selection.s_last_generated)
+
+  @patch('wp1.models.wp10.selection.utcnow',
+         return_value=datetime.datetime(2018, 12, 25, 5, 55, 55))
+  def test_set_last_generated_now(self, patched_now):
+    self.selection.set_last_generated_now()
+
+    self.assertEqual(b'20181225055555', self.selection.s_last_generated)


### PR DESCRIPTION
This PR adds a database migration for adding the selections table to the WP10 MariaDB database. Developers will have to migrate their development databases, and the production database migrations will also have to be run.

There is also a model added for Selection.

Fixes #374