### PR TITLE
Use github actions to build images in GHCR and pull from there for deployment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,7 @@ jobs:
   build-and-push-images:
     strategy:
       matrix:
-        docker-file-location:
-          ['workers.Dockerfile', 'web.Dockerfile', 'frontend.Dockerfile']
+        project: ['workers', 'web', 'frontend']
 
     runs-on: ubuntu-latest
     permissions:
@@ -35,12 +34,12 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.project }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
-          file: ${{ matrix.docker_file_location }}
+          file: ${{ matrix.project }}.Dockerfile
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Wikipedia 1.0 engine
 
+DELETE ME
+
 This directory contains the code of Wikipedia 1.0 supporting
 software. More information about the Wikipedia 1.0 project can be
 found [on the Wikipedia in

--- a/README.md
+++ b/README.md
@@ -253,19 +253,21 @@ to something like:
 
 # Updating production
 
-- Since Docker Hub no longer auto builds images, you must build the images yourself.
-  From the wp1 directory, run the following commands to build and push the images:
+- Push to the release branch of the github repository:
   - `git checkout main`
   - `git pull origin main`
-  - `./build_production_images.sh`
+  - `git checkout release`
+  - `git merge main`
+  - `git push origin release`
+- Wait for the release images [to be built](https://github.com/openzim/wp1/actions/workflows/publish.yml)
 - Log in to the box that contains the production docker images. It is
   called wp1.
 - `cd /data/code/wp1/`
 - `sudo git pull origin main`
 - Pull the docker images from docker hub:
-  - `docker pull openzim/wp1bot-workers`
-  - `docker pull openzim/wp1bot-web`
-  - `docker pull openzim/wp1bot-frontend`
+  - `docker pull ghcr.io/openzim/wp1-workers`
+  - `docker pull ghcr.io/openzim/wp1-web`
+  - `docker pull ghcr.io/openzim/wp1-frontend`
 - Run docker-compose to bring the production images online.
   - `docker-compose up -d`
 - Run the production database migrations in the worker container:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Wikipedia 1.0 engine
 
-DELETE ME
-
 This directory contains the code of Wikipedia 1.0 supporting
 software. More information about the Wikipedia 1.0 project can be
 found [on the Wikipedia in

--- a/build_production_images.sh
+++ b/build_production_images.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -e
-
-docker build -f web.Dockerfile -t openzim/wp1bot-web .
-docker build -f workers.Dockerfile -t openzim/wp1bot-workers .
-docker build -f frontend.Dockerfile -t openzim/wp1bot-frontend .
-docker push openzim/wp1bot-web:latest
-docker push openzim/wp1bot-workers:latest
-docker push openzim/wp1bot-frontend:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     restart: always
 
   workers:
-    image: openzim/wp1bot-workers
+    image: ghcr.io/openzim/wp1-workers:release
     container_name: wp1bot-workers
     volumes:
       - /data/wp1bot/credentials.py:/usr/src/app/wp1/credentials.py
@@ -26,7 +26,7 @@ services:
       - redis
 
   web:
-    image: openzim/wp1bot-web
+    image: ghcr.io/openzim/wp1-web:release
     container_name: wp1bot-web
     environment:
       - VIRTUAL_HOST=api.wp1.openzim.org
@@ -50,7 +50,7 @@ services:
       - redis
 
   frontend:
-    image: openzim/wp1bot-frontend
+    image: ghcr.io/openzim/wp1-frontend:release
     container_name: wp1bot-frontend
     environment:
       - VIRTUAL_HOST=wp1.openzim.org


### PR DESCRIPTION
This PR finishes the work that was partially completed by directly committing to the master/release branches.

It "adds" the .github/workflows/publish.yml file (though it was technically added earlier) and configures it to publish the images available at: https://github.com/openzim/wp1/packages

It also updates the docker-compose.yml file to pull from this repository for the production images.

Finally, it updates the steps in the README

Fixes #423 