### PR TITLE
Cleanup some builder logic and frontend styles, add Selection to main navigation

### DIFF
--- a/wp1-frontend/cypress/fixtures/list_data.json
+++ b/wp1-frontend/cypress/fixtures/list_data.json
@@ -6,8 +6,9 @@
       "project": "en.wikipedia.org",
       "selections": [
         {
-          "s_id": "1",
-          "content_type": "tsv",
+          "id": "1",
+          "content_type": "text/tab-separated-values",
+          "extension": "tsv",
           "selection_url": "https://www.example.com/<id>"
         }
       ]

--- a/wp1-frontend/cypress/integration/createList_page.spec.js
+++ b/wp1-frontend/cypress/integration/createList_page.spec.js
@@ -7,7 +7,7 @@ describe('when the user is logged in', () => {
   });
 
   it('successfully loads', () => {
-    cy.visit('/#/selection/lists/simple/new');
+    cy.visit('/#/selections/simple');
   });
 
   it('displays wiki projects', () => {
@@ -27,19 +27,19 @@ describe('when the user is logged in', () => {
   });
 
   it('validates list name on losing focus', () => {
-    cy.visit('/#/selection/lists/simple/new');
+    cy.visit('/#/selections/simple');
     cy.get('#listName > .form-control').click();
     cy.get('#listName').contains('Please provide a valid List Name.');
   });
 
   it('validates textbox on losing focus', () => {
-    cy.visit('/#/selection/lists/simple/new');
+    cy.visit('/#/selections/simple');
     cy.get('#items > .form-control').click();
     cy.get('#items').contains('Please provide valid items.');
   });
 
   it('displays a textbox with invalid article names', () => {
-    cy.visit('/#/selection/lists/simple/new');
+    cy.visit('/#/selections/simple');
     cy.get('#listName > .form-control')
       .click()
       .type('List Name');
@@ -59,7 +59,7 @@ describe('when the user is logged in', () => {
   });
 
   it('redirects on saving valid article names', () => {
-    cy.visit('/#/selection/lists/simple/new');
+    cy.visit('/#/selections/simple');
     cy.get('#listName > .form-control')
       .click()
       .type('List Name');
@@ -77,7 +77,7 @@ describe('when the user is logged in', () => {
     });
 
     it('opens login page', () => {
-      cy.visit('/#/selection/lists/simple/new');
+      cy.visit('/#/selections/simple');
       cy.contains('Please Log In To Continue');
       cy.get('.pt-2 > .btn');
     });

--- a/wp1-frontend/cypress/integration/createList_page.spec.js
+++ b/wp1-frontend/cypress/integration/createList_page.spec.js
@@ -68,7 +68,7 @@ describe('when the user is logged in', () => {
       .type('Eiffel_Tower\nStatue of Liberty');
     cy.intercept('v1/selection/simple', { fixture: 'save_list_success.json' });
     cy.get('#saveListButton').click();
-    cy.url().should('eq', 'http://localhost:3000/#/selection/user');
+    cy.url().should('eq', 'http://localhost:3000/#/selections/user');
   });
 }),
   describe('when the user is not logged in', () => {

--- a/wp1-frontend/cypress/integration/myLists_page.spec.js
+++ b/wp1-frontend/cypress/integration/myLists_page.spec.js
@@ -7,7 +7,7 @@ describe('when the user is logged in', () => {
   });
 
   it('successfully loads', () => {
-    cy.visit('/#/selection/user');
+    cy.visit('/#/selections/user');
   });
 
   it('displays list and its contents', () => {
@@ -28,7 +28,7 @@ describe('when the user is logged in', () => {
 
 describe('when the user is not logged in', () => {
   it('opens login page', () => {
-    cy.visit('/#/selection/user');
+    cy.visit('/#/selections/user');
     cy.contains('Please Log In To Continue');
     cy.get('.pt-2 > .btn');
   });

--- a/wp1-frontend/src/App.vue
+++ b/wp1-frontend/src/App.vue
@@ -28,12 +28,23 @@
             :class="
               'nav-item ' +
                 (!this.$route.path.startsWith('/update') &&
-                !this.$route.path.startsWith('/compare')
+                !this.$route.path.startsWith('/compare') &&
+                !this.$route.path.startsWith('/selections')
                   ? 'active'
                   : '')
             "
           >
             <router-link class="nav-link" to="/">Projects</router-link>
+          </li>
+          <li
+            :class="
+              'nav-item ' +
+                (this.$route.path.startsWith('/selections') ? 'active' : '')
+            "
+          >
+            <router-link class="nav-link" to="/selections/user"
+              >Selections</router-link
+            >
           </li>
           <li
             :class="
@@ -58,11 +69,10 @@
         </ul>
         <div>
           <div v-if="this.username">
+            <span class="username"> {{ this.username }} </span>
             <button type="button" class="btn btn-secondary" @click="logout">
               Logout
             </button>
-            <span style="font-size:20px"> | </span>
-            <span> {{ this.username }} </span>
           </div>
           <a v-else :href="this.loginInitiateUrl"
             ><button type="button" class="btn btn-primary">Login</button>
@@ -150,5 +160,11 @@ a:visited {
 
 .row {
   margin-top: 10px;
+}
+
+.username {
+  /* Center the username vertically */
+  position: relative;
+  top: 2px;
 }
 </style>

--- a/wp1-frontend/src/components/CreateSimpleList.vue
+++ b/wp1-frontend/src/components/CreateSimpleList.vue
@@ -138,7 +138,7 @@ export default {
       var data = await response.json();
       parent.success = data.success;
       if (parent.success) {
-        parent.$router.push('/selection/user');
+        parent.$router.push('/selections/user');
         return;
       }
       parent.$refs.form_group.classList.add('was-validated');

--- a/wp1-frontend/src/components/CreateSimpleList.vue
+++ b/wp1-frontend/src/components/CreateSimpleList.vue
@@ -5,7 +5,7 @@
     </div>
     <div class="row">
       <div class="col-lg-6 col-md-9 m-4">
-        <div class="m-4">
+        <div class="ml-4 mb-4">
           Use this tool to create an article selection list for the Wikipedia
           project of your choice. Your selection will be saved in public cloud
           storage and can be accessed through URLs that will be provided once it

--- a/wp1-frontend/src/components/MyLists.vue
+++ b/wp1-frontend/src/components/MyLists.vue
@@ -17,7 +17,7 @@
               class="input-group col-sm-9 mx-auto mb-3"
             >
               <input
-                :id="selection.s_id"
+                :id="selection.id"
                 :value="selection.selection_url"
                 class="form-control"
               />

--- a/wp1-frontend/src/components/MyLists.vue
+++ b/wp1-frontend/src/components/MyLists.vue
@@ -30,7 +30,7 @@
                 </button>
               </div>
               <a :href="item.url" class="btn btn-primary ml-3" download
-                >Download {{ selection.content_type }}</a
+                >Download {{ selection.extension }}</a
               >
             </div>
           </div>

--- a/wp1-frontend/src/components/SecondaryNav.vue
+++ b/wp1-frontend/src/components/SecondaryNav.vue
@@ -1,7 +1,6 @@
 <template>
   <div>
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
-      <a class="navbar-brand" href="/">Selection</a>
       <button
         class="navbar-toggler"
         type="button"
@@ -19,23 +18,25 @@
           <li
             :class="
               'nav-item ' +
-                (this.$route.path.startsWith('/selection/user') ? 'active' : '')
+                (this.$route.path.startsWith('/selections/user')
+                  ? 'active'
+                  : '')
             "
           >
-            <router-link class="nav-link" to="/selection/user"
-              >My Lists</router-link
+            <router-link class="nav-link" to="/selections/user"
+              >My Selections</router-link
             >
           </li>
           <li
             :class="
               'nav-item ' +
-                (this.$route.path.startsWith('/selection/lists/simple/new')
+                (this.$route.path.startsWith('/selections/simple')
                   ? 'active'
                   : '')
             "
           >
-            <router-link class="nav-link" to="/selection/lists/simple/new"
-              >Create Simple List</router-link
+            <router-link class="nav-link" to="/selections/simple"
+              >Create Simple Selection</router-link
             >
           </li>
         </ul>

--- a/wp1-frontend/src/main.js
+++ b/wp1-frontend/src/main.js
@@ -83,17 +83,17 @@ const routes = [
     }
   },
   {
-    path: '/selection/user',
+    path: '/selections/user',
     component: MyLists,
     meta: {
-      title: () => BASE_TITLE + ' - My Lists'
+      title: () => BASE_TITLE + ' - My Selections'
     }
   },
   {
-    path: '/selection/lists/simple/new',
+    path: '/selections/simple',
     component: CreateSimpleList,
     meta: {
-      title: () => BASE_TITLE + ' - Create Simple List'
+      title: () => BASE_TITLE + ' - Create Simple Selection'
     }
   }
 ];

--- a/wp1/constants.py
+++ b/wp1/constants.py
@@ -37,4 +37,5 @@ PAGE_SIZE = 100
 
 CONTENT_TYPE_TO_EXT = {
     'text/tab-separated-values': 'tsv',
+    'application/vnd.ms-excel': 'xls',
 }

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -62,7 +62,8 @@ def get_builders_with_selections(wp10db, user_id):
     cursor.execute(
         '''SELECT * FROM selections
                       RIGHT JOIN builders ON selections.s_builder_id=builders.b_id
-                      WHERE b_user_id=%(b_user_id)s''', {'b_user_id': user_id})
+                      WHERE b_user_id=%(b_user_id)s
+                      ORDER BY selections.s_id ASC''', {'b_user_id': user_id})
     data = cursor.fetchall()
 
     builders = {}
@@ -79,7 +80,7 @@ def get_builders_with_selections(wp10db, user_id):
         builders[b['b_id']]['selections'].append({
             'id': b['s_id'].decode('utf-8'),
             'content_type': content_type,
-            'extension': CONTENT_TYPE_TO_EXT[content_type],
+            'extension': CONTENT_TYPE_TO_EXT.get(content_type, '???'),
             'selection_url': 'https://www.example.com/<id>',
         })
     for id_, value in builders.items():

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -4,7 +4,7 @@ from unittest.mock import patch, MagicMock, ANY
 import attr
 
 from wp1.base_db_test import BaseWpOneDbTest
-from wp1.logic.builder import save_builder, insert_builder, get_builder, get_lists, materialize_builder
+from wp1.logic import builder as logic_builder
 from wp1.models.wp10.builder import Builder
 from wp1.selection.models.simple_builder import SimpleBuilder
 
@@ -40,8 +40,9 @@ class BuilderTest(BaseWpOneDbTest):
       'project':
           'en.wikipedia.fake',
       'selections': [{
-          's_id': '1',
-          'content_type': 'tsv',
+          'id': '1',
+          'content_type': 'text/tab-separated-values',
+          'extension': 'tsv',
           'selection_url': 'https://www.example.com/<id>'
       }]
   }]
@@ -54,13 +55,15 @@ class BuilderTest(BaseWpOneDbTest):
       'project':
           'en.wikipedia.fake',
       'selections': [{
-          's_id': '1',
-          'content_type': 'tsv',
-          'selection_url': 'https://www.example.com/<id>'
+          'id': '1',
+          'content_type': 'text/tab-separated-values',
+          'extension': 'tsv',
+          'selection_url': 'https://www.example.com/<id>',
       }, {
-          's_id': '2',
-          'content_type': 'xls',
-          'selection_url': 'https://www.example.com/<id>'
+          'id': '2',
+          'content_type': 'application/vnd.ms-excel',
+          'extension': 'xls',
+          'selection_url': 'https://www.example.com/<id>',
       }]
   }]
 
@@ -68,7 +71,22 @@ class BuilderTest(BaseWpOneDbTest):
       'id': 1,
       'name': 'My Builder',
       'project': 'en.wikipedia.fake',
-      'selections': []
+      'selections': [],
+  }]
+
+  expected_lists_with_unmapped_selections = [{
+      'id':
+          1,
+      'name':
+          'My Builder',
+      'project':
+          'en.wikipedia.fake',
+      'selections': [{
+          'id': '1',
+          'content_type': 'foo/bar-baz',
+          'extension': '???',
+          'selection_url': 'https://www.example.com/<id>',
+      }],
   }]
 
   def _insert_builder(self):
@@ -82,6 +100,13 @@ class BuilderTest(BaseWpOneDbTest):
     self.wp10db.commit()
     return id_
 
+  def _insert_selection(self, id_, content_type):
+    with self.wp10db.cursor() as cursor:
+      cursor.execute(
+          'INSERT INTO selections VALUES (%s, 1, %s, "20191225044444")',
+          (id_, content_type))
+    self.wp10db.commit()
+
   def _get_builder_by_user_id(self):
     with self.wp10db.cursor() as cursor:
       cursor.execute('SELECT * FROM builders WHERE b_user_id=%(b_user_id)s',
@@ -92,28 +117,28 @@ class BuilderTest(BaseWpOneDbTest):
   @patch('wp1.models.wp10.builder.utcnow',
          return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
   def test_save_builder(self, mock_utcnow):
-    save_builder(self.wp10db, 'My Builder', '1234', 'en.wikipedia.fake',
-                 'a\nb\nc')
+    logic_builder.save_builder(self.wp10db, 'My Builder', '1234',
+                               'en.wikipedia.fake', 'a\nb\nc')
     db_lists = self._get_builder_by_user_id()
     self.assertEqual(self.expected_builder, db_lists)
 
   @patch('wp1.models.wp10.builder.utcnow',
          return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
   def test_insert_builder(self, mock_utcnow):
-    insert_builder(self.wp10db, self.builder)
+    logic_builder.insert_builder(self.wp10db, self.builder)
     db_lists = self._get_builder_by_user_id()
     self.assertEqual(self.expected_builder, db_lists)
 
   @patch('wp1.models.wp10.builder.utcnow',
          return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
   def test_insert_builder_returns_id(self, mock_utcnow):
-    actual = insert_builder(self.wp10db, self.builder)
+    actual = logic_builder.insert_builder(self.wp10db, self.builder)
     self.assertEqual(1, actual)
 
   def test_get_builder(self):
     id_ = self._insert_builder()
 
-    actual = get_builder(self.wp10db, id_)
+    actual = logic_builder.get_builder(self.wp10db, id_)
     self.builder.b_id = id_
     self.assertEqual(self.builder, actual)
 
@@ -130,7 +155,8 @@ class BuilderTest(BaseWpOneDbTest):
       self.wp10db.close = lambda: True
       id_ = self._insert_builder()
 
-      materialize_builder(TestBuilderClass, id_, 'text/tab-separated-values')
+      logic_builder.materialize_builder(TestBuilderClass, id_,
+                                        'text/tab-separated-values')
       materialize_mock.materialize.assert_called_once_with(
           ANY, ANY, self.builder, 'text/tab-separated-values')
     finally:
@@ -140,71 +166,53 @@ class BuilderTest(BaseWpOneDbTest):
 
   @patch('wp1.models.wp10.builder.utcnow',
          return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
-  def test_get_lists(self, mock_utcnow):
-    with self.wp10db.cursor() as cursor:
-      cursor.execute(
-          'INSERT INTO selections VALUES (1, 1, "tsv", "20191225044444")')
-      cursor.execute(
-          '''INSERT INTO builders
-        (b_name, b_user_id, b_project, b_params, b_model, b_created_at, b_updated_at)
-        VALUES (%(b_name)s, %(b_user_id)s, %(b_project)s,
-                %(b_params)s, %(b_model)s, %(b_created_at)s, %(b_updated_at)s)
-      ''', attr.asdict(self.builder))
-    article_data = get_lists(self.wp10db, '1234')
+  def test_get_builders(self, mock_utcnow):
+    self._insert_selection(1, 'text/tab-separated-values')
+    self._insert_builder()
+    article_data = logic_builder.get_builders_with_selections(
+        self.wp10db, '1234')
     self.assertEqual(self.expected_lists, article_data)
 
   @patch('wp1.models.wp10.builder.utcnow',
          return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
-  def test_get_lists_with_multiple_selections(self, mock_utcnow):
-    with self.wp10db.cursor() as cursor:
-      cursor.execute(
-          'INSERT INTO selections VALUES (1, 1, "tsv", "20191225044444")')
-      cursor.execute(
-          'INSERT INTO selections VALUES (2, 1, "xls", "20201225105544")')
-      cursor.execute(
-          '''INSERT INTO builders
-        (b_name, b_user_id, b_project, b_params,
-         b_model, b_created_at, b_updated_at)
-        VALUES (%(b_name)s, %(b_user_id)s, %(b_project)s,
-                %(b_params)s, %(b_model)s, %(b_created_at)s, %(b_updated_at)s)
-      ''', attr.asdict(self.builder))
-    article_data = get_lists(self.wp10db, '1234')
+  def test_get_builders_with_multiple_selections(self, mock_utcnow):
+    self._insert_selection(1, 'text/tab-separated-values')
+    self._insert_selection(2, 'application/vnd.ms-excel')
+    self._insert_builder()
+    article_data = logic_builder.get_builders_with_selections(
+        self.wp10db, '1234')
     self.assertEqual(self.expected_lists_with_multiple_selections, article_data)
 
   @patch('wp1.models.wp10.builder.utcnow',
          return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
-  def test_get_lists_with_no_selections(self, mock_utcnow):
-    with self.wp10db.cursor() as cursor:
-      cursor.execute(
-          '''INSERT INTO builders
-        (b_name, b_user_id, b_project, b_params,
-         b_model, b_created_at, b_updated_at)
-        VALUES (%(b_name)s, %(b_user_id)s, %(b_project)s,
-                %(b_params)s, %(b_model)s, %(b_created_at)s, %(b_updated_at)s)
-      ''', attr.asdict(self.builder))
-    article_data = get_lists(self.wp10db, '1234')
+  def test_get_builders_with_no_selections(self, mock_utcnow):
+    self._insert_builder()
+    article_data = logic_builder.get_builders_with_selections(
+        self.wp10db, '1234')
     self.assertEqual(self.expected_lists_with_no_selections, article_data)
 
   @patch('wp1.models.wp10.builder.utcnow',
          return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
   def test_get_empty_lists(self, mock_utcnow):
-    with self.wp10db.cursor() as cursor:
-      cursor.execute(
-          'INSERT INTO selections VALUES (1, 1, "tsv", "20191225044444")')
-      cursor.execute(
-          '''INSERT INTO builders
-        (b_name, b_user_id, b_project, b_params, b_model, b_created_at, b_updated_at)
-        VALUES (%(b_name)s, %(b_user_id)s, %(b_project)s, %(b_params)s,
-                %(b_model)s, %(b_created_at)s, %(b_updated_at)s)
-      ''', attr.asdict(self.builder))
-    article_data = get_lists(self.wp10db, '0000')
+    self._insert_selection(1, 'text/tab-separated-values')
+    self._insert_builder()
+    article_data = logic_builder.get_builders_with_selections(
+        self.wp10db, '0000')
     self.assertEqual([], article_data)
 
   @patch('wp1.models.wp10.builder.utcnow',
          return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
-  def test_get_lists_with_no_builders(self, mock_utcnow):
-    with self.wp10db.cursor() as cursor:
-      cursor.execute(
-          'INSERT INTO selections VALUES (1, 1, "tsv", "20191225044444")')
-    article_data = get_lists(self.wp10db, '0000')
+  def test_get_builders_with_no_builders(self, mock_utcnow):
+    self._insert_selection(1, 'text/tab-separated-values')
+    article_data = logic_builder.get_builders_with_selections(
+        self.wp10db, '0000')
     self.assertEqual([], article_data)
+
+  @patch('wp1.models.wp10.builder.utcnow',
+         return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
+  def test_get_builders_with_unmapped_content_type(self, mock_utcnow):
+    self._insert_selection(1, 'foo/bar-baz')
+    self._insert_builder()
+    article_data = logic_builder.get_builders_with_selections(
+        self.wp10db, '1234')
+    self.assertEqual(self.expected_lists_with_unmapped_selections, article_data)

--- a/wp1/web/selection.py
+++ b/wp1/web/selection.py
@@ -50,5 +50,5 @@ def create():
 def get_list_data():
   wp10db = get_db('wp10db')
   user_id = flask.session['user']['identity']['sub']
-  builders = logic_builder.get_lists(wp10db, user_id)
+  builders = logic_builder.get_builders_with_selections(wp10db, user_id)
   return flask.jsonify({'builders': builders})

--- a/wp1/web/selection_test.py
+++ b/wp1/web/selection_test.py
@@ -9,8 +9,8 @@ class SelectionTest(BaseWebTestcase):
       'access_token': 'access_token',
       'identity': {
           'username': 'WP1_user',
-          'sub': '1234'
-      }
+          'sub': '1234',
+      },
   }
   invalid_article_name = "Eiffel_Tower\nStatue of#Liberty"
   unsuccessful_response = {
@@ -18,8 +18,8 @@ class SelectionTest(BaseWebTestcase):
       "items": {
           'valid': ['Eiffel_Tower'],
           'invalid': ['Statue_of#Liberty'],
-          'errors': ['The list contained the following invalid characters: #']
-      }
+          'errors': ['The list contained the following invalid characters: #'],
+      },
   }
   valid_article_name = "Eiffel_Tower\nStatue of Liberty"
   successful_response = {"success": True, "items": {}}
@@ -33,11 +33,12 @@ class SelectionTest(BaseWebTestcase):
           'project':
               'project_name',
           'selections': [{
-              's_id': '1',
-              'content_type': 'tsv',
+              'id': '1',
+              'content_type': 'text/tab-separated-values',
+              'extension': 'tsv',
               'selection_url': 'https://www.example.com/<id>'
-          }]
-      }]
+          }],
+      }],
   }
 
   expected_lists_with_multiple_selections = {
@@ -49,12 +50,14 @@ class SelectionTest(BaseWebTestcase):
           'project':
               'project_name',
           'selections': [{
-              's_id': '1',
-              'content_type': 'tsv',
+              'id': '1',
+              'content_type': 'text/tab-separated-values',
+              'extension': 'tsv',
               'selection_url': 'https://www.example.com/<id>'
           }, {
-              's_id': '2',
-              'content_type': 'xls',
+              'id': '2',
+              'content_type': 'application/vnd.ms-excel',
+              'extension': 'xls',
               'selection_url': 'https://www.example.com/<id>'
           }]
       }]
@@ -154,7 +157,8 @@ class SelectionTest(BaseWebTestcase):
         VALUES ('list_name', '1234', 'project_name', 'model')
       ''')
         cursor.execute(
-            '''INSERT INTO selections VALUES (1, 1, "tsv", '20201225105544')''')
+            'INSERT INTO selections VALUES (1, 1, "text/tab-separated-values", "20201225105544")'
+        )
       self.wp10db.commit()
       with client.session_transaction() as sess:
         sess['user'] = self.USER
@@ -170,9 +174,11 @@ class SelectionTest(BaseWebTestcase):
         VALUES ('list_name', '1234', 'project_name', 'model')
       ''')
         cursor.execute(
-            '''INSERT INTO selections VALUES (1, 1, "tsv", '20201225105544')''')
+            'INSERT INTO selections VALUES (1, 1, "text/tab-separated-values", "20201225105544")'
+        )
         cursor.execute(
-            '''INSERT INTO selections VALUES (2, 1, "xls", '20201225105544')''')
+            'INSERT INTO selections VALUES (2, 1, "application/vnd.ms-excel", "20201225105544")'
+        )
       self.wp10db.commit()
       with client.session_transaction() as sess:
         sess['user'] = self.USER
@@ -199,7 +205,8 @@ class SelectionTest(BaseWebTestcase):
     with self.override_db(self.app), self.app.test_client() as client:
       with self.wp10db.cursor() as cursor:
         cursor.execute(
-            '''INSERT INTO selections VALUES (2, 1, "xls", '20201225105544')''')
+            '''INSERT INTO selections VALUES (2, 1, "application/vnd.ms-excel", '20201225105544')'''
+        )
       self.wp10db.commit()
       with client.session_transaction() as sess:
         sess['user'] = self.USER


### PR DESCRIPTION
This PR is a bit of cleanup work. It does the following:

- Fixes #415 
- Adds the "Selections" tab to the header nav, which reveals the secondary nav
- Cleans up some frontend styles
- Disambiguates "content-type" from "extension" for list builders
- Cleans up some tests