### PR TITLE
Allow for editing of list builders

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -253,6 +253,8 @@ paths:
                   next_update_time:
                     type: string
                     description: 'A string representing the UTC timestamp of when the next manual update can be performed.'
+        401:
+          description: 'Unauthorized. You must be logged in to perform a project update.'
         404:
           description: 'No project with that projectId was found'
     parameters:
@@ -342,7 +344,7 @@ paths:
                     type: array
                     items:
                       type: string
-  /selection/simple:
+  /builders:
     post:
       summary: 'Save a new Simple list, validating it first and returning invalid items if they exist'
       operationId: createSimpleList
@@ -355,7 +357,7 @@ paths:
               properties:
                 articles:
                   type: string
-                list_name:
+                name:
                   type: string
                 project:
                   type: string
@@ -365,32 +367,75 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
-                    description: True when article name does not contain forbidden chars {"#", "<", ">", "[", "]", "{", "}", "|"}, false otherwise.
-                  items:
-                    type: object
-                    description: Empty in case of success being true
-                    properties:
-                      valid:
-                        type: array
-                        description: List of valid article names
-                        items:
-                          type: string
-                      invalid:
-                        type: array
-                        description: List of invalid article names
-                        items:
-                          type: string
-                      errors:
-                        type: array
-                        description: List of forbidden characters present in article names
-                        items:
-                          type: string
+                $ref: '#/components/schemas/CreateOrUpdateListResponse'
+        401:
+          description: 'Unauthorized. You must be logged in to save a list.'
         400:
           description: 'Request with either empty list_name or project or articles'
+  /builders/{builderId}:
+    get:
+      summary: 'Return the builder (Simple list) with the given id'
+      operationId: getSimpleList
+      responses:
+        200:
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  project:
+                    type: string
+                  articles:
+                    type: string
+                    description: 'A newline separated list of articles that make up this Simple list.'
+        401:
+          description: 'Unauthorized. You must be logged in to retrieve builders.'
+        404:
+          description: 'Not found. The logged in user does not own a builder with the given ID.'
+      parameters:
+        - name: builderId
+          in: path
+          required: true
+          description: 'The id of the builder to retrieve.'
+          schema:
+            type: string
+    post:
+      summary: 'Update the builder (Simple list) with the given id'
+      operationId: updateSimpleList
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                articles:
+                  type: string
+                name:
+                  type: string
+                project:
+                  type: string
+      responses:
+        401:
+          description: 'Unauthorized. You must be logged in to update a builder.'
+        404:
+          description: 'Not found. No builder with the given ID was found for the logged in user.'
+        200:
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateOrUpdateListResponse'
+      parameters:
+        - name: builderId
+          in: path
+          required: true
+          description: 'The id of the builder to update.'
+          schema:
+            type: string
   /selection/simple/lists:
     get:
       summary: 'Return list details from database'
@@ -413,7 +458,6 @@ paths:
                         name:
                           type: string
                         project:
-                          items:
                           type: string
                         selections:
                           type: object
@@ -428,6 +472,31 @@ paths:
 
 components:
   schemas:
+    CreateOrUpdateListResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          description: True when article name does not contain forbidden chars {"#", "<", ">", "[", "]", "{", "}", "|"}, false otherwise.
+        items:
+          type: object
+          description: Empty in case of success being true
+          properties:
+            valid:
+              type: array
+              description: List of valid article names
+              items:
+                type: string
+            invalid:
+              type: array
+              description: List of invalid article names
+              items:
+                type: string
+            errors:
+              type: array
+              description: List of forbidden characters present in article names
+              items:
+                type: string
     Project:
       type: object
       properties:

--- a/wp1-frontend/cypress/fixtures/builder_1.json
+++ b/wp1-frontend/cypress/fixtures/builder_1.json
@@ -1,0 +1,5 @@
+{
+  "articles": "Eiffel_Tower\nStatue_of_Liberty",
+  "name": "Builder 1",
+  "project": "en.wiktionary.org"
+}

--- a/wp1-frontend/cypress/integration/createList_page.spec.js
+++ b/wp1-frontend/cypress/integration/createList_page.spec.js
@@ -4,11 +4,10 @@ describe('when the user is logged in', () => {
   beforeEach(() => {
     cy.intercept('v1/sites/', { fixture: 'sites.json' });
     cy.intercept('v1/oauth/identify', { fixture: 'identity.json' });
-  });
-
-  it('successfully loads', () => {
     cy.visit('/#/selections/simple');
   });
+
+  it('successfully loads', () => {});
 
   it('displays wiki projects', () => {
     cy.get('select').contains('aa.wikipedia.org');
@@ -18,36 +17,40 @@ describe('when the user is logged in', () => {
 
   it('validates list name on clicking save', () => {
     cy.get('#saveListButton').click();
-    cy.get('#listName').contains('Please provide a valid List Name.');
+    cy.get('#listName').contains('Please provide a valid list name');
   });
 
   it('validates textbox on clicking save', () => {
     cy.get('#saveListButton').click();
-    cy.get('#items').contains('Please provide valid items.');
+    cy.get('#listName > .invalid-feedback').should('be.visible');
+    cy.get('#items > .invalid-feedback').should('be.visible');
   });
 
   it('validates list name on losing focus', () => {
-    cy.visit('/#/selections/simple');
     cy.get('#listName > .form-control').click();
-    cy.get('#listName').contains('Please provide a valid List Name.');
+    cy.get('#items > .form-control').click();
+    cy.get('#listName > .invalid-feedback').should('be.visible');
   });
 
   it('validates textbox on losing focus', () => {
-    cy.visit('/#/selections/simple');
     cy.get('#items > .form-control').click();
-    cy.get('#items').contains('Please provide valid items.');
+    cy.get('#listName > .form-control').click();
+    cy.get('#items > .invalid-feedback').should('be.visible');
   });
 
   it('displays a textbox with invalid article names', () => {
-    cy.visit('/#/selections/simple');
     cy.get('#listName > .form-control')
       .click()
       .type('List Name');
     cy.get('#items > .form-control')
       .click()
       .type('Eiffel_Tower\nStatue of#Liberty');
-    cy.intercept('v1/selection/simple', { fixture: 'save_list_failure.json' });
+    cy.intercept('v1/builders/', { fixture: 'save_list_failure.json' });
     cy.get('#saveListButton').click();
+
+    cy.get('#items > .invalid-feedback').should('not.be.visible');
+    cy.get('#listName > .invalid-feedback').should('not.be.visible');
+
     cy.get('#items > .form-control').should('have.value', 'Eiffel_Tower');
     cy.get('#invalid_articles').contains(
       'The list contained the following invalid characters: #'
@@ -59,14 +62,13 @@ describe('when the user is logged in', () => {
   });
 
   it('redirects on saving valid article names', () => {
-    cy.visit('/#/selections/simple');
     cy.get('#listName > .form-control')
       .click()
       .type('List Name');
     cy.get('#items > .form-control')
       .click()
       .type('Eiffel_Tower\nStatue of Liberty');
-    cy.intercept('v1/selection/simple', { fixture: 'save_list_success.json' });
+    cy.intercept('v1/builders/', { fixture: 'save_list_success.json' });
     cy.get('#saveListButton').click();
     cy.url().should('eq', 'http://localhost:3000/#/selections/user');
   });

--- a/wp1-frontend/cypress/integration/updateList_page.spec.js
+++ b/wp1-frontend/cypress/integration/updateList_page.spec.js
@@ -1,0 +1,90 @@
+/// <reference types="Cypress" />
+
+describe('when the user is logged in', () => {
+  beforeEach(() => {
+    cy.intercept('v1/sites/', { fixture: 'sites.json' });
+    cy.intercept('v1/oauth/identify', { fixture: 'identity.json' });
+  });
+
+  describe('and the builder is found', () => {
+    beforeEach(() => {
+      cy.intercept('GET', 'v1/builders/1', { fixture: 'builder_1.json' });
+      cy.visit('/#/selections/simple/1');
+    });
+
+    it('successfully loads', () => {});
+
+    it('displays wiki projects', () => {
+      cy.get('select').contains('aa.wikipedia.org');
+      cy.get('select').contains('en.wiktionary.org');
+      cy.get('select').contains('en.wikipedia.org');
+    });
+
+    it('displays builder information', () => {
+      cy.get('#listName > .form-control').should('have.value', 'Builder 1');
+      cy.get('#items > .form-control').should(
+        'have.value',
+        'Eiffel_Tower\nStatue_of_Liberty'
+      );
+      cy.get('#project > select').should('have.value', 'en.wiktionary.org');
+    });
+
+    it('does not show invalid list items', () => {
+      cy.get('#updateListButton').click();
+      cy.get('#items > .invalid-feedback').should('not.be.visible');
+    });
+
+    it('does not show invalid list name', () => {
+      cy.get('#updateListButton').click();
+      cy.get('#listName > .invalid-feedback').should('not.be.visible');
+    });
+
+    it('displays a textbox with invalid article names', () => {
+      cy.get('#items > .form-control')
+        .click()
+        .type('\nStatue of#Liberty');
+      cy.intercept('v1/builders/1', { fixture: 'save_list_failure.json' });
+      cy.get('#updateListButton').click();
+      cy.get('#items > .form-control').should('have.value', 'Eiffel_Tower');
+      cy.get('#invalid_articles').contains(
+        'The list contained the following invalid characters: #'
+      );
+      cy.get('#invalid_articles > .form-control').should(
+        'have.value',
+        'Statue_of#Liberty'
+      );
+    });
+
+    it('redirects on saving valid article names', () => {
+      cy.intercept('v1/builders/1', { fixture: 'save_list_success.json' });
+      cy.get('#updateListButton').click();
+      cy.url().should('eq', 'http://localhost:3000/#/selections/user');
+    });
+  });
+
+  describe('and the builder is not found', () => {
+    beforeEach(() => {
+      cy.intercept('GET', 'v1/builders/1', {
+        statusCode: 404,
+        body: '404 NOT FOUND'
+      });
+      cy.visit('/#/selections/simple/1');
+    });
+
+    it('displays the 404 text', () => {
+      cy.get('#404').should('be.visible');
+    });
+  });
+});
+
+describe('when the user is not logged in', () => {
+  beforeEach(() => {
+    cy.intercept('v1/sites/', { fixture: 'sites.json' });
+  });
+
+  it('opens login page', () => {
+    cy.visit('/#/selections/simple/1');
+    cy.contains('Please Log In To Continue');
+    cy.get('.pt-2 > .btn');
+  });
+});

--- a/wp1-frontend/src/components/MyLists.vue
+++ b/wp1-frontend/src/components/MyLists.vue
@@ -7,7 +7,12 @@
       <div class=" col-lg-6">
         <div v-for="item in list" :key="item.id" class="card text-center m-5">
           <div class="card-header">
-            {{ item.name }}
+            <router-link
+              :to="{
+                path: `/selections/simple/${item.id}`
+              }"
+              >{{ item.name }} {{ item.id }}</router-link
+            >
           </div>
           <div class="card-body ">
             <h5 class="card-title">{{ item.project }}</h5>

--- a/wp1-frontend/src/components/SecondaryNav.vue
+++ b/wp1-frontend/src/components/SecondaryNav.vue
@@ -36,7 +36,7 @@
             "
           >
             <router-link class="nav-link" to="/selections/simple"
-              >Create Simple Selection</router-link
+              >Simple Selection</router-link
             >
           </li>
         </ul>

--- a/wp1-frontend/src/components/SimpleList.vue
+++ b/wp1-frontend/src/components/SimpleList.vue
@@ -90,7 +90,7 @@ import LoginRequired from './LoginRequired';
 
 export default {
   components: { SecondaryNav, LoginRequired },
-  name: 'CreateSimpleLists',
+  name: 'SimpleList',
   data: function() {
     return {
       wikiProjects: [],

--- a/wp1-frontend/src/components/SimpleList.vue
+++ b/wp1-frontend/src/components/SimpleList.vue
@@ -3,7 +3,14 @@
     <div>
       <SecondaryNav></SecondaryNav>
     </div>
-    <div class="row">
+    <div v-if="notFound">
+      <div class="col-lg-6 m-4">
+        <h2>404 Not Found</h2>
+        Sorry, the builder (simple list) with that ID either doesn't exist or
+        isn't owned by you.
+      </div>
+    </div>
+    <div v-else class="row">
       <div class="col-lg-6 col-md-9 m-4">
         <h2 v-if="!isEditing" class="ml-4">New Simple Selection</h2>
         <h2 v-else class="ml-4">Editing Simple Selection</h2>
@@ -110,6 +117,7 @@ export default {
   name: 'SimpleList',
   data: function() {
     return {
+      notFound: false,
       wikiProjects: [],
       success: true,
       valid_article_names: '',
@@ -139,6 +147,11 @@ export default {
       this.getBuilder();
     }
   },
+  watch: {
+    builderId: function() {
+      this.getBuilder();
+    }
+  },
   methods: {
     getWikiProjects: async function() {
       const response = await fetch(`${process.env.VUE_APP_API_URL}/sites/`);
@@ -153,7 +166,12 @@ export default {
           credentials: 'include'
         }
       );
-      this.builder = await response.json();
+      if (!response.ok) {
+        this.notFound = true;
+      } else {
+        this.notFound = false;
+        this.builder = await response.json();
+      }
     },
     onSubmit: async function() {
       const form = this.$refs.form;
@@ -193,12 +211,6 @@ export default {
         event.target.classList.add('is-invalid');
       }
     }
-  },
-  beforeRouteUpdate(to, from, next) {
-    if (to.params.builder_id) {
-      this.getBuilder();
-    }
-    next();
   }
 };
 </script>

--- a/wp1-frontend/src/components/SimpleList.vue
+++ b/wp1-frontend/src/components/SimpleList.vue
@@ -5,12 +5,15 @@
     </div>
     <div class="row">
       <div class="col-lg-6 col-md-9 m-4">
-        <div class="ml-4 mb-4">
+        <h2 v-if="!isEditing" class="ml-4">New Simple Selection</h2>
+        <h2 v-else class="ml-4">Editing Simple Selection</h2>
+        <div v-if="!isEditing" class="ml-4 mb-4">
           Use this tool to create an article selection list for the Wikipedia
           project of your choice. Your selection will be saved in public cloud
           storage and can be accessed through URLs that will be provided once it
           has been saved.
         </div>
+
         <form
           ref="form"
           v-on:submit.prevent="onSubmit"
@@ -40,7 +43,7 @@
                 required
               />
               <div class="invalid-feedback">
-                Please provide a valid List Name.
+                Please provide a valid list name.
               </div>
             </div>
             <div id="items" class="form-group m-4">
@@ -107,7 +110,6 @@ export default {
   name: 'SimpleList',
   data: function() {
     return {
-      isEditing: false,
       wikiProjects: [],
       success: true,
       valid_article_names: '',
@@ -123,11 +125,16 @@ export default {
   computed: {
     isLoggedIn: function() {
       return this.$root.$data.isLoggedIn;
+    },
+    isEditing: function() {
+      return !!this.builderId;
+    },
+    builderId: function() {
+      return this.$route.params.builder_id;
     }
   },
   created: function() {
     this.getWikiProjects();
-    this.isEditing = !!this.$route.params.builder_id;
     if (this.isEditing) {
       this.getBuilder();
     }
@@ -139,7 +146,6 @@ export default {
       this.wikiProjects = data.sites;
     },
     getBuilder: async function() {
-      window.console.log(this.$route.params.builder_id);
       const response = await fetch(
         `${process.env.VUE_APP_API_URL}/builders/${this.$route.params.builder_id}`,
         {
@@ -160,7 +166,7 @@ export default {
       if (this.isEditing) {
         postUrl = `${process.env.VUE_APP_API_URL}/builders/${this.$route.params.builder_id}`;
       } else {
-        postUrl = `${process.env.VUE_APP_API_URL}/selections/simple`;
+        postUrl = `${process.env.VUE_APP_API_URL}/builders/`;
       }
 
       const response = await fetch(postUrl, {
@@ -187,6 +193,12 @@ export default {
         event.target.classList.add('is-invalid');
       }
     }
+  },
+  beforeRouteUpdate(to, from, next) {
+    if (to.params.builder_id) {
+      this.getBuilder();
+    }
+    next();
   }
 };
 </script>

--- a/wp1-frontend/src/components/SimpleList.vue
+++ b/wp1-frontend/src/components/SimpleList.vue
@@ -4,7 +4,7 @@
       <SecondaryNav></SecondaryNav>
     </div>
     <div v-if="notFound">
-      <div class="col-lg-6 m-4">
+      <div id="404" class="col-lg-6 m-4">
         <h2>404 Not Found</h2>
         Sorry, the builder (simple list) with that ID either doesn't exist or
         isn't owned by you.
@@ -28,7 +28,7 @@
           novalidate
         >
           <div ref="form_group" class="form-group">
-            <div class="m-4">
+            <div id="project" class="m-4">
               <label>Project</label>
               <select v-model="builder.project" class="custom-select my-list">
                 <option v-if="wikiProjects.length == 0" selected
@@ -50,7 +50,7 @@
                 required
               />
               <div class="invalid-feedback">
-                Please provide a valid list name.
+                Please provide a valid list name
               </div>
             </div>
             <div id="items" class="form-group m-4">
@@ -66,7 +66,7 @@
                 required
               ></textarea>
               <div class="invalid-feedback">
-                Please provide valid items.
+                Please provide valid items
               </div>
             </div>
           </div>

--- a/wp1-frontend/src/components/SimpleList.vue
+++ b/wp1-frontend/src/components/SimpleList.vue
@@ -20,8 +20,10 @@
           <div ref="form_group" class="form-group">
             <div class="m-4">
               <label>Project</label>
-              <select ref="project" class="custom-select my-list">
-                <option selected>en.wikipedia.org</option>
+              <select v-model="builder.project" class="custom-select my-list">
+                <option v-if="wikiProjects.length == 0" selected
+                  >en.wikipedia.org</option
+                >
                 <option v-for="item in wikiProjects" v-bind:key="item">
                   {{ item }}
                 </option>
@@ -31,8 +33,8 @@
               <label for="listName">List Name</label>
               <input
                 v-on:blur="validationOnBlur"
+                v-model="builder.list_name"
                 type="text"
-                ref="list_name"
                 placeholder="My List"
                 class="form-control my-list"
                 required
@@ -45,13 +47,12 @@
               <label for="Items">Items</label>
               <textarea
                 v-on:blur="validationOnBlur"
+                v-model="builder.articles"
                 :placeholder="
                   'Eiffel_Tower\nStatue_of_Liberty\nFreedom_Monument_(Baghdad)\nGeorge-Étienne_Cartier_Monument'
                 "
                 class="form-control my-list"
                 rows="13"
-                ref="articles"
-                v-model="valid_article_names"
                 required
               ></textarea>
               <div class="invalid-feedback">
@@ -97,7 +98,12 @@ export default {
       success: true,
       valid_article_names: '',
       invalid_article_names: '',
-      errors: ''
+      errors: '',
+      builder: {
+        articles: '',
+        list_name: '',
+        project: 'en.wikipedia.org'
+      }
     };
   },
   computed: {
@@ -121,18 +127,13 @@ export default {
         parent.$refs.form_group.classList.add('was-validated');
         return;
       }
-      const article_detail = {
-        articles: parent.$refs.articles.value,
-        list_name: parent.$refs.list_name.value,
-        project: parent.$refs.project.value
-      };
       const response = await fetch(
         `${process.env.VUE_APP_API_URL}/selection/simple`,
         {
           headers: { 'Content-Type': 'application/json' },
           method: 'post',
           credentials: 'include',
-          body: JSON.stringify(article_detail)
+          body: JSON.stringify(this.builder)
         }
       );
       var data = await response.json();
@@ -142,7 +143,7 @@ export default {
         return;
       }
       parent.$refs.form_group.classList.add('was-validated');
-      parent.valid_article_names = data.items.valid.join('\n');
+      this.builder.articles = data.items.valid.join('\n');
       parent.invalid_article_names = data.items.invalid.join('\n');
       parent.errors = data.items.errors.join(', ');
     },

--- a/wp1-frontend/src/main.js
+++ b/wp1-frontend/src/main.js
@@ -6,7 +6,7 @@ import VueRouter from 'vue-router';
 
 import App from './App.vue';
 import ArticlePage from './components/ArticlePage.vue';
-import CreateSimpleList from './components/CreateSimpleList.vue';
+import SimpleList from './components/SimpleList.vue';
 import ComparePage from './components/ComparePage.vue';
 import IndexPage from './components/IndexPage.vue';
 import MyLists from './components/MyLists.vue';
@@ -91,7 +91,7 @@ const routes = [
   },
   {
     path: '/selections/simple',
-    component: CreateSimpleList,
+    component: SimpleList,
     meta: {
       title: () => BASE_TITLE + ' - Create Simple Selection'
     }

--- a/wp1-frontend/src/main.js
+++ b/wp1-frontend/src/main.js
@@ -95,6 +95,13 @@ const routes = [
     meta: {
       title: () => BASE_TITLE + ' - Create Simple Selection'
     }
+  },
+  {
+    path: '/selections/simple/:builder_id',
+    component: SimpleList,
+    meta: {
+      title: () => BASE_TITLE + ' - Edit Simple Selection'
+    }
   }
 ];
 

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -29,9 +29,11 @@ def create_or_update_builder(wp10db,
     builder.set_created_at_now()
     return insert_builder(wp10db, builder)
 
-  builder.b_id = builder_id
-  update_builder(wp10db, builder)
-  return builder_id
+  builder.b_id = int(builder_id)
+  if update_builder(wp10db, builder):
+    return builder_id
+
+  return None
 
 
 def insert_builder(wp10db, builder):
@@ -51,17 +53,19 @@ def update_builder(wp10db, builder):
     cursor.execute(
         '''UPDATE builders
       SET b_name = %(b_name)s, b_project = %(b_project)s, b_params = %(b_params)s, b_model = %(b_model)s,
-          b_created_at = %(b_created_at)s, b_updated_at = %(b_updated_at)s
+          b_updated_at = %(b_updated_at)s
       WHERE b_id = %(b_id)s AND b_user_id = %(b_user_id)s
       ''', attr.asdict(builder))
+    rowcount = cursor.rowcount
   wp10db.commit()
+  return rowcount > 0
 
 
 def get_builder(wp10db, id_):
   with wp10db.cursor() as cursor:
     cursor.execute('SELECT * FROM builders WHERE b_id = %s', id_)
     db_builder = cursor.fetchone()
-    return Builder(**db_builder)
+    return Builder(**db_builder) if db_builder else None
 
 
 def materialize_builder(builder_cls, builder_id, content_type):

--- a/wp1/models/wp10/builder.py
+++ b/wp1/models/wp10/builder.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import logging
 
 import attr
@@ -56,3 +57,11 @@ class Builder:
   def set_updated_at_now(self):
     """Sets the updated_at field to a timestamp that is equal to now"""
     self.set_updated_at_dt(utcnow())
+
+  def to_web_dict(self):
+    articles = '\n'.join(json.loads(self.b_params.decode('utf-8'))['list'])
+    return {
+        'name': self.b_name.decode('utf-8'),
+        'project': self.b_project.decode('utf-8'),
+        'articles': articles,
+    }

--- a/wp1/web/app.py
+++ b/wp1/web/app.py
@@ -13,6 +13,7 @@ import wp1.logic.project as logic_project
 from wp1 import environment
 from wp1.web.db import get_db, has_db
 from wp1.web.articles import articles
+from wp1.web.builders import builders
 from wp1.web.projects import projects
 from wp1.web.selection import selection
 from wp1.web.sites import sites
@@ -127,6 +128,7 @@ def create_app():
   app.register_blueprint(articles, url_prefix='/v1/articles')
   app.register_blueprint(sites, url_prefix='/v1/sites')
   app.register_blueprint(selection, url_prefix='/v1/selection')
+  app.register_blueprint(builders, url_prefix='/v1/builders')
 
   if not missing_credentials:
     mwoauth = CREDENTIALS.get(ENV, {}).get('MWOAUTH', {})

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -33,10 +33,16 @@ def _create_or_update_builder(data, builder_id=None):
   redis = get_redis()
 
   user_id = flask.session['user']['identity']['sub']
+  print('user id: %s' % user_id)
   is_update = builder_id is not None
   builder_id = logic_builder.create_or_update_builder(wp10db, list_name,
                                                       user_id, project,
                                                       articles, builder_id)
+  # Either the builder was not found or the user ID was not correct. Nothing was
+  # updated, return 404.
+  if builder_id is None:
+    flask.abort(404)
+
   if not is_update:
     queues.enqueue_materialize(redis, SimpleBuilder, builder_id,
                                'text/tab-separated-values')

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -1,0 +1,30 @@
+import flask
+
+import wp1.logic.builder as logic_builder
+from wp1.web import authenticate
+from wp1.web.db import get_db
+
+builders = flask.Blueprint('builders', __name__)
+
+
+@builders.route('/<builder_id>')
+@authenticate
+def get_builder(builder_id):
+  wp10db = get_db('wp10db')
+  builder = logic_builder.get_builder(wp10db, builder_id)
+  if not builder:
+    flask.abort(404)
+
+  # Don't return the builder unless it belongs to this user.
+  user = flask.session.get('user')
+  if builder.b_user_id != user['identity']['sub']:
+    flask.abort(404)
+
+  return flask.jsonify(builder.to_web_dict())
+
+
+@builders.route('/<builder_id>', methods=['POST'])
+@authenticate
+def update_builder(builder_id):
+  # TODO: actually update the builder
+  pass

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -1,10 +1,60 @@
 import flask
 
 import wp1.logic.builder as logic_builder
+from wp1 import queues
+from wp1.selection.models.simple_builder import SimpleBuilder
 from wp1.web import authenticate
 from wp1.web.db import get_db
+from wp1.web.redis import get_redis
 
 builders = flask.Blueprint('builders', __name__)
+
+
+def _create_or_update_builder(data, builder_id=None):
+  list_name = data['name']
+  articles = data['articles']
+  project = data['project']
+  params = {'list': articles.split('\n')}
+  if not articles or not list_name or not project:
+    flask.abort(400)
+  simple_builder = SimpleBuilder()
+  valid_names, invalid_names, errors = simple_builder.validate(**params)
+  if invalid_names:
+    return flask.jsonify({
+        'success': False,
+        'items': {
+            'valid': valid_names,
+            'invalid': invalid_names,
+            'errors': errors
+        }
+    })
+
+  wp10db = get_db('wp10db')
+  redis = get_redis()
+
+  user_id = flask.session['user']['identity']['sub']
+  is_update = builder_id is not None
+  builder_id = logic_builder.create_or_update_builder(wp10db, list_name,
+                                                      user_id, project,
+                                                      articles, builder_id)
+  if not is_update:
+    queues.enqueue_materialize(redis, SimpleBuilder, builder_id,
+                               'text/tab-separated-values')
+  return flask.jsonify({'success': True, 'items': {}})
+
+
+@builders.route('/', methods=['POST'])
+@authenticate
+def create():
+  data = flask.request.get_json()
+  return _create_or_update_builder(data)
+
+
+@builders.route('/<builder_id>', methods=['POST'])
+@authenticate
+def update_builder(builder_id):
+  data = flask.request.get_json()
+  return _create_or_update_builder(data, builder_id)
 
 
 @builders.route('/<builder_id>')
@@ -21,10 +71,3 @@ def get_builder(builder_id):
     flask.abort(404)
 
   return flask.jsonify(builder.to_web_dict())
-
-
-@builders.route('/<builder_id>', methods=['POST'])
-@authenticate
-def update_builder(builder_id):
-  # TODO: actually update the builder
-  pass

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -1,0 +1,229 @@
+from unittest.mock import patch
+
+import attr
+
+from wp1.models.wp10.builder import Builder
+from wp1.web.app import create_app
+from wp1.web.base_web_testcase import BaseWebTestcase
+
+
+class BuildersTest(BaseWebTestcase):
+  USER = {
+      'access_token': 'access_token',
+      'identity': {
+          'username': 'WP1_user',
+          'sub': 1234,
+      },
+  }
+  invalid_article_name = 'Eiffel_Tower\nStatue of#Liberty'
+  unsuccessful_response = {
+      'success': False,
+      'items': {
+          'valid': ['Eiffel_Tower'],
+          'invalid': ['Statue_of#Liberty'],
+          'errors': ['The list contained the following invalid characters: #'],
+      },
+  }
+  valid_article_name = 'Eiffel_Tower\nStatue of Liberty'
+  successful_response = {'success': True, 'items': {}}
+
+  builder = Builder(
+      b_name=b'My Builder',
+      b_user_id=1234,
+      b_project=b'en.wikipedia.fake',
+      b_model=b'wp1.selection.models.simple',
+      b_params=b'{"list": ["a", "b", "c"]}',
+      b_created_at=b'20191225044444',
+      b_updated_at=b'20191225044444',
+  )
+
+  def _insert_builder(self):
+    with self.wp10db.cursor() as cursor:
+      cursor.execute(
+          '''INSERT INTO builders
+         (b_name, b_user_id, b_project, b_params, b_model, b_created_at, b_updated_at)
+         VALUES (%(b_name)s, %(b_user_id)s, %(b_project)s, %(b_params)s, %(b_model)s, %(b_created_at)s, %(b_updated_at)s)
+        ''', attr.asdict(self.builder))
+      id_ = cursor.lastrowid
+    self.wp10db.commit()
+    return id_
+
+  def test_create_unsuccessful(self):
+    self.app = create_app()
+    with self.app.test_client() as client:
+      with client.session_transaction() as sess:
+        sess['user'] = self.USER
+      rv = client.post('/v1/builders/',
+                       json={
+                           'articles': self.invalid_article_name,
+                           'name': 'my_list',
+                           'project': 'my_project'
+                       })
+      self.assertEqual(self.unsuccessful_response, rv.get_json())
+
+  def test_create_successful(self):
+    self.app = create_app()
+    with self.app.test_client() as client, self.override_db(self.app):
+      with client.session_transaction() as sess:
+        sess['user'] = self.USER
+      rv = client.post('/v1/builders/',
+                       json={
+                           'articles': self.valid_article_name,
+                           'name': 'my_list',
+                           'project': 'my_project'
+                       })
+      self.assertEqual(self.successful_response, rv.get_json())
+
+  def test_update_unsuccessful(self):
+    builder_id = self._insert_builder()
+    self.app = create_app()
+    with self.override_db(self.app), self.app.test_client() as client:
+      with client.session_transaction() as sess:
+        sess['user'] = self.USER
+      rv = client.post('/v1/builders/%s' % builder_id,
+                       json={
+                           'articles': self.invalid_article_name,
+                           'name': 'updated_list',
+                           'project': 'my_project'
+                       })
+      self.assertEqual(self.unsuccessful_response, rv.get_json())
+
+  def test_update_successful(self):
+    builder_id = self._insert_builder()
+    self.app = create_app()
+    with self.override_db(self.app), self.app.test_client() as client:
+      with client.session_transaction() as sess:
+        sess['user'] = self.USER
+      rv = client.post('/v1/builders/%s' % builder_id,
+                       json={
+                           'articles': self.valid_article_name,
+                           'name': 'updated_list',
+                           'project': 'my_project'
+                       })
+      print(rv.status)
+      self.assertEqual(self.successful_response, rv.get_json())
+
+  def test_update_not_owner(self):
+    builder_id = self._insert_builder()
+    different_user = {
+        'access_token': 'access_token',
+        'identity': {
+            'username': 'Another_User',
+            'sub': 5555,
+        },
+    }
+    self.app = create_app()
+    with self.override_db(self.app), self.app.test_client() as client:
+      with client.session_transaction() as sess:
+        sess['user'] = different_user
+      rv = client.post('/v1/builders/%s' % builder_id,
+                       json={
+                           'articles': self.valid_article_name,
+                           'name': 'updated_list',
+                           'project': 'my_project'
+                       })
+      self.assertEqual('404 NOT FOUND', rv.status)
+
+  def test_empty_article_create(self):
+    self.app = create_app()
+    with self.app.test_client() as client:
+      with client.session_transaction() as sess:
+        sess['user'] = self.USER
+      rv = client.post('/v1/builders/',
+                       json={
+                           'articles': '',
+                           'name': 'my_list',
+                           'project': 'my_project'
+                       })
+      self.assertEqual('400 BAD REQUEST', rv.status)
+
+  def test_empty_list_create(self):
+    self.app = create_app()
+    with self.app.test_client() as client:
+      with client.session_transaction() as sess:
+        sess['user'] = self.USER
+      rv = client.post('/v1/builders/',
+                       json={
+                           'articles': self.valid_article_name,
+                           'name': '',
+                           'project': 'my_project'
+                       })
+      self.assertEqual('400 BAD REQUEST', rv.status)
+
+  def test_empty_project_create(self):
+    self.app = create_app()
+    with self.app.test_client() as client:
+      with client.session_transaction() as sess:
+        sess['user'] = self.USER
+      rv = client.post('/v1/builders/',
+                       json={
+                           'articles': self.valid_article_name,
+                           'name': 'my_list',
+                           'project': ''
+                       })
+      self.assertEqual('400 BAD REQUEST', rv.status)
+
+  def test_selection_unauthorized_user_create(self):
+    self.app = create_app()
+    with self.app.test_client() as client:
+      rv = client.post('/v1/builders/',
+                       json={
+                           'articles': self.valid_article_name,
+                           'name': 'my_list',
+                           'project': 'my_project'
+                       })
+    self.assertEqual('401 UNAUTHORIZED', rv.status)
+
+  def test_empty_article_update(self):
+    builder_id = self._insert_builder()
+    self.app = create_app()
+    with self.app.test_client() as client:
+      with client.session_transaction() as sess:
+        sess['user'] = self.USER
+      rv = client.post('/v1/builders/%s' % builder_id,
+                       json={
+                           'articles': '',
+                           'name': 'my_list',
+                           'project': 'my_project'
+                       })
+      self.assertEqual('400 BAD REQUEST', rv.status)
+
+  def test_empty_list_update(self):
+    builder_id = self._insert_builder()
+    self.app = create_app()
+    with self.app.test_client() as client:
+      with client.session_transaction() as sess:
+        sess['user'] = self.USER
+      rv = client.post('/v1/builders/%s' % builder_id,
+                       json={
+                           'articles': self.valid_article_name,
+                           'name': '',
+                           'project': 'my_project'
+                       })
+      self.assertEqual('400 BAD REQUEST', rv.status)
+
+  def test_empty_project_update(self):
+    builder_id = self._insert_builder()
+    self.app = create_app()
+    with self.app.test_client() as client:
+      with client.session_transaction() as sess:
+        sess['user'] = self.USER
+      rv = client.post('/v1/builders/%s' % builder_id,
+                       json={
+                           'articles': self.valid_article_name,
+                           'name': 'my_list',
+                           'project': ''
+                       })
+      self.assertEqual('400 BAD REQUEST', rv.status)
+
+  def test_selection_unauthorized_user_update(self):
+    builder_id = self._insert_builder()
+    self.app = create_app()
+    with self.app.test_client() as client:
+      rv = client.post('/v1/builders/%s' % builder_id,
+                       json={
+                           'articles': self.valid_article_name,
+                           'name': 'my_list',
+                           'project': 'my_project'
+                       })
+    self.assertEqual('401 UNAUTHORIZED', rv.status)

--- a/wp1/web/selection.py
+++ b/wp1/web/selection.py
@@ -16,7 +16,7 @@ selection = flask.Blueprint('selection', __name__)
 @authenticate
 def create():
   data = flask.request.get_json()
-  list_name = data['list_name']
+  list_name = data['name']
   articles = data['articles']
   project = data['project']
   params = {'list': articles.split('\n')}

--- a/wp1/web/selection.py
+++ b/wp1/web/selection.py
@@ -2,47 +2,12 @@ import flask
 
 from wp1.constants import CONTENT_TYPE_TO_EXT
 import wp1.logic.builder as logic_builder
-from wp1 import queues
-from wp1.selection.models.simple_builder import SimpleBuilder
+
 from wp1.web import authenticate
 from wp1.web.db import get_db
-from wp1.web.redis import get_redis
 from wp1.web.storage import get_storage
 
 selection = flask.Blueprint('selection', __name__)
-
-
-@selection.route('/simple', methods=['POST'])
-@authenticate
-def create():
-  data = flask.request.get_json()
-  list_name = data['name']
-  articles = data['articles']
-  project = data['project']
-  params = {'list': articles.split('\n')}
-  if not articles or not list_name or not project:
-    flask.abort(400)
-  simple_builder = SimpleBuilder()
-  valid_names, invalid_names, errors = simple_builder.validate(**params)
-  if invalid_names:
-    return flask.jsonify({
-        'success': False,
-        'items': {
-            'valid': valid_names,
-            'invalid': invalid_names,
-            'errors': errors
-        }
-    })
-
-  wp10db = get_db('wp10db')
-  redis = get_redis()
-
-  user_id = flask.session['user']['identity']['sub']
-  builder_id = logic_builder.save_builder(wp10db, list_name, user_id, project,
-                                          articles)
-  queues.enqueue_materialize(redis, SimpleBuilder, builder_id,
-                             'text/tab-separated-values')
-  return flask.jsonify({'success': True, 'items': {}})
 
 
 @selection.route('/simple/lists')

--- a/wp1/web/selection_test.py
+++ b/wp1/web/selection_test.py
@@ -4,7 +4,6 @@ from wp1.web.base_web_testcase import BaseWebTestcase
 
 
 class SelectionTest(BaseWebTestcase):
-
   USER = {
       'access_token': 'access_token',
       'identity': {
@@ -12,24 +11,13 @@ class SelectionTest(BaseWebTestcase):
           'sub': '1234',
       },
   }
-  invalid_article_name = "Eiffel_Tower\nStatue of#Liberty"
-  unsuccessful_response = {
-      "success": False,
-      "items": {
-          'valid': ['Eiffel_Tower'],
-          'invalid': ['Statue_of#Liberty'],
-          'errors': ['The list contained the following invalid characters: #'],
-      },
-  }
-  valid_article_name = "Eiffel_Tower\nStatue of Liberty"
-  successful_response = {"success": True, "items": {}}
 
   expected_list_data = {
       'builders': [{
           'id':
               1,
           'name':
-              'list_name',
+              'name',
           'project':
               'project_name',
           'selections': [{
@@ -46,7 +34,7 @@ class SelectionTest(BaseWebTestcase):
           'id':
               1,
           'name':
-              'list_name',
+              'name',
           'project':
               'project_name',
           'selections': [{
@@ -66,87 +54,11 @@ class SelectionTest(BaseWebTestcase):
   expected_lists_with_no_selections = {
       'builders': [{
           'id': 1,
-          'name': 'list_name',
+          'name': 'name',
           'project': 'project_name',
           'selections': []
       }]
   }
-
-  def test_create_unsuccessful(self):
-    self.app = create_app()
-    with self.app.test_client() as client:
-      with client.session_transaction() as sess:
-        sess['user'] = self.USER
-      rv = client.post('/v1/selection/simple',
-                       json={
-                           'articles': self.invalid_article_name,
-                           'list_name': 'my_list',
-                           'project': 'my_project'
-                       })
-      self.assertEqual(rv.get_json(), self.unsuccessful_response)
-
-  def test_create_successful(self):
-    self.app = create_app()
-    with self.app.test_client() as client, self.override_db(self.app):
-      with client.session_transaction() as sess:
-        sess['user'] = self.USER
-      rv = client.post('/v1/selection/simple',
-                       json={
-                           'articles': self.valid_article_name,
-                           'list_name': 'my_list',
-                           'project': 'my_project'
-                       })
-      self.assertEqual(rv.get_json(), self.successful_response)
-
-  def test_empty_article(self):
-    self.app = create_app()
-    with self.app.test_client() as client:
-      with client.session_transaction() as sess:
-        sess['user'] = self.USER
-      rv = client.post('/v1/selection/simple',
-                       json={
-                           'articles': '',
-                           'list_name': 'my_list',
-                           'project': 'my_project'
-                       })
-      self.assertEqual(rv.status, '400 BAD REQUEST')
-
-  def test_empty_list(self):
-    self.app = create_app()
-    with self.app.test_client() as client:
-      with client.session_transaction() as sess:
-        sess['user'] = self.USER
-      rv = client.post('/v1/selection/simple',
-                       json={
-                           'articles': self.valid_article_name,
-                           'list_name': '',
-                           'project': 'my_project'
-                       })
-      self.assertEqual(rv.status, '400 BAD REQUEST')
-
-  def test_empty_project(self):
-    self.app = create_app()
-    with self.app.test_client() as client:
-      with client.session_transaction() as sess:
-        sess['user'] = self.USER
-      rv = client.post('/v1/selection/simple',
-                       json={
-                           'articles': self.valid_article_name,
-                           'list_name': 'my_list',
-                           'project': ''
-                       })
-      self.assertEqual(rv.status, '400 BAD REQUEST')
-
-  def test_selection_unauthorized_user(self):
-    self.app = create_app()
-    with self.app.test_client() as client:
-      rv = client.post('/v1/selection/simple',
-                       json={
-                           'articles': self.valid_article_name,
-                           'list_name': 'my_list',
-                           'project': ''
-                       })
-    self.assertEqual('401 UNAUTHORIZED', rv.status)
 
   def test_get_list_data(self):
     self.app = create_app()
@@ -154,7 +66,7 @@ class SelectionTest(BaseWebTestcase):
       with self.wp10db.cursor() as cursor:
         cursor.execute('''INSERT INTO builders
         (b_name, b_user_id, b_project, b_model)
-        VALUES ('list_name', '1234', 'project_name', 'model')
+        VALUES ('name', '1234', 'project_name', 'model')
       ''')
         cursor.execute(
             'INSERT INTO selections VALUES (1, 1, "text/tab-separated-values", "20201225105544")'
@@ -171,7 +83,7 @@ class SelectionTest(BaseWebTestcase):
       with self.wp10db.cursor() as cursor:
         cursor.execute('''INSERT INTO builders
         (b_name, b_user_id, b_project, b_model)
-        VALUES ('list_name', '1234', 'project_name', 'model')
+        VALUES ('name', '1234', 'project_name', 'model')
       ''')
         cursor.execute(
             'INSERT INTO selections VALUES (1, 1, "text/tab-separated-values", "20201225105544")'
@@ -192,7 +104,7 @@ class SelectionTest(BaseWebTestcase):
       with self.wp10db.cursor() as cursor:
         cursor.execute('''INSERT INTO builders
         (b_name, b_user_id, b_project, b_model)
-        VALUES ('list_name', '1234', 'project_name', 'model')
+        VALUES ('name', '1234', 'project_name', 'model')
       ''')
       self.wp10db.commit()
       with client.session_transaction() as sess:


### PR DESCRIPTION
Currently you can click on the name of the builder in the card view in order to open the edit page.

This PR refactors some of the endpoints under `/v1/selection` to be `/v1/builders`.

The CreateSimpleList.vue page is renamed to SimpleList.vue and reworked so that it handles both initial input and editing builders.

Currently builders are NOT re-materialized when they are edited.