### PR TITLE
AbstractBuilder with tests

### DIFF
--- a/db/migrations/20210728_01_eJYGE-add-model-to-builders.py
+++ b/db/migrations/20210728_01_eJYGE-add-model-to-builders.py
@@ -1,0 +1,12 @@
+"""
+Add model to builders
+"""
+
+from yoyo import step
+
+__depends__ = {'20210724_03_C7FOH-selections-table'}
+
+steps = [
+    step("ALTER TABLE builders ADD COLUMN (b_model VARBINARY(255) NOT NULL)",
+         "ALTER TABLE builders DROP COLUMN b_model")
+]

--- a/wp1/constants.py
+++ b/wp1/constants.py
@@ -34,3 +34,7 @@ WIKI_BASE = 'https://en.wikipedia.org/wiki/'
 FRONTEND_WIKI_BASE = 'https://en.wikipedia.org/w/'
 
 PAGE_SIZE = 100
+
+CONTENT_TYPE_TO_EXT = {
+    'text/tab-seperated-values': 'tsv',
+}

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -1,5 +1,7 @@
 import urllib.parse
 
+import attr
+
 
 def validate_list(items):
   item_list = items.split("\n")
@@ -29,3 +31,13 @@ def validate_list(items):
           "").replace("https://en.wikipedia.org/w/index.php?title=", "")
       valid_article_names.append(article_name)
   return (valid_article_names, invalid_article_names, forbiden_chars)
+
+
+def insert_selection(wp10db, selection):
+  with wp10db.cursor() as cursor:
+    cursor.execute(
+        '''INSERT INTO selections
+      (s_id, s_builder_id, s_content_type, s_updated_at)
+      VALUES (%(s_id)s, %(s_builder_id)s, %(s_content_type)s, %(s_updated_at)s)
+    ''', attr.asdict(selection))
+  wp10db.commit()

--- a/wp1/models/wp10/builder.py
+++ b/wp1/models/wp10/builder.py
@@ -16,6 +16,7 @@ class Builder:
   b_name = attr.ib()
   b_user_id = attr.ib()
   b_project = attr.ib()
+  b_model = attr.ib()
   b_params = attr.ib()
   # The ID for Builders can be auto-assigned, so it is not required. See the migration file.
   b_id = attr.ib(default=None)

--- a/wp1/models/wp10/builder_test.py
+++ b/wp1/models/wp10/builder_test.py
@@ -12,6 +12,7 @@ class ModelsBuilderTest(BaseWpOneDbTest):
     self.builder = Builder(b_name='My List',
                            b_user_id=100,
                            b_project='en.wikipedia.org',
+                           b_model='wp1.selection.models.simple',
                            b_params='{}',
                            b_created_at=b'20180929123055',
                            b_updated_at=b'20190830112844')

--- a/wp1/models/wp10/selection.py
+++ b/wp1/models/wp10/selection.py
@@ -4,7 +4,7 @@ import uuid
 
 import attr
 
-from wp1.constants import TS_FORMAT
+from wp1.constants import TS_FORMAT_WP10
 from wp1.timestamp import utcnow
 
 logger = logging.getLogger(__name__)
@@ -24,18 +24,18 @@ class Selection:
   def updated_at_dt(self):
     """The timestamp parsed into a datetime.datetime object."""
     return datetime.datetime.strptime(self.s_updated_at.decode('utf-8'),
-                                      TS_FORMAT)
+                                      TS_FORMAT_WP10)
 
   def set_updated_at_dt(self, dt):
     """Sets the updated_at field using a datetime.datetime object"""
     if dt is None:
       logger.warning('Attempt to set selection updated_at to None ignored')
       return
-    self.s_updated_at = dt.strftime(TS_FORMAT).encode('utf-8')
+    self.s_updated_at = dt.strftime(TS_FORMAT_WP10).encode('utf-8')
 
   def set_updated_at_now(self):
     """Sets the updated_at field to a timestamp that is equal to now"""
     self.set_updated_at_dt(utcnow())
 
   def set_id(self):
-    self.s_id = str(uuid.uuid4()).encode('utf-8')
+    self.s_id = str(uuid.uuid4()).encode()

--- a/wp1/models/wp10/selection.py
+++ b/wp1/models/wp10/selection.py
@@ -19,6 +19,8 @@ class Selection:
   # This is required, but is set by the set_id method below.
   s_id = attr.ib(default=None)
   s_updated_at = attr.ib(default=None)
+  # The data that is stored in the backend s3-like storage. Not saved to the database.
+  data = attr.ib(default=None)
 
   @property
   def updated_at_dt(self):

--- a/wp1/models/wp10/selection.py
+++ b/wp1/models/wp10/selection.py
@@ -1,9 +1,10 @@
 import datetime
 import logging
+import uuid
 
 import attr
 
-from wp1.constants import TS_FORMAT_WP10
+from wp1.constants import TS_FORMAT
 from wp1.timestamp import utcnow
 
 logger = logging.getLogger(__name__)
@@ -13,24 +14,28 @@ logger = logging.getLogger(__name__)
 class Selection:
   table_name = 'selections'
 
-  s_id = attr.ib()
   s_builder_id = attr.ib()
   s_content_type = attr.ib()
-  s_updated_at = attr.ib()
+  # This is required, but is set by the set_id method below.
+  s_id = attr.ib(default=None)
+  s_updated_at = attr.ib(default=None)
 
   @property
   def updated_at_dt(self):
     """The timestamp parsed into a datetime.datetime object."""
     return datetime.datetime.strptime(self.s_updated_at.decode('utf-8'),
-                                      TS_FORMAT_WP10)
+                                      TS_FORMAT)
 
   def set_updated_at_dt(self, dt):
     """Sets the updated_at field using a datetime.datetime object"""
     if dt is None:
       logger.warning('Attempt to set selection updated_at to None ignored')
       return
-    self.s_updated_at = dt.strftime(TS_FORMAT_WP10).encode('utf-8')
+    self.s_updated_at = dt.strftime(TS_FORMAT).encode('utf-8')
 
   def set_updated_at_now(self):
     """Sets the updated_at field to a timestamp that is equal to now"""
     self.set_updated_at_dt(utcnow())
+
+  def set_id(self):
+    self.s_id = str(uuid.uuid4()).encode('utf-8')

--- a/wp1/selection/abstract_builder.py
+++ b/wp1/selection/abstract_builder.py
@@ -1,0 +1,41 @@
+import io
+import json
+
+from wp1.constants import CONTENT_TYPE_TO_EXT
+import wp1.logic.selection as logic_selection
+from wp1.models.wp10.selection import Selection
+
+
+class AbstractBuilder:
+
+  def _upload_to_storage(self, s3, selection, builder):
+    ext = CONTENT_TYPE_TO_EXT.get(selection.s_content_type, '').encode('utf-8')
+    object_key = b'selection/%(model)s/%(user_id)s/%(id)s.%(ext)s' % {
+        b'model': builder.b_model,
+        b'user_id': bytes(builder.b_user_id),
+        b'id': selection.s_id,
+        b'ext': ext,
+    }
+
+    upload_data = io.BytesIO()
+    upload_data.write(selection.data)
+    upload_data.seek(0)
+    s3.upload_fileobj(upload_data, key=object_key.decode('utf-8'))
+
+  def materialize(self, s3, wp10db, builder, content_type):
+    params = json.loads(builder.b_params)
+
+    selection = Selection(s_content_type=content_type,
+                          s_builder_id=builder.b_id)
+    selection.set_id()
+    selection.data = self.build(content_type, **params)
+    selection.set_updated_at_now()
+    self._upload_to_storage(s3, selection, builder)
+
+    logic_selection.insert_selection(wp10db, selection)
+
+  def build(self, content_type, **params):
+    raise NotImplementedError()
+
+  def validate(self, **params):
+    raise NotImplementedError()

--- a/wp1/selection/abstract_builder_test.py
+++ b/wp1/selection/abstract_builder_test.py
@@ -41,7 +41,7 @@ class AbstractBuilderTest(BaseWpOneDbTest):
     self.assertEqual(actual.s_builder_id, 100)
 
   @patch('wp1.models.wp10.selection.uuid.uuid4', return_value='abcd-1234')
-  def test_materialize_selection_id(self, mock_setid):
+  def test_materialize_selection_id(self, mock_uuid4):
     self.test_builder.materialize(self.s3, self.wp10db, self.builder,
                                   'text/tab-separated-values')
     actual = _get_first_selection(self.wp10db)

--- a/wp1/selection/abstract_builder_test.py
+++ b/wp1/selection/abstract_builder_test.py
@@ -53,7 +53,7 @@ class AbstractBuilderTest(BaseWpOneDbTest):
     self.test_builder.materialize(self.s3, self.wp10db, self.builder,
                                   'text/tab-separated-values')
     actual = _get_first_selection(self.wp10db)
-    self.assertEqual(actual.s_updated_at, b'2020-12-25T10:55:44Z')
+    self.assertEqual(actual.s_updated_at, b'20201225105544\00\00\00\00\00\00')
 
   def test_materialize_uploads_to_s3(self):
     self.test_builder.materialize(self.s3, self.wp10db, self.builder,

--- a/wp1/selection/abstract_builder_test.py
+++ b/wp1/selection/abstract_builder_test.py
@@ -1,0 +1,62 @@
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from wp1.base_db_test import BaseWpOneDbTest
+from wp1.models.wp10.builder import Builder
+from wp1.models.wp10.selection import Selection
+from wp1.selection.abstract_builder import AbstractBuilder
+
+
+def _get_first_selection(wp10db):
+  with wp10db.cursor() as cursor:
+    cursor.execute('SELECT * from selections LIMIT 1')
+    db_selection = cursor.fetchone()
+    return Selection(**db_selection)
+
+
+class TestBuilder(AbstractBuilder):
+
+  def build(self, content_type, **params):
+    return '\n'.join(params['list']).encode('utf-8')
+
+
+class AbstractBuilderTest(BaseWpOneDbTest):
+
+  def setUp(self):
+    super().setUp()
+    self.s3 = MagicMock()
+    self.test_builder = TestBuilder()
+    self.builder = Builder(b_id=100,
+                           b_name=b'My Builder',
+                           b_user_id=1234,
+                           b_project=b'en.wikipedia.fake',
+                           b_model=b'wp1.selection.models.simple',
+                           b_params='{"list":["a","b","c"]}')
+
+  def test_materialize_creates_selection(self):
+    self.test_builder.materialize(self.s3, self.wp10db, self.builder,
+                                  'text/tab-separated-values')
+    actual = _get_first_selection(self.wp10db)
+    self.assertEqual(actual.s_content_type, b'text/tab-separated-values')
+    self.assertEqual(actual.s_builder_id, 100)
+
+  @patch('wp1.models.wp10.selection.uuid.uuid4', return_value='abcd-1234')
+  def test_materialize_selection_id(self, mock_setid):
+    self.test_builder.materialize(self.s3, self.wp10db, self.builder,
+                                  'text/tab-separated-values')
+    actual = _get_first_selection(self.wp10db)
+    self.assertEqual(actual.s_id, b'abcd-1234')
+
+  @patch('wp1.models.wp10.selection.utcnow',
+         return_value=datetime(2020, 12, 25, 10, 55, 44))
+  def test_materialize_selection_updated_at(self, mock_utcnow):
+    self.test_builder.materialize(self.s3, self.wp10db, self.builder,
+                                  'text/tab-separated-values')
+    actual = _get_first_selection(self.wp10db)
+    self.assertEqual(actual.s_updated_at, b'2020-12-25T10:55:44Z')
+
+  def test_materialize_uploads_to_s3(self):
+    self.test_builder.materialize(self.s3, self.wp10db, self.builder,
+                                  'text/tab-separated-values')
+    data = self.s3.upload_fileobj.call_args[0][0]
+    self.assertEqual(b'a\nb\nc', data.read())

--- a/wp10_test.down.sql
+++ b/wp10_test.down.sql
@@ -8,3 +8,5 @@ DROP TABLE IF EXISTS `releases`;
 DROP TABLE IF EXISTS `global_articles`;
 DROP TABLE IF EXISTS `global_rankings`;
 DROP TABLE IF EXISTS `users`;
+DROP TABLE IF EXISTS `builders`;
+DROP TABLE IF EXISTS `selections`;

--- a/wp10_test.up.sql
+++ b/wp10_test.up.sql
@@ -92,6 +92,24 @@ CREATE TABLE `users` (
   `u_username` varchar(255) DEFAULT NULL
 );
 
+CREATE TABLE `builders` (
+  s_id INTEGER NOT NULL PRIMARY KEY AUTO_INCREMENT,
+  s_name VARBINARY(255) NOT NULL,
+  s_user_id INTEGER NOT NULL,
+  s_project VARBINARY(255) NOT NULL,
+  s_model VARBINARY(255) NOT NULL,
+  s_params BLOB,
+  s_created_at BINARY(20),
+  s_updated_at BINARY(20)
+);
+
+CREATE TABLE `selections` (
+  s_id VARBINARY(255) NOT NULL PRIMARY KEY,
+  s_builder_id INTEGER NOT NULL,
+  s_content_type VARBINARY(255) NOT NULL,
+  s_updated_at BINARY(20) NOT NULL
+);
+
 INSERT INTO `global_rankings` (gr_type, gr_rating, gr_ranking) VALUES ('importance', 'Unknown-Class', 0);
 INSERT INTO `global_rankings` (gr_type, gr_rating, gr_ranking) VALUES ('importance', 'NA-Class', 50);
 INSERT INTO `global_rankings` (gr_type, gr_rating, gr_ranking) VALUES ('importance', 'Low-Class', 100);


### PR DESCRIPTION
Includes database migration to add b_model to builders table and necessary test schema files.

This code doesn't do much on it's own, but provides an interface for a subclass to implement the not-implemented build method. Given such an implementation, and when passed a valid builder and a content type, the AbstractBuilder materialize method will build the selection from the builder and store the resultant selection list in s3. It will also save a Selection record in the WP 1.0 database for the selection list.

Fixes #394