### PR TITLE
Setup backend storage (s3-like) for web app

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,10 @@ appdirs==1.4.4
 arrow==0.14.5
 aspy.yaml==1.3.0
 attrs==18.2.0
+aws-requests-auth==0.4.3
 blinker==1.4
+boto3==1.17.101
+botocore==1.20.101
 cachelib==0.1.1
 certifi==2018.11.29
 cfgv==2.0.1
@@ -23,6 +26,8 @@ idna==2.8
 importlib-metadata==0.19
 itsdangerous==1.1.0
 Jinja2==2.11.3
+jmespath==0.10.0
+kiwixstorage==0.8
 MarkupSafe==1.1.1
 meld3==1.0.2
 more-itertools==7.2.0
@@ -42,6 +47,7 @@ requests==2.25.1
 requests-oauthlib==1.0.0
 rq==1.1.0
 rq-dashboard==0.5.2
+s3transfer==0.4.2
 six==1.12.0
 sortedcontainers==2.1.0
 sqlparse==0.4.1

--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -77,6 +77,15 @@ CREDENTIALS = {
             'domains': ['http://localhost:3000'],
             'homepage': 'http://localhost:3000/#/',
         },
+
+        # Configuration for the storage backend for storing selection lists.
+        # See https://github.com/openzim/zimfarm/wiki/S3-Cache-Policy for how to
+        # get these credentials.
+        'STORAGE': {
+            'key': '',
+            'secret': '',
+            'bucket': 'org-kiwix-dev-wp1',
+        },
     },
 
     # EDIT: Remove the next line after you've provided actual credentials.
@@ -135,5 +144,12 @@ CREDENTIALS = {
     #   'CLIENT_URL': {
     #       'domains': ['http://wp1.openzim.org', 'https://wp1.openzim.org'],
     #       'homepage': 'https://wp1.openzim.org/#/',
-    #   }
+    #   },
+
+    # Configuration for the storage backend for storing selection lists.
+    #   'STORAGE': {
+    #       'key': '', # EDIT this line for production.
+    #       'secret': '', # EDIT this line for production.
+    #       'bucket': 'org-kiwix-wp1',
+    #   },
 }

--- a/wp1/web/base_web_testcase.py
+++ b/wp1/web/base_web_testcase.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 import unittest
+from unittest.mock import MagicMock
 
 from flask import appcontext_pushed, g
 import fakeredis
@@ -101,5 +102,14 @@ class BaseWebTestcase(unittest.TestCase):
       with appcontext_pushed.connected_to(handler, app):
         yield
 
-    with set_wiki_db(), set_wp10_db(), set_redis():
+    @contextmanager
+    def set_storage():
+
+      def handler(sender, **kwargs):
+        g.storage = MagicMock()
+
+      with appcontext_pushed.connected_to(handler, app):
+        yield
+
+    with set_wiki_db(), set_wp10_db(), set_redis(), set_storage():
       yield

--- a/wp1/web/storage.py
+++ b/wp1/web/storage.py
@@ -1,0 +1,34 @@
+import logging
+
+import flask
+from kiwixstorage import KiwixStorage
+
+logger = logging.getLogger(__name__)
+
+try:
+  from wp1.credentials import CREDENTIALS, ENV
+except ImportError:
+  logger.exception('The file credentials.py must be populated manually in '
+                   'order to connect to the backend storage system.')
+  CREDENTIALS = None
+  ENV = None
+
+
+def has_storage():
+  return hasattr(flask.g, 'storage')
+
+
+def get_storage():
+  if not has_storage():
+    if CREDENTIALS is None or ENV is None or CREDENTIALS[ENV].get(
+        'STORAGE') is None:
+      raise ValueError('storage (s3) credentials in ENV=%s are None' % ENV)
+    creds = CREDENTIALS[ENV]['STORAGE']
+    connect_str = (
+        'https://s3.us-west-1.wasabisys.com/'
+        '?keyId=%(key)s&secretAccessKey=%(secret)s&bucketName=%(bucket)s' %
+        creds)
+    s3 = KiwixStorage(connect_str)
+    s3.check_credentials(list_buckets=True, bucket=True, write=True, read=True)
+    setattr(flask.g, 'storage', s3)
+  return getattr(flask.g, 'storage')

--- a/wp1/web/storage_test.py
+++ b/wp1/web/storage_test.py
@@ -111,7 +111,7 @@ class StorageTest(BaseWebTestcase):
   @patch('wp1.web.storage.ENV', Environment.DEVELOPMENT)
   @patch('wp1.web.storage.KiwixStorage')
   def test_get_storage_sets_storage(self, patched_kiwixstorage):
-    with self.app.app_context() as ctx:
+    with self.app.app_context():
       actual = get_storage()
       self.assertTrue(hasattr(flask.g, 'storage'))
 
@@ -130,6 +130,6 @@ class StorageTest(BaseWebTestcase):
   def test_get_storage_returns_s3_from_kiwixstorage(self, patched_kiwixstorage):
     s3_mock = MagicMock()
     patched_kiwixstorage.return_value = s3_mock
-    with self.app.app_context() as ctx:
+    with self.app.app_context():
       actual = get_storage()
       self.assertEqual(s3_mock, actual)

--- a/wp1/web/storage_test.py
+++ b/wp1/web/storage_test.py
@@ -1,0 +1,135 @@
+from unittest.mock import patch, MagicMock
+
+import flask
+
+from wp1.environment import Environment
+from wp1.web.base_web_testcase import BaseWebTestcase
+from wp1.web.storage import has_storage, get_storage
+
+
+class StorageTest(BaseWebTestcase):
+
+  def test_has_storage_empty(self):
+    with self.app.app_context():
+      self.assertFalse(has_storage())
+
+  def test_has_storage_exists(self):
+    with self.override_db(self.app), self.app.app_context():
+      self.assertTrue(has_storage())
+
+  def test_does_not_connect_if_no_creds(self):
+    with self.app.app_context():
+      with self.assertRaises(ValueError):
+        actual = get_storage()
+
+  @patch('wp1.web.storage.KiwixStorage')
+  def test_get_storage_does_not_connect_if_existing(self, patched_kiwixstorage):
+    with self.override_db(self.app), self.app.app_context():
+      actual = get_storage()
+      patched_kiwixstorage.assert_not_called()
+
+  @patch(
+      'wp1.web.storage.CREDENTIALS', {
+          Environment.DEVELOPMENT: {
+              'STORAGE': {
+                  'key': 'test_key',
+                  'secret': 'test_secret',
+                  'bucket': 'org-kiwix-dev-wp1',
+              }
+          }
+      })
+  def test_get_storage_raises_if_no_env(self):
+    with self.app.app_context():
+      with self.assertRaises(ValueError):
+        actual = get_storage()
+
+  @patch('wp1.web.storage.ENV', Environment.DEVELOPMENT)
+  def test_get_storage_raises_if_no_credentials(self):
+    with self.app.app_context():
+      with self.assertRaises(ValueError):
+        actual = get_storage()
+
+  @patch('wp1.web.storage.CREDENTIALS', {Environment.DEVELOPMENT: {}})
+  @patch('wp1.web.storage.ENV', Environment.DEVELOPMENT)
+  def test_get_storage_raises_if_no_storage_key(self):
+    with self.app.app_context():
+      with self.assertRaises(ValueError):
+        actual = get_storage()
+
+  @patch(
+      'wp1.web.storage.CREDENTIALS', {
+          Environment.DEVELOPMENT: {
+              'STORAGE': {
+                  'key': 'test_key',
+                  'secret': 'test_secret',
+                  'bucket': 'org-kiwix-dev-wp1',
+              }
+          }
+      })
+  @patch('wp1.web.storage.ENV', Environment.DEVELOPMENT)
+  @patch('wp1.web.storage.KiwixStorage')
+  def test_get_storage_connects_to_kiwixstorage(self, patched_kiwixstorage):
+    with self.app.app_context():
+      actual = get_storage()
+      patched_kiwixstorage.assert_called_once_with(
+          'https://s3.us-west-1.wasabisys.com/'
+          '?keyId=test_key&secretAccessKey=test_secret&bucketName=org-kiwix-dev-wp1'
+      )
+
+  @patch(
+      'wp1.web.storage.CREDENTIALS', {
+          Environment.DEVELOPMENT: {
+              'STORAGE': {
+                  'key': 'test_key',
+                  'secret': 'test_secret',
+                  'bucket': 'org-kiwix-dev-wp1',
+              }
+          }
+      })
+  @patch('wp1.web.storage.ENV', Environment.DEVELOPMENT)
+  @patch('wp1.web.storage.KiwixStorage')
+  def test_get_storage_checks_permissions(self, patched_kiwixstorage):
+    s3_mock = MagicMock()
+    patched_kiwixstorage.return_value = s3_mock
+    with self.app.app_context():
+      actual = get_storage()
+      s3_mock.check_credentials.assert_called_once_with(list_buckets=True,
+                                                        bucket=True,
+                                                        write=True,
+                                                        read=True)
+
+  @patch(
+      'wp1.web.storage.CREDENTIALS', {
+          Environment.DEVELOPMENT: {
+              'STORAGE': {
+                  'key': 'test_key',
+                  'secret': 'test_secret',
+                  'bucket': 'org-kiwix-dev-wp1',
+              }
+          }
+      })
+  @patch('wp1.web.storage.ENV', Environment.DEVELOPMENT)
+  @patch('wp1.web.storage.KiwixStorage')
+  def test_get_storage_sets_storage(self, patched_kiwixstorage):
+    with self.app.app_context() as ctx:
+      actual = get_storage()
+      self.assertTrue(hasattr(flask.g, 'storage'))
+
+  @patch(
+      'wp1.web.storage.CREDENTIALS', {
+          Environment.DEVELOPMENT: {
+              'STORAGE': {
+                  'key': 'test_key',
+                  'secret': 'test_secret',
+                  'bucket': 'org-kiwix-dev-wp1',
+              }
+          }
+      })
+  @patch('wp1.web.storage.ENV', Environment.DEVELOPMENT)
+  @patch('wp1.web.storage.KiwixStorage')
+  def test_get_storage_returns_s3_from_kiwixstorage(self, patched_kiwixstorage):
+    s3_mock = MagicMock()
+    patched_kiwixstorage.return_value = s3_mock
+    with self.app.app_context() as ctx:
+      actual = get_storage()
+      self.assertEqual(s3_mock, actual)


### PR DESCRIPTION
This PR creates sample entries in credentials.py.example for Development and Production for the s3 storage backend. It also provides a way to get the storage from the web frontend, as well as a way to mock that storage backend in web tests.