### PR TITLE
Add builders to the materializer queue when they get saved

### DIFF
--- a/wp1/constants.py
+++ b/wp1/constants.py
@@ -36,5 +36,5 @@ FRONTEND_WIKI_BASE = 'https://en.wikipedia.org/w/'
 PAGE_SIZE = 100
 
 CONTENT_TYPE_TO_EXT = {
-    'text/tab-seperated-values': 'tsv',
+    'text/tab-separated-values': 'tsv',
 }

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -19,7 +19,7 @@ def save_builder(wp10db, name, user_id, project, articles):
                     b_params=params)
   builder.set_created_at_now()
   builder.set_updated_at_now()
-  insert_builder(wp10db, builder)
+  return insert_builder(wp10db, builder)
 
 
 def insert_builder(wp10db, builder):
@@ -29,7 +29,9 @@ def insert_builder(wp10db, builder):
         (b_name, b_user_id, b_project, b_params, b_model, b_created_at, b_updated_at)
         VALUES (%(b_name)s, %(b_user_id)s, %(b_project)s, %(b_params)s, %(b_model)s, %(b_created_at)s, %(b_updated_at)s)
       ''', attr.asdict(builder))
+    id_ = cursor.lastrowid
   wp10db.commit()
+  return id_
 
 
 def get_builder(wp10db, id_):

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -104,6 +104,12 @@ class BuilderTest(BaseWpOneDbTest):
     db_lists = self._get_builder_by_user_id()
     self.assertEqual(self.expected_builder, db_lists)
 
+  @patch('wp1.models.wp10.builder.utcnow',
+         return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
+  def test_insert_builder_returns_id(self, mock_utcnow):
+    actual = insert_builder(self.wp10db, self.builder)
+    self.assertEqual(1, actual)
+
   def test_get_builder(self):
     id_ = self._insert_builder()
 

--- a/wp1/queues.py
+++ b/wp1/queues.py
@@ -34,7 +34,7 @@ def _get_queues(redis, manual=False):
 
 
 def _get_materializer_queue(redis):
-  return Queue('wp1-materializer', connection=redis)
+  return Queue('materializer', connection=redis)
 
 
 def enqueue_all_projects(redis):
@@ -153,7 +153,7 @@ def enqueue_project(project_name,
                    'not PRODUCTION')
 
 
-def enqueue_materialize(redis, builder_id, builder_cls, content_type):
+def enqueue_materialize(redis, builder_cls, builder_id, content_type):
   materialize_q = _get_materializer_queue(redis)
   materialize_q.enqueue(logic_builder.materialize_builder,
                         builder_cls,

--- a/wp1/queues_test.py
+++ b/wp1/queues_test.py
@@ -150,7 +150,7 @@ class QueuesTest(BaseRedisTest):
     materialize_q_mock = MagicMock()
     patched_queue.return_value = materialize_q_mock
 
-    queues.enqueue_materialize(self.redis, 1234, SimpleBuilder,
+    queues.enqueue_materialize(self.redis, SimpleBuilder, 1234,
                                'text/tab-separated-values')
     materialize_q_mock.enqueue.assert_called_once_with(
         patched_materialize_builder,

--- a/wp1/web/selection.py
+++ b/wp1/web/selection.py
@@ -1,11 +1,13 @@
 import flask
-from flask import session
 
 from wp1.constants import CONTENT_TYPE_TO_EXT
-from wp1.logic.builder import get_lists, save_builder
+import wp1.logic.builder as logic_builder
+from wp1 import queues
 from wp1.selection.models.simple_builder import SimpleBuilder
 from wp1.web import authenticate
 from wp1.web.db import get_db
+from wp1.web.redis import get_redis
+from wp1.web.storage import get_storage
 
 selection = flask.Blueprint('selection', __name__)
 
@@ -23,24 +25,30 @@ def create():
   simple_builder = SimpleBuilder()
   valid_names, invalid_names, errors = simple_builder.validate(**params)
   if invalid_names:
-    return {
-        "success": False,
-        "items": {
+    return flask.jsonify({
+        'success': False,
+        'items': {
             'valid': valid_names,
             'invalid': invalid_names,
-            "errors": errors
+            'errors': errors
         }
-    }
-  user_id = session['user']['identity']['sub']
+    })
+
   wp10db = get_db('wp10db')
-  save_builder(wp10db, list_name, user_id, project, articles)
-  return {"success": True, "items": {}}
+  redis = get_redis()
+
+  user_id = flask.session['user']['identity']['sub']
+  builder_id = logic_builder.save_builder(wp10db, list_name, user_id, project,
+                                          articles)
+  queues.enqueue_materialize(redis, SimpleBuilder, builder_id,
+                             'text/tab-separated-values')
+  return flask.jsonify({'success': True, 'items': {}})
 
 
 @selection.route('/simple/lists')
 @authenticate
 def get_list_data():
   wp10db = get_db('wp10db')
-  user_id = session['user']['identity']['sub']
-  article_lists = get_lists(wp10db, user_id)
-  return {'builders': article_lists}
+  user_id = flask.session['user']['identity']['sub']
+  builders = logic_builder.get_lists(wp10db, user_id)
+  return flask.jsonify({'builders': builders})


### PR DESCRIPTION
This PR adds an extra step to the builder saving process, specifically for Simple lists, so that they are added to the materializer queue when they get saved. This means, if the queue is not busy, they will get materialized immediately and stored in the s3-like storage (by the background materializer job).

This is the final step in hooking up Simple list builders!