### PR TITLE
New schema for Selections that respects the difference between Selections and List Builders

### DIFF
--- a/db/migrations/20210724_01_p2yUM-remove-deprecated-selections-table.py
+++ b/db/migrations/20210724_01_p2yUM-remove-deprecated-selections-table.py
@@ -1,0 +1,9 @@
+"""
+Remove deprecated selections table
+"""
+
+from yoyo import step
+
+__depends__ = {'20210706_01_4UFpC-add-created-at-timestamp-to-selections-table'}
+
+steps = [step("DROP TABLE selections")]

--- a/db/migrations/20210724_02_PR3Js-list-builders-table.py
+++ b/db/migrations/20210724_02_PR3Js-list-builders-table.py
@@ -1,0 +1,20 @@
+"""
+List builders table
+"""
+
+from yoyo import step
+
+__depends__ = {'20210724_01_p2yUM-remove-deprecated-selections-table'}
+
+steps = [
+    step(
+        "CREATE TABLE builders ("
+        "s_id INTEGER NOT NULL PRIMARY KEY AUTO_INCREMENT, "
+        "s_name VARBINARY(255) NOT NULL, "
+        "s_user_id INTEGER NOT NULL, "
+        "s_project VARBINARY(255) NOT NULL, "
+        "s_params BLOB, "
+        "s_created_at BINARY(20), "
+        "s_updated_at BINARY(20)"
+        ")", "DROP TABLE builders")
+]

--- a/db/migrations/20210724_03_C7FOH-selections-table.py
+++ b/db/migrations/20210724_03_C7FOH-selections-table.py
@@ -1,0 +1,17 @@
+"""
+Selections table
+"""
+
+from yoyo import step
+
+__depends__ = {'20210724_02_PR3Js-list-builders-table'}
+
+steps = [
+    step(
+        "CREATE TABLE selections ("
+        "s_id VARBINARY(255) NOT NULL PRIMARY KEY, "
+        "s_builder_id INTEGER NOT NULL, "
+        "s_content_type VARBINARY(255) NOT NULL, "
+        "s_updated_at BINARY(20) NOT NULL"
+        ")", "DROP TABLE selections")
+]

--- a/wp1/models/wp10/builder.py
+++ b/wp1/models/wp10/builder.py
@@ -1,0 +1,57 @@
+import datetime
+import logging
+
+import attr
+
+from wp1.constants import TS_FORMAT_WP10
+from wp1.timestamp import utcnow
+
+logger = logging.getLogger(__name__)
+
+
+@attr.s
+class Builder:
+  table_name = 'builders'
+
+  b_name = attr.ib()
+  b_user_id = attr.ib()
+  b_project = attr.ib()
+  b_params = attr.ib()
+  # The ID for Builders can be auto-assigned, so it is not required. See the migration file.
+  b_id = attr.ib(default=None)
+  b_created_at = attr.ib(default=None)
+  b_updated_at = attr.ib(default=None)
+
+  @property
+  def created_at_dt(self):
+    """The timestamp parsed into a datetime.datetime object."""
+    return datetime.datetime.strptime(self.b_created_at.decode('utf-8'),
+                                      TS_FORMAT_WP10)
+
+  def set_created_at_dt(self, dt):
+    """Sets the created_at field using a datetime.datetime object"""
+    if dt is None:
+      logger.warning('Attempt to set selection created_at to None ignored')
+      return
+    self.b_created_at = dt.strftime(TS_FORMAT_WP10).encode('utf-8')
+
+  def set_created_at_now(self):
+    """Sets the created_at field to a timestamp that is equal to now"""
+    self.set_created_at_dt(utcnow())
+
+  @property
+  def updated_at_dt(self):
+    """The timestamp parsed into a datetime.datetime object."""
+    return datetime.datetime.strptime(self.b_updated_at.decode('utf-8'),
+                                      TS_FORMAT_WP10)
+
+  def set_updated_at_dt(self, dt):
+    """Sets the updated_at field using a datetime.datetime object"""
+    if dt is None:
+      logger.warning('Attempt to set selection updated_at to None ignored')
+      return
+    self.b_updated_at = dt.strftime(TS_FORMAT_WP10).encode('utf-8')
+
+  def set_updated_at_now(self):
+    """Sets the updated_at field to a timestamp that is equal to now"""
+    self.set_updated_at_dt(utcnow())

--- a/wp1/models/wp10/builder_test.py
+++ b/wp1/models/wp10/builder_test.py
@@ -1,0 +1,61 @@
+import datetime
+from unittest.mock import patch
+
+from wp1.base_db_test import BaseWpOneDbTest
+from wp1.models.wp10.builder import Builder
+
+
+class ModelsBuilderTest(BaseWpOneDbTest):
+
+  def setUp(self):
+    super().setUp()
+    self.builder = Builder(b_name='My List',
+                           b_user_id=100,
+                           b_project='en.wikipedia.org',
+                           b_params='{}',
+                           b_created_at=b'20180929123055',
+                           b_updated_at=b'20190830112844')
+
+  def test_created_at_dt(self):
+    dt = self.builder.created_at_dt
+    self.assertEqual(2018, dt.year)
+    self.assertEqual(9, dt.month)
+    self.assertEqual(29, dt.day)
+    self.assertEqual(12, dt.hour)
+    self.assertEqual(30, dt.minute)
+    self.assertEqual(55, dt.second)
+
+  def test_set_created_at_dt(self):
+    dt = datetime.datetime(2020, 12, 15, 9, 30, 55)
+    self.builder.set_created_at_dt(dt)
+
+    self.assertEqual(b'20201215093055', self.builder.b_created_at)
+
+  @patch('wp1.models.wp10.builder.utcnow',
+         return_value=datetime.datetime(2018, 12, 25, 5, 55, 55))
+  def test_set_created_at_now(self, patched_now):
+    self.builder.set_created_at_now()
+
+    self.assertEqual(b'20181225055555', self.builder.b_created_at)
+
+  def test_updated_at_dt(self):
+    dt = self.builder.updated_at_dt
+    self.assertEqual(2019, dt.year)
+    self.assertEqual(8, dt.month)
+    self.assertEqual(30, dt.day)
+    self.assertEqual(11, dt.hour)
+    self.assertEqual(28, dt.minute)
+    self.assertEqual(44, dt.second)
+
+  def test_set_updated_at_dt(self):
+    dt = datetime.datetime(2020, 12, 15, 9, 30, 55)
+    self.builder.set_updated_at_dt(dt)
+
+    self.assertEqual(b'20201215093055', self.builder.b_updated_at)
+
+  @patch('wp1.models.wp10.builder.utcnow',
+         return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
+  def test_set_updated_at_now(self, patched_now):
+    self.builder.set_updated_at_now()
+
+    self.assertEqual(b'20191225044444', self.builder.b_updated_at)

--- a/wp1/models/wp10/selection.py
+++ b/wp1/models/wp10/selection.py
@@ -18,9 +18,9 @@ class Selection:
   s_content_type = attr.ib()
   s_updated_at = attr.ib()
 
-  # The timestamp parsed into a datetime.datetime object.
   @property
   def updated_at_dt(self):
+    """The timestamp parsed into a datetime.datetime object."""
     return datetime.datetime.strptime(self.s_updated_at.decode('utf-8'),
                                       TS_FORMAT_WP10)
 

--- a/wp1/models/wp10/selection.py
+++ b/wp1/models/wp10/selection.py
@@ -13,30 +13,24 @@ logger = logging.getLogger(__name__)
 class Selection:
   table_name = 'selections'
 
-  s_name = attr.ib()
-  s_user_id = attr.ib()
-  s_project = attr.ib()
-  s_id = attr.ib(default=None)
-  s_hash = attr.ib(default=None)
-  s_model = attr.ib(default=None)
-  s_region = attr.ib(default=None)
-  s_bucket = attr.ib(default=None)
-  s_object_key = attr.ib(default=None)
-  s_last_generated = attr.ib(default=None)
+  s_id = attr.ib()
+  s_builder_id = attr.ib()
+  s_content_type = attr.ib()
+  s_updated_at = attr.ib()
 
   # The timestamp parsed into a datetime.datetime object.
   @property
-  def last_generated_dt(self):
-    return datetime.datetime.strptime(self.s_last_generated.decode('utf-8'),
+  def updated_at_dt(self):
+    return datetime.datetime.strptime(self.s_updated_at.decode('utf-8'),
                                       TS_FORMAT_WP10)
 
-  def set_last_generated_dt(self, dt):
-    """Sets the last_generated field using a datetime.datetime object"""
+  def set_updated_at_dt(self, dt):
+    """Sets the updated_at field using a datetime.datetime object"""
     if dt is None:
-      logger.warning('Attempt to set selection last_generated to None ignored')
+      logger.warning('Attempt to set selection updated_at to None ignored')
       return
-    self.s_last_generated = dt.strftime(TS_FORMAT_WP10).encode('utf-8')
+    self.s_updated_at = dt.strftime(TS_FORMAT_WP10).encode('utf-8')
 
-  def set_last_generated_now(self):
-    """Sets the last_generated field to a timestamp that is equal to now"""
-    self.set_last_generated_dt(utcnow())
+  def set_updated_at_now(self):
+    """Sets the updated_at field to a timestamp that is equal to now"""
+    self.set_updated_at_dt(utcnow())

--- a/wp1/models/wp10/selection_test.py
+++ b/wp1/models/wp10/selection_test.py
@@ -9,29 +9,29 @@ class ModelsSelectionTest(BaseWpOneDbTest):
 
   def setUp(self):
     super().setUp()
-    self.selection = Selection(s_name='My List',
-                               s_user_id=100,
-                               s_project='en.wikipedia.org',
-                               s_last_generated=b'20180929123055')
+    self.selection = Selection(s_id='deadbeef',
+                               s_builder_id=100,
+                               s_content_type='text/tab-separated-values',
+                               s_updated_at=b'20190830112844')
 
-  def test_last_generated_dt(self):
-    dt = self.selection.last_generated_dt
-    self.assertEqual(2018, dt.year)
-    self.assertEqual(9, dt.month)
-    self.assertEqual(29, dt.day)
-    self.assertEqual(12, dt.hour)
-    self.assertEqual(30, dt.minute)
-    self.assertEqual(55, dt.second)
+  def test_updated_at_dt(self):
+    dt = self.selection.updated_at_dt
+    self.assertEqual(2019, dt.year)
+    self.assertEqual(8, dt.month)
+    self.assertEqual(30, dt.day)
+    self.assertEqual(11, dt.hour)
+    self.assertEqual(28, dt.minute)
+    self.assertEqual(44, dt.second)
 
-  def test_set_last_generated_dt(self):
+  def test_set_updated_at_dt(self):
     dt = datetime.datetime(2020, 12, 15, 9, 30, 55)
-    self.selection.set_last_generated_dt(dt)
+    self.selection.set_updated_at_dt(dt)
 
-    self.assertEqual(b'20201215093055', self.selection.s_last_generated)
+    self.assertEqual(b'20201215093055', self.selection.s_updated_at)
 
   @patch('wp1.models.wp10.selection.utcnow',
-         return_value=datetime.datetime(2018, 12, 25, 5, 55, 55))
-  def test_set_last_generated_now(self, patched_now):
-    self.selection.set_last_generated_now()
+         return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
+  def test_set_updated_at_now(self, patched_now):
+    self.selection.set_updated_at_now()
 
-    self.assertEqual(b'20181225055555', self.selection.s_last_generated)
+    self.assertEqual(b'20191225044444', self.selection.s_updated_at)


### PR DESCRIPTION
This PR includes a migration that removes the old selections table, since it conflates the ideas of list builders and selections as discussed in #370. The PR further creates both a table for list builders (named just "builders") which the user can input and save, and selections, which are materialized lists of articles that are generated from builders but stored in the s3-like backend.

There is a one-to-many relationship between builders and selections, in that many selections (presumably of different content types) can be generated from a builder.

This PR also provides basic `attrs` based classes for modeling the data in these tables.