### PR TITLE
Use new dev-workers image in dev docker compose graph

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -70,6 +70,10 @@ jobs:
         run: |
           cd wp1-frontend && yarn
 
+      - name: Copy credentials
+        run: |
+          cp wp1/credentials.py.e2e wp1/credentials.py
+
       - name: Start Docker dev services
         run: docker-compose -f docker-compose-dev.yml up -d --build
 
@@ -84,7 +88,6 @@ jobs:
           FLASK_APP: wp1.web.app
           FLASK_DEBUG: 1
         run: |
-          cp wp1/credentials.py.e2e wp1/credentials.py
           python -m flask run &
           cd wp1-frontend
           $(yarn bin)/wait-on http://localhost:5000/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ cookies.txt
 # Don't commit test artifacts
 **/cypress/videos
 **/cypress/screenshots
+
+# Don't commit logs
+log/**

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -17,7 +17,7 @@ services:
   dev-workers:
     build:
       context: .
-      dockerfile: workers.Dockerfile
+      dockerfile: docker/dev-workers/Dockerfile
     container_name: wp1bot-workers-dev
     volumes:
       - ./wp1/credentials.py:/usr/src/app/wp1/credentials.py

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -14,6 +14,20 @@ services:
       - '6300:3306'
     restart: always
 
+  dev-workers:
+    build:
+      context: .
+      dockerfile: workers.Dockerfile
+    container_name: wp1bot-workers-dev
+    volumes:
+      - ./wp1/credentials.py:/usr/src/app/wp1/credentials.py
+      - ./log/:/var/log/wp1bot/
+    links:
+      - redis
+    restart: always
+    depends_on:
+      - redis
+
 networks:
   default:
     name: dev.openzim.org

--- a/docker/dev-workers/Dockerfile
+++ b/docker/dev-workers/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.9
+
+# Meta
+LABEL maintainer="kiwix"
+
+# Python app
+WORKDIR /usr/src
+COPY . app
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends cron && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+RUN pip3 install --no-cache-dir -r app/requirements.txt
+
+# Start
+CMD supervisord -c /usr/src/app/supervisord-dev.conf -n

--- a/docker/dev-workers/Dockerfile
+++ b/docker/dev-workers/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update && \
   apt-get install -y --no-install-recommends cron && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
+
+# hadolint ignore=DL3059
 RUN pip3 install --no-cache-dir -r app/requirements.txt
 
 # Start

--- a/docker/dev-workers/README.md
+++ b/docker/dev-workers/README.md
@@ -1,0 +1,8 @@
+# Dev Workers Dockerfile
+
+This file represents a version of the workers image to be used in development. It only
+starts a worker for materializing selection results from builders, and does not contain
+any cron commands.
+
+This image uses `supervisord-dev.conf` in the root directory, as opposed to the real
+workers image which uses simply `supervisord.conf`.

--- a/supervisord-dev.conf
+++ b/supervisord-dev.conf
@@ -1,0 +1,45 @@
+
+[unix_http_server]
+file=/tmp/supervisor.sock   ; the path to the socket file
+
+[supervisord]
+logfile=/var/log/wp1bot/supervisord.log ; main log file; default $CWD/supervisord.log
+logfile_maxbytes=50MB        ; max main logfile bytes b4 rotation; default 50MB
+logfile_backups=10           ; # of main logfile backups; 0 means none, default 10
+loglevel=debug                ; log level; default info; others: debug,warn,trace
+pidfile=/tmp/supervisord.pid ; supervisord pidfile; default supervisord.pid
+nodaemon=false               ; start in foreground if true; default false
+minfds=1024                  ; min. avail startup file descriptors; default 1024
+minprocs=200                 ; min. avail process descriptors;default 200
+childlogdir=/tmp            ; 'AUTO' child log dir, default $TEMP
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[program:wp1-materializer]
+; In the docker-compose world, the redis host is just 'redis'
+command=/usr/local/bin/rq worker -u redis://redis --queue-class rate_limit_queue.RateLimitQueue materializer
+; process_num is required if you specify >1 numprocs
+process_name=materializer-%(process_num)s
+
+; If you want to run more than one materializer instance, increase this.
+numprocs=1
+
+; This is the directory from which RQ is run. Be sure to point this to the
+; directory where your source code is importable from
+directory=/usr/src/app
+
+redirect_stderr=true
+stdout_logfile=/var/log/wp1bot/%(program_name)s-%(process_num)s.log
+stdout_logfile_maxbytes=100MB
+stdout_logfile_backups=5
+
+; RQ requires the TERM signal to perform a warm shutdown. If RQ does not die
+; within 10 seconds, supervisor will forcefully kill it
+stopsignal=TERM
+autostart=true
+autorestart=true

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -180,7 +180,7 @@ command=/usr/local/bin/rq worker -u redis://redis --queue-class rate_limit_queue
 ; process_num is required if you specify >1 numprocs
 process_name=materializer-%(process_num)s
 
-; If you want to run more than one worker instance, increase this
+; If you want to run more than one materializer instance, increase this
 numprocs=1
 
 ; This is the directory from which RQ is run. Be sure to point this to the


### PR DESCRIPTION
This allows the dev server to actually materialize builders using the dev workers and store the materialized selections in the dev s3.