### PR TITLE
Add backup image to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,12 @@ services:
         max-size: '10k'
     restart: always
 
+  backup:
+    image: kiwix/borg-backup:latest
+    env_file:
+      - /data/wp1bot/db/.wp1db_backup.env
+    restart: always
+
 networks:
   default:
     name: openzim.org


### PR DESCRIPTION
In #454 @rgaudin added an env file that allows us to back up the WP1 database using a docker image running on the production server.

This PR adds that backup image to the production docker-compose file, so that it is automatically run when the WP1 server is deployed.