### PR TITLE
Fix column name in created_at migration

### DIFF
--- a/db/migrations/20210706_01_4UFpC-add-created-at-timestamp-to-selections-table.py
+++ b/db/migrations/20210706_01_4UFpC-add-created-at-timestamp-to-selections-table.py
@@ -7,6 +7,6 @@ from yoyo import step
 __depends__ = {'20210705_01_TgcHL-add-selections-table'}
 
 steps = [
-    step("ALTER TABLE selections ADD COLUMN (created_at BINARY(20))",
-         "ALTER TABLE selections DROP COLUMN created_at")
+    step("ALTER TABLE selections ADD COLUMN (s_created_at BINARY(20))",
+         "ALTER TABLE selections DROP COLUMN s_created_at")
 ]

--- a/wp1/models/wp10/selection.py
+++ b/wp1/models/wp10/selection.py
@@ -1,9 +1,12 @@
 import datetime
+import logging
 
 import attr
 
 from wp1.constants import TS_FORMAT_WP10
 from wp1.timestamp import utcnow
+
+logger = logging.getLogger(__name__)
 
 
 @attr.s


### PR DESCRIPTION
Also add a logger to the Selection model, because it requires it.