### PR TITLE
Setup for wp1bot-workers-dev Docker image and compose file

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -73,6 +73,7 @@ jobs:
       - name: Copy credentials
         run: |
           cp wp1/credentials.py.e2e wp1/credentials.py
+          cp wp1/credentials.py.dev.e2e wp1/credentials.py.dev
 
       - name: Start Docker dev services
         run: docker-compose -f docker-compose-dev.yml up -d --build

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ venv
 # Don't commit credentials, credential backup files, or login cookies!
 wp1/credentials.py
 wp1/credentials.py.bak
+wp1/credentials.py.dev
+wp1/credentials.py.dev.bak
 cookies.txt
 
 # Don't commit test artifacts

--- a/README.md
+++ b/README.md
@@ -160,8 +160,14 @@ For development, you will need to have Docker installed as explained above.
 ## Running docker-compose
 
 There is a Docker setup for a development database. It lives in
-`docker-compose-dev.yml`. To download the database and setup development
-MariaDB and Redis, use:
+`docker-compose-dev.yml`.
+
+Before you run the docker-compose command below, you must copy the file
+`wp1/credentials.py.dev.example` to `wp1/credentials.py.dev` and fill out the
+section for `STORAGE`, if you wish to properly materialize builder lists into
+backend selections.
+
+After that is done, use the following command to run the dev environment:
 
 ```bash
 docker-compose -f docker-compose-dev.yml up -d

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -20,13 +20,16 @@ services:
       dockerfile: docker/dev-workers/Dockerfile
     container_name: wp1bot-workers-dev
     volumes:
-      - ./wp1/credentials.py:/usr/src/app/wp1/credentials.py
+      - ./wp1:/usr/src/app/wp1/
+      - ./wp1/credentials.py.dev:/usr/src/app/wp1/credentials.py
       - ./log/:/var/log/wp1bot/
     links:
       - redis
+      - dev-database
     restart: always
     depends_on:
       - redis
+      - dev-database
 
 networks:
   default:

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,3 +11,9 @@ WP1 bot has been dockerized in a few images:
 
 - "web" image is responsible for providing an API service to the frontend
   image and to anyone who might need the data.
+
+- "dev-db" image is the database that is used for development
+
+- "dev-workers" image is dev version of the workers image, that only contains
+  `materialize` workers, so that selections can be materialized to the dev
+  s3 storage.

--- a/docker/dev-workers/.dockerignore
+++ b/docker/dev-workers/.dockerignore
@@ -1,0 +1,1 @@
+wp1/wp1-frontend

--- a/docker/dev-workers/Dockerfile
+++ b/docker/dev-workers/Dockerfile
@@ -6,12 +6,6 @@ LABEL maintainer="kiwix"
 # Python app
 WORKDIR /usr/src
 COPY . app
-RUN apt-get update && \
-  apt-get install -y --no-install-recommends cron && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/*
-
-# hadolint ignore=DL3059
 RUN pip3 install --no-cache-dir -r app/requirements.txt
 
 # Start

--- a/docker/dev-workers/README.md
+++ b/docker/dev-workers/README.md
@@ -6,3 +6,9 @@ any cron commands.
 
 This image uses `supervisord-dev.conf` in the root directory, as opposed to the real
 workers image which uses simply `supervisord.conf`.
+
+The image requires that the `credentials.py.dev.example` file in the `wp1` directory
+be filled out and copied to `credentials.py.dev`. More info is in the .example file.
+If this is not done before the `docker-compose-dev.yml` file is run, `credentials.py.dev`
+will be created as a directory and will have to be removed and replaced with the actual
+file.

--- a/wp1/credentials.py.dev.e2e
+++ b/wp1/credentials.py.dev.e2e
@@ -1,0 +1,68 @@
+# Version of the .dev credentials, for the e2e tests. This file is mostly provided
+# so that the docker-compose graph will start up at all. It doesn't contain credentials
+# for s3 storage, as those are developer specific.
+
+from wp1.environment import Environment
+
+ENV = Environment.DEVELOPMENT
+
+CONF_LANG = 'en'
+
+CREDENTIALS = {
+    Environment.DEVELOPMENT: {
+       'WIKIDB': {
+            'user': 'yourtoolforgeuser', # EDIT this line
+            'password': 'yourtoolforgepass', # EDIT this line
+            'host': 'localhost',
+            'port': 4711,
+            'db': 'enwiki_p',
+        },
+
+        'WP10DB': {
+            'user': 'root',
+            'password': 'wikipedia',
+            'host': 'dev-database',
+            'port': 3306,
+            'db': 'enwp10_dev',
+        },
+
+        'REDIS': {
+            'host': 'redis',
+            'port': 9736,
+        },
+
+        # These don't exist in development.
+        'API': {},
+
+        # Credentials for authentication through mwoauth.
+        'MWOAUTH': {
+            'consumer_key': '',
+            'consumer_secret': '',
+        },
+
+        # This is meaningless in the docker-compose environment and should not have to be
+        # edited.
+        'SESSION': {
+            'secret_key': 'WP1_secret_key'
+        },
+
+        # Client side url used for redirection in login process. Also meaningless in the
+        # docker-compose environment and should not have to be edited.
+        'CLIENT_URL': {
+            'domains': ['http://localhost:3000'],
+            'homepage': 'http://localhost:3000/#/',
+        },
+
+        # Configuration for the storage backend for storing selection lists.
+        # IMPORTANT: Materializing builders will not work in e2e cypress tests, since
+        # these lines are left empty.
+        'STORAGE': {
+            'key': '',
+            'secret': '',
+            'bucket': 'org-kiwix-dev-wp1',
+        },
+    },
+
+    # EDIT: Remove the next line after you've provided actual credentials.
+    Environment.PRODUCTION: {}
+}

--- a/wp1/credentials.py.dev.example
+++ b/wp1/credentials.py.dev.example
@@ -1,0 +1,86 @@
+# This file is provided for the dev docker compose environment. Specifically, it is
+# for the dev rq workers, which run within the docker-compose environment and must
+# connect to redis and mysql using special paths.
+
+# To get end-to-end testing in the dev enviroment to work YOU MUST EDIT THIS FILE in
+# the places indicated, then copy it to wp1/wp1/credentials.py.dev. Specifically, edit
+# the objects for the key 'STORAGE'.
+
+from wp1.environment import Environment
+
+ENV = Environment.DEVELOPMENT
+
+CONF_LANG = 'en'
+
+CREDENTIALS = {
+    Environment.DEVELOPMENT: {
+
+        # This is your connection to the Wikipedia replica database, through toolforge.
+        # If you have a toolforge account, you can add your credentials here, after
+        # setting up a local tunnel. This is generally NOT NECESSARY because the
+        # crawling workers are not currently set up in the dev environment. See:
+        # https://wikitech.wikimedia.org/wiki/Help:Toolforge/Database#SSH_tunneling_for_local_testing_which_makes_use_of_Wiki_Replica_databases
+        'WIKIDB': {
+            'user': 'yourtoolforgeuser', # EDIT this line
+            'password': 'yourtoolforgepass', # EDIT this line
+            'host': 'localhost',
+            'port': 4711,
+            'db': 'enwiki_p',
+        },
+
+        # The credentials for the local WP1 database. This is prepopulated to work in the
+        # docker-compose environment with the dev database that the dev environment already
+        # uses (the same db that the dev frontend connects to in your credentials.py). This
+        # should not have to be edited.
+        'WP10DB': {
+            'user': 'root',
+            'password': 'wikipedia',
+            'host': 'dev-database',
+            'port': 3306,
+            'db': 'enwp10_dev',
+        },
+
+        # The connection string for Redis in the docker-compose environment. This is also
+        # prepopulated to use the dev Redis, and should not have to be edited.
+        'REDIS': {
+            'host': 'redis',
+            'port': 9736,
+        },
+
+        # These don't exist in development.
+        'API': {},
+
+        # Credentials for authentication through mwoauth.
+        'MWOAUTH': {
+            'consumer_key': '',
+            'consumer_secret': '',
+        },
+
+        # This is meaningless in the docker-compose environment and should not have to be
+        # edited.
+        'SESSION': {
+            'secret_key': 'WP1_secret_key'
+        },
+
+        # Client side url used for redirection in login process. Also meaningless in the
+        # docker-compose environment and should not have to be edited.
+        'CLIENT_URL': {
+            'domains': ['http://localhost:3000'],
+            'homepage': 'http://localhost:3000/#/',
+        },
+
+        # Configuration for the storage backend for storing selection lists. You MUST
+        # edit this line for your selections to be stored in the dev storage backend, which
+        # exists in the cloud.
+        # See https://github.com/openzim/zimfarm/wiki/S3-Cache-Policy for how to
+        # get these credentials.
+        'STORAGE': {
+            'key': '', # EDIT this line
+            'secret': '', # EDIT this line
+            'bucket': 'org-kiwix-dev-wp1',
+        },
+    },
+
+    # EDIT: Remove the next line after you've provided actual credentials.
+    Environment.PRODUCTION: {}
+}


### PR DESCRIPTION
This PR changes the setup for the dev-workers Docker image, so that in the compose file there is an overlay for both the code it is running (in order to iterate quickly on that code) as well as a new credentials.py file. The new credentials include the local hostnames for the MariaDB and Redis databases inside of the docker-compose graph, as well as potentially contain the developer's credentials for kiwix wasabi S3 storage.

README files have been updated where appropriate for this change.