### PR TITLE
Refactor code for calculating object_key for selections

### DIFF
--- a/wp1/constants.py
+++ b/wp1/constants.py
@@ -35,7 +35,10 @@ FRONTEND_WIKI_BASE = 'https://en.wikipedia.org/w/'
 
 PAGE_SIZE = 100
 
+# Put both bytes and str as keys for convenience.
 CONTENT_TYPE_TO_EXT = {
     'text/tab-separated-values': 'tsv',
+    b'text/tab-separated-values': 'tsv',
     'application/vnd.ms-excel': 'xls',
+    b'application/vnd.ms-excel': 'xls',
 }

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -1,5 +1,7 @@
 import attr
 
+from wp1.constants import CONTENT_TYPE_TO_EXT
+
 
 def insert_selection(wp10db, selection):
   with wp10db.cursor() as cursor:
@@ -9,3 +11,16 @@ def insert_selection(wp10db, selection):
       VALUES (%(s_id)s, %(s_builder_id)s, %(s_content_type)s, %(s_updated_at)s)
     ''', attr.asdict(selection))
   wp10db.commit()
+
+
+def object_key_for_selection(selection, model):
+  if not selection:
+    raise ValueError('Cannot get object key for None selection')
+  if not model:
+    raise ValueError('Expected WP1 model name, got: %r' % model)
+  ext = CONTENT_TYPE_TO_EXT.get(selection.s_content_type, '???')
+  return 'selections/%(model)s/%(id)s.%(ext)s' % {
+      'model': model,
+      'id': selection.s_id.decode('utf-8'),
+      'ext': ext,
+  }

--- a/wp1/logic/selection_test.py
+++ b/wp1/logic/selection_test.py
@@ -28,3 +28,11 @@ class SelectionTest(BaseWpOneDbTest):
     actual = logic_selection.object_key_for_selection(self.selection,
                                                       'foo.bar.model')
     self.assertEqual('selections/foo.bar.model/deadbeef.tsv', actual)
+
+  def test_object_key_for_selection_none_selection(self):
+    with self.assertRaises(ValueError):
+      logic_selection.object_key_for_selection(None, 'foo.bar.model')
+
+  def test_object_key_for_selection_none_model(self):
+    with self.assertRaises(ValueError):
+      logic_selection.object_key_for_selection(self.selection, None)

--- a/wp1/logic/selection_test.py
+++ b/wp1/logic/selection_test.py
@@ -1,0 +1,30 @@
+from wp1.base_db_test import BaseWpOneDbTest
+import wp1.logic.selection as logic_selection
+from wp1.models.wp10.selection import Selection
+
+
+def _get_selection(wp10db):
+  with wp10db.cursor() as cursor:
+    cursor.execute('SELECT * FROM selections LIMIT 1')
+    db_selection = cursor.fetchone()
+    return Selection(**db_selection)
+
+
+class SelectionTest(BaseWpOneDbTest):
+
+  def setUp(self):
+    super().setUp()
+    self.selection = Selection(s_id=b'deadbeef',
+                               s_builder_id=100,
+                               s_content_type=b'text/tab-separated-values',
+                               s_updated_at=b'20190830112844')
+
+  def test_insert_selection(self):
+    logic_selection.insert_selection(self.wp10db, self.selection)
+    actual = _get_selection(self.wp10db)
+    self.assertEqual(self.selection, actual)
+
+  def test_object_key_for_selection(self):
+    actual = logic_selection.object_key_for_selection(self.selection,
+                                                      'foo.bar.model')
+    self.assertEqual('selections/foo.bar.model/deadbeef.tsv', actual)

--- a/wp1/selection/abstract_builder.py
+++ b/wp1/selection/abstract_builder.py
@@ -12,19 +12,14 @@ logger = logging.getLogger(__name__)
 class AbstractBuilder:
 
   def _upload_to_storage(self, s3, selection, builder):
-    ext = CONTENT_TYPE_TO_EXT.get(selection.s_content_type, '').encode('utf-8')
-    object_key = b'selection/%(model)s/%(user_id)s/%(id)s.%(ext)s' % {
-        b'model': builder.b_model,
-        b'user_id': str(builder.b_user_id).encode('utf-8'),
-        b'id': selection.s_id,
-        b'ext': ext,
-    }
+    object_key = logic_selection.object_key_for_selection(
+        selection, builder.b_model.decode('utf-8'))
 
     upload_data = io.BytesIO()
     upload_data.write(selection.data)
     upload_data.seek(0)
-    logger.info('Uploading to path: %s ' % object_key.decode('utf-8'))
-    s3.upload_fileobj(upload_data, key=object_key.decode('utf-8'))
+    logger.info('Uploading to path: %s ' % object_key)
+    s3.upload_fileobj(upload_data, key=object_key)
 
   def materialize(self, s3, wp10db, builder, content_type):
     params = json.loads(builder.b_params)

--- a/wp1/selection/abstract_builder_test.py
+++ b/wp1/selection/abstract_builder_test.py
@@ -55,8 +55,12 @@ class AbstractBuilderTest(BaseWpOneDbTest):
     actual = _get_first_selection(self.wp10db)
     self.assertEqual(actual.s_updated_at, b'20201225105544')
 
-  def test_materialize_uploads_to_s3(self):
+  @patch('wp1.models.wp10.selection.uuid.uuid4', return_value='abcd-1234')
+  def test_materialize_uploads_to_s3(self, mock_uuid4):
     self.test_builder.materialize(self.s3, self.wp10db, self.builder,
                                   'text/tab-separated-values')
     data = self.s3.upload_fileobj.call_args[0][0]
+    object_key = self.s3.upload_fileobj.call_args[1]['key']
     self.assertEqual(b'a\nb\nc', data.read())
+    self.assertEqual('selections/wp1.selection.models.simple/abcd-1234.tsv',
+                     object_key)


### PR DESCRIPTION
We were including the user_id in the object_key for selections, however since this is going to be a public URL, it should not include that information. At the same time, we need to be able to calculate the object_key independently of the initial saving of the selection. Also add some additional tests.