### PR TITLE
Methods for enqueuing the materialization of a builder

### DIFF
--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -1,9 +1,13 @@
 import json
+import logging
 
 import attr
 
 from wp1.models.wp10.builder import Builder
+from wp1.storage import connect_storage
 from wp1.wp10_db import connect as wp10_connect
+
+logger = logging.getLogger(__name__)
 
 
 def save_builder(wp10db, name, user_id, project, articles):
@@ -26,3 +30,25 @@ def insert_builder(wp10db, builder):
         VALUES (%(b_name)s, %(b_user_id)s, %(b_project)s, %(b_params)s, %(b_model)s, %(b_created_at)s, %(b_updated_at)s)
       ''', attr.asdict(builder))
   wp10db.commit()
+
+
+def get_builder(wp10db, id_):
+  with wp10db.cursor() as cursor:
+    cursor.execute('SELECT * FROM builders WHERE b_id = %s', id_)
+    db_builder = cursor.fetchone()
+    return Builder(**db_builder)
+
+
+def materialize_builder(builder_cls, builder_id, content_type):
+  wp10db = wp10_connect()
+  s3 = connect_storage()
+  logging.basicConfig(level=logging.INFO)
+
+  try:
+    builder = get_builder(wp10db, builder_id)
+    materializer = builder_cls()
+    logger.info('Materializing builder id=%s, content_type=%s with class=%s' %
+                (builder_id, content_type, builder_cls))
+    materializer.materialize(s3, wp10db, builder, content_type)
+  finally:
+    wp10db.close()

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -1,4 +1,3 @@
-import attr
 import datetime
 from unittest.mock import patch, MagicMock, ANY
 

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -102,7 +102,7 @@ class BuilderTest(BaseWpOneDbTest):
   def test_insert_builder(self, mock_utcnow):
     insert_builder(self.wp10db, self.builder)
     db_lists = self._get_builder_by_user_id()
-    self.assertEqual(self.expected, db_lists)
+    self.assertEqual(self.expected_builder, db_lists)
 
   def test_get_builder(self):
     id_ = self._insert_builder()
@@ -137,7 +137,7 @@ class BuilderTest(BaseWpOneDbTest):
   def test_get_lists(self, mock_utcnow):
     with self.wp10db.cursor() as cursor:
       cursor.execute(
-          '''INSERT INTO selections VALUES (1, 1, 'tsv', '20191225044444')''')
+          'INSERT INTO selections VALUES (1, 1, "tsv", "20191225044444")')
       cursor.execute(
           '''INSERT INTO builders
         (b_name, b_user_id, b_project, b_params, b_model, b_created_at, b_updated_at)
@@ -152,9 +152,9 @@ class BuilderTest(BaseWpOneDbTest):
   def test_get_lists_with_multiple_selections(self, mock_utcnow):
     with self.wp10db.cursor() as cursor:
       cursor.execute(
-          '''INSERT INTO selections VALUES (1, 1, 'tsv', '20191225044444')''')
+          'INSERT INTO selections VALUES (1, 1, "tsv", "20191225044444")')
       cursor.execute(
-          '''INSERT INTO selections VALUES (2, 1, "xls", '20201225105544')''')
+          'INSERT INTO selections VALUES (2, 1, "xls", "20201225105544")')
       cursor.execute(
           '''INSERT INTO builders
         (b_name, b_user_id, b_project, b_params,
@@ -184,7 +184,7 @@ class BuilderTest(BaseWpOneDbTest):
   def test_get_empty_lists(self, mock_utcnow):
     with self.wp10db.cursor() as cursor:
       cursor.execute(
-          '''INSERT INTO selections VALUES (1, 1, 'tsv', '20191225044444')''')
+          'INSERT INTO selections VALUES (1, 1, "tsv", "20191225044444")')
       cursor.execute(
           '''INSERT INTO builders
         (b_name, b_user_id, b_project, b_params, b_model, b_created_at, b_updated_at)
@@ -199,6 +199,6 @@ class BuilderTest(BaseWpOneDbTest):
   def test_get_lists_with_no_builders(self, mock_utcnow):
     with self.wp10db.cursor() as cursor:
       cursor.execute(
-          '''INSERT INTO selections VALUES (1, 1, 'tsv', '20191225044444')''')
+          'INSERT INTO selections VALUES (1, 1, "tsv", "20191225044444")')
     article_data = get_lists(self.wp10db, '0000')
     self.assertEqual([], article_data)

--- a/wp1/logs_test.py
+++ b/wp1/logs_test.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from datetime import datetime
-from unittest.mock import patch, ANY
+from unittest.mock import patch
 
 import attr
 


### PR DESCRIPTION
This PR provides methods in `queues.py` for materializing a builder given the ID of the builder in the db, the class to use for materialization, and the content_type that is desired.

Fixes #405 