### PR TITLE
New process for building production images manually

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+wp1-frontend/node_modules
+log
+venv

--- a/README.md
+++ b/README.md
@@ -253,6 +253,11 @@ to something like:
 
 # Updating production
 
+- Since Docker Hub no longer auto builds images, you must build the images yourself.
+  From the wp1 directory, run the following commands to build and push the images:
+  - `git checkout main`
+  - `git pull origin main`
+  - `./build_production_images.sh`
 - Log in to the box that contains the production docker images. It is
   called wp1.
 - `cd /data/code/wp1/`

--- a/build_production_images.sh
+++ b/build_production_images.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+docker build -f web.Dockerfile -t openzim/wp1bot-web .
+docker build -f workers.Dockerfile -t openzim/wp1bot-workers .
+docker build -f frontend.Dockerfile -t openzim/wp1bot-frontend .
+docker push openzim/wp1bot-web:latest
+docker push openzim/wp1bot-workers:latest
+docker push openzim/wp1bot-frontend:latest


### PR DESCRIPTION
Since Docker Hub no longer automatically builds images on repo update (on their free plan), we must have a process in place for building and pushing the production images manually.

While we're add it, add a .dockerignore file to speed up the process dramatically (less data transferred for transient directories).

This is actually perhaps a bit more satisfying than waiting for Docker Hub anyways.