### PR TITLE
Create TEST environment and add docker-compose-test for faster unit tests.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -42,6 +42,11 @@ jobs:
         run: |
           mysql --host 127.0.0.1 --port 3306 -uroot -e 'CREATE DATABASE enwp10_test; CREATE DATABASE enwikip_test;'
 
+      - name: Copy credentials
+        run: |
+          cp wp1/credentials.py.e2e wp1/credentials.py
+          cp wp1/credentials.py.dev.e2e wp1/credentials.py.dev
+
       - name: Test with nose
         run: |
           nosetests --with-coverage

--- a/db/test/conf.d/test.cnf
+++ b/db/test/conf.d/test.cnf
@@ -1,0 +1,6 @@
+[mysqld]
+log-output=NONE
+slow-query-log=0
+innodb_flush_log_at_trx_commit=2
+innodb_log_buffer_size=3M
+innodb_buffer_pool_size=180M

--- a/db/test/init/01-databases.sql
+++ b/db/test/init/01-databases.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE `enwp10_test`;
+CREATE DATABASE `enwikip_test`;

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,7 +1,7 @@
 version: '3.5'
 
 services:
-  dev-database:
+  test-database:
     image: mysql:8.0.30
     container_name: wp1bot-test-db
     environment:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,0 +1,14 @@
+version: '3.5'
+
+services:
+  dev-database:
+    image: mysql:8.0.30
+    container_name: wp1bot-test-db
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 1
+    volumes:
+      - ./db/test/conf.d:/etc/mysql/conf.d
+      - ./db/test/init:/docker-entrypoint-initdb.d
+    ports:
+      - '6600:3306'
+    restart: always

--- a/wp1/api.py
+++ b/wp1/api.py
@@ -13,7 +13,7 @@ def get_credentials():
   try:
     from wp1.credentials import ENV, CREDENTIALS
     return CREDENTIALS[ENV]['API']
-  except ImportError:
+  except (ImportError, KeyError):
     # No credentials, probably in development environment.
     pass
 

--- a/wp1/base_db_test.py
+++ b/wp1/base_db_test.py
@@ -1,4 +1,5 @@
 import importlib
+import logging
 import unittest
 import sys
 
@@ -6,10 +7,12 @@ import pymysql
 
 from wp1.environment import Environment
 
+logger = logging.getLogger(__name__)
+
 try:
   from wp1.credentials import CREDENTIALS, ENV
 except ImportError:
-  logging.exception('The credentials.py file must be populated to run tests.')
+  logger.exception('The credentials.py file must be populated to run tests.')
   CREDENTIALS = None
   ENV = None
 

--- a/wp1/base_db_test.py
+++ b/wp1/base_db_test.py
@@ -6,6 +6,13 @@ import pymysql
 
 from wp1.environment import Environment
 
+try:
+  from wp1.credentials import CREDENTIALS, ENV
+except ImportError:
+  logging.exception('The credentials.py file must be populated to run tests.')
+  CREDENTIALS = None
+  ENV = None
+
 
 def parse_sql(filename):
   data = open(filename, 'r').readlines()
@@ -39,10 +46,15 @@ def parse_sql(filename):
 class BaseWpOneDbTest(unittest.TestCase):
 
   def connect_wp_one_db(self):
-    return pymysql.connect(host='localhost',
-                           port=6600,
-                           db='enwp10_test',
-                           user='root',
+    if ENV != Environment.TEST:
+      raise ValueError(
+          'Database tests destroy data! They should only be run in the TEST env'
+      )
+    creds = CREDENTIALS.get(Environment.TEST, {}).get('WP10DB')
+    if creds is None:
+      raise ValueError('No WP10DB creds found')
+
+    return pymysql.connect(**creds,
                            charset=None,
                            use_unicode=False,
                            cursorclass=pymysql.cursors.DictCursor)
@@ -71,10 +83,15 @@ class BaseWpOneDbTest(unittest.TestCase):
 class BaseWikiDbTest(unittest.TestCase):
 
   def connect_wiki_db(self):
-    return pymysql.connect(host='localhost',
-                           port=6600,
-                           db='enwikip_test',
-                           user='root',
+    if ENV != Environment.TEST:
+      raise ValueError(
+          'Database tests destroy data! They should only be run in the TEST env'
+      )
+    creds = CREDENTIALS.get(Environment.TEST, {}).get('WIKIDB')
+    if creds is None:
+      raise ValueError('No WIKIDB creds found')
+
+    return pymysql.connect(**creds,
                            charset=None,
                            use_unicode=False,
                            cursorclass=pymysql.cursors.DictCursor)

--- a/wp1/base_db_test.py
+++ b/wp1/base_db_test.py
@@ -108,26 +108,3 @@ class BaseCombinedDbTest(BaseWikiDbTest, BaseWpOneDbTest):
 
     self.addCleanup(self._cleanup_wp_one_db)
     self._setup_wp_one_db()
-
-
-def get_test_connect_creds():
-  return {
-      Environment.DEVELOPMENT: {
-          'WP10DB': {
-              'user': 'root',
-              'host': 'localhost',
-              'db': 'enwp10_test',
-          },
-          'WIKIDB': {
-              'user': 'root',
-              'host': 'localhost',
-              'db': 'enwikip_test',
-          },
-          # Put a phony Redis port so that nothing gets connected.
-          'REDIS': {
-              'host': 'localhost',
-              'port': 55555
-          },
-      },
-      Environment.PRODUCTION: {}
-  }

--- a/wp1/base_db_test.py
+++ b/wp1/base_db_test.py
@@ -38,6 +38,15 @@ def parse_sql(filename):
 
 class BaseWpOneDbTest(unittest.TestCase):
 
+  def connect_wp_one_db(self):
+    return pymysql.connect(host='localhost',
+                           port=6600,
+                           db='enwp10_test',
+                           user='root',
+                           charset=None,
+                           use_unicode=False,
+                           cursorclass=pymysql.cursors.DictCursor)
+
   def _cleanup_wp_one_db(self):
     stmts = parse_sql('wp10_test.down.sql')
     with self.wp10db.cursor() as cursor:
@@ -47,12 +56,7 @@ class BaseWpOneDbTest(unittest.TestCase):
     self.wp10db.close()
 
   def _setup_wp_one_db(self):
-    self.wp10db = pymysql.connect(host='localhost',
-                                  db='enwp10_test',
-                                  user='root',
-                                  charset=None,
-                                  use_unicode=False,
-                                  cursorclass=pymysql.cursors.DictCursor)
+    self.wp10db = self.connect_wp_one_db()
     stmts = parse_sql('wp10_test.up.sql')
     with self.wp10db.cursor() as cursor:
       for stmt in stmts:
@@ -66,6 +70,15 @@ class BaseWpOneDbTest(unittest.TestCase):
 
 class BaseWikiDbTest(unittest.TestCase):
 
+  def connect_wiki_db(self):
+    return pymysql.connect(host='localhost',
+                           port=6600,
+                           db='enwikip_test',
+                           user='root',
+                           charset=None,
+                           use_unicode=False,
+                           cursorclass=pymysql.cursors.DictCursor)
+
   def _cleanup_wiki_db(self):
     stmts = parse_sql('wiki_test.down.sql')
     with self.wikidb.cursor() as cursor:
@@ -75,12 +88,7 @@ class BaseWikiDbTest(unittest.TestCase):
     self.wikidb.close()
 
   def _setup_wiki_db(self):
-    self.wikidb = pymysql.connect(host='localhost',
-                                  db='enwikip_test',
-                                  user='root',
-                                  charset=None,
-                                  use_unicode=False,
-                                  cursorclass=pymysql.cursors.DictCursor)
+    self.wikidb = self.connect_wiki_db()
     stmts = parse_sql('wiki_test.up.sql')
     with self.wikidb.cursor() as cursor:
       for stmt in stmts:

--- a/wp1/credentials.py.dev.e2e
+++ b/wp1/credentials.py.dev.e2e
@@ -40,19 +40,6 @@ CREDENTIALS = {
             'bucket': 'org-kiwix-dev-wp1',
         },
     },
-    Environment.TEST: {
-        'WIKIDB': {
-            'user': 'root',
-            'host': 'localhost',
-            'port': 3306,
-            'db': 'enwikip_test',
-        },
-        'WP10DB': {
-            'user': 'root',
-            'host': 'localhost',
-            'port': 3306,
-            'db': 'enwp10_test',
-        },
-    },
+    Environment.TEST: {},
     Environment.PRODUCTION: {}
 }

--- a/wp1/credentials.py.dev.e2e
+++ b/wp1/credentials.py.dev.e2e
@@ -31,29 +31,6 @@ CREDENTIALS = {
             'port': 9736,
         },
 
-        # These don't exist in development.
-        'API': {},
-
-        # Credentials for authentication through mwoauth.
-        'MWOAUTH': {
-            'consumer_key': '',
-            'consumer_secret': '',
-        },
-
-        # This is meaningless in the docker-compose environment and should not have to be
-        # edited.
-        'SESSION': {
-            'secret_key': 'WP1_secret_key'
-        },
-
-        # Client side url used for redirection in login process. Also meaningless in the
-        # docker-compose environment and should not have to be edited.
-        'CLIENT_URL': {
-            'domains': ['http://localhost:3000'],
-            'homepage': 'http://localhost:3000/#/',
-            's3': 'https://org-kiwix-dev-wp1.s3.us-west-1.wasabisys.com',
-        },
-
         # Configuration for the storage backend for storing selection lists.
         # IMPORTANT: Materializing builders will not work in e2e cypress tests, since
         # these lines are left empty.
@@ -63,7 +40,19 @@ CREDENTIALS = {
             'bucket': 'org-kiwix-dev-wp1',
         },
     },
-
-    # EDIT: Remove the next line after you've provided actual credentials.
+    Environment.TEST: {
+        'WIKIDB': {
+            'user': 'root',
+            'host': 'localhost',
+            'port': 3306,
+            'db': 'enwikip_test',
+        },
+        'WP10DB': {
+            'user': 'root',
+            'host': 'localhost',
+            'port': 3306,
+            'db': 'enwp10_test',
+        },
+    },
     Environment.PRODUCTION: {}
 }

--- a/wp1/credentials.py.e2e
+++ b/wp1/credentials.py.e2e
@@ -1,10 +1,12 @@
 # This version of the credentials file is used in e2e testing, where the
 # web server is running in a docker container alongside the dev database,
 # also running in a Docker container.
-
+import sys
 from wp1.environment import Environment
 
-ENV = Environment.DEVELOPMENT
+# yapf: disable
+ENV = Environment.TEST if 'nose' in sys.modules.keys() else Environment.DEVELOPMENT
+# yapf: enable
 
 CREDENTIALS = {
     Environment.DEVELOPMENT: {
@@ -57,4 +59,5 @@ CREDENTIALS = {
             'db': 'enwp10_test',
         },
     },
+    Environment.PRODUCTION: {},
 }

--- a/wp1/credentials.py.e2e
+++ b/wp1/credentials.py.e2e
@@ -43,4 +43,18 @@ CREDENTIALS = {
             's3': 'https://org-kiwix-dev-wp1.s3.us-west-1.wasabisys.com',
         },
     },
+    Environment.TEST: {
+        'WIKIDB': {
+            'user': 'root',
+            'host': 'localhost',
+            'port': 3306,
+            'db': 'enwikip_test',
+        },
+        'WP10DB': {
+            'user': 'root',
+            'host': 'localhost',
+            'port': 3306,
+            'db': 'enwp10_test',
+        },
+    },
 }

--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -130,8 +130,9 @@ CREDENTIALS = {
             'port': 6600,
             'db': 'enwp10_test',
         },
+    },
 
-    # EDIT: Remove the next line after you've provided actual credentials.
+    # EDIT: Remove the next line after you've provided actual production credentials.
     Environment.PRODUCTION: {}
 
     # Example production config. Edit the indicated lines to provide credentials.

--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -2,7 +2,10 @@
 # database should work immediately after you run:
 # $ docker-compose -f docker-compose-dev.yml -d
 # in the root directory. The Wiki replica database requires actual toolforge
-# credentials to be accessible.
+# credentials to be accessible. The test database will be available when you run:
+# $ docker-compose -f docker-compose-test.yml -d
+# in the root directory.
+import sys
 
 from wp1.environment import Environment
 
@@ -10,7 +13,13 @@ from wp1.environment import Environment
 # the CREDENTIALS dictionary. When the app is run, it looks for the credentials for the
 # environment specified in this line. For development, this should remain
 # Environment.DEVELOPMENT. For production, it should be set to Environment.PRODUCTION.
-ENV = Environment.DEVELOPMENT
+# Uncomment the following line in production systems.
+# ENV = Environment.Production
+
+# yapf: disable
+# Comment the following line in production systems.
+ENV = Environment.TEST if 'nose' in sys.modules.keys() else Environment.DEVELOPMENT
+# yapf: enable
 
 # The directory under conf/ to look for the conf.json file in. So if this is
 # 'foo', the file will be loaded as conf/foo/conf.json. It is okay to check in
@@ -55,6 +64,21 @@ CREDENTIALS = {
         # These don't exist in development.
         'API': {}
 
+        # OAuth credentials for connecting to Wikipedia via OAuth. Required for
+        # logging into the development system
+        'CLIENT_OAUTH': {
+            'OAUTH_KEY': '', # EDIT this line
+            'OAUTH_SECRET': '', # EDIT this line
+        },
+
+        # Options for the "Development overlay" which mocks queue functionality
+        # in the development environment.
+        'OVERLAY': {
+            'update_wait_time_seconds': 40,
+            'job_elapsed_time_seconds': 10,
+            'basic_income_total_time_seconds': 60,
+        },
+
         # Credentials for authentication through mwoauth.
         # To register the app go to 'https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration/propose'
         'MWOAUTH': {
@@ -83,11 +107,29 @@ CREDENTIALS = {
         # See https://github.com/openzim/zimfarm/wiki/S3-Cache-Policy for how to
         # get these credentials.
         'STORAGE': {
-            'key': '',
-            'secret': '',
+            'key': '', # EDIT this line
+            'secret': '', # EDIT this line
             'bucket': 'org-kiwix-dev-wp1',
         },
     },
+
+    # Environment for python nosetests. In this environment, only the MySQL database
+    # connections for the WP10 and WIKI dbs are configured. No other services are available.
+    # This section should work as is, alongside the test database in docker-compose-test.yml
+    # Run that file ($ docker-compose -f docker-compose-test.yml up -d) before running tests.
+    Environment.TEST: {
+        'WIKIDB': {
+            'user': 'root',
+            'host': 'localhost',
+            'port': 6600,
+            'db': 'enwikip_test',
+        },
+        'WP10DB': {
+            'user': 'root',
+            'host': 'localhost',
+            'port': 6600,
+            'db': 'enwp10_test',
+        },
 
     # EDIT: Remove the next line after you've provided actual credentials.
     Environment.PRODUCTION: {}

--- a/wp1/db_test.py
+++ b/wp1/db_test.py
@@ -3,21 +3,17 @@ from unittest.mock import patch
 
 import pymysql.err
 
-from wp1.base_db_test import get_test_connect_creds
 from wp1.environment import Environment
 
 
 class DbTest(unittest.TestCase):
 
-  @patch('wp1.db.ENV', Environment.DEVELOPMENT)
-  @patch('wp1.db.CREDENTIALS', get_test_connect_creds())
-  def test_connect_works_with_creds(self):
+  def test_connect_works(self):
     from wp1.db import connect
     self.assertIsNotNone(connect('WP10DB'))
     self.assertIsNotNone(connect('WIKIDB'))
 
   @patch('wp1.db.ENV', Environment.PRODUCTION)
-  @patch('wp1.db.CREDENTIALS', get_test_connect_creds())
   def test_exception_thrown_with_empty_creds(self):
     from wp1.db import connect
     with self.assertRaises(ValueError):
@@ -26,8 +22,6 @@ class DbTest(unittest.TestCase):
     with self.assertRaises(ValueError):
       self.assertIsNotNone(connect('WIKIDB'))
 
-  @patch('wp1.db.ENV', Environment.DEVELOPMENT)
-  @patch('wp1.db.CREDENTIALS', get_test_connect_creds())
   @patch('wp1.db.pymysql.connect')
   @patch('wp1.db.time.sleep')
   def test_retries_four_times_failure(self, patched_sleep, patched_pymysql):

--- a/wp1/environment.py
+++ b/wp1/environment.py
@@ -4,3 +4,4 @@ import enum
 class Environment(enum.Enum):
   DEVELOPMENT = 0
   PRODUCTION = 1
+  TEST = 2

--- a/wp1/storage_test.py
+++ b/wp1/storage_test.py
@@ -7,24 +7,25 @@ from wp1.storage import connect_storage
 
 class StorageTest(unittest.TestCase):
 
+  @patch('wp1.storage.ENV', None)
   def test_connect_storage_raises_if_no_env(self):
     with self.assertRaises(ValueError):
       actual = connect_storage()
 
-  @patch('wp1.storage.ENV', Environment.DEVELOPMENT)
+  @patch('wp1.storage.ENV', Environment.TEST)
   def test_connect_storage_raises_if_no_credentials(self):
     with self.assertRaises(ValueError):
       actual = connect_storage()
 
-  @patch('wp1.storage.CREDENTIALS', {Environment.DEVELOPMENT: {}})
-  @patch('wp1.storage.ENV', Environment.DEVELOPMENT)
+  @patch('wp1.storage.CREDENTIALS', {Environment.TEST: {}})
+  @patch('wp1.storage.ENV', Environment.TEST)
   def test_connect_storage_raises_if_no_storage_key(self):
     with self.assertRaises(ValueError):
       actual = connect_storage()
 
   @patch(
       'wp1.storage.CREDENTIALS', {
-          Environment.DEVELOPMENT: {
+          Environment.TEST: {
               'STORAGE': {
                   'key': 'test_key',
                   'secret': 'test_secret',
@@ -32,7 +33,7 @@ class StorageTest(unittest.TestCase):
               }
           }
       })
-  @patch('wp1.storage.ENV', Environment.DEVELOPMENT)
+  @patch('wp1.storage.ENV', Environment.TEST)
   @patch('wp1.storage.KiwixStorage')
   def test_connect_storage_connects_to_kiwixstorage(self, patched_kiwixstorage):
     actual = connect_storage()
@@ -43,7 +44,7 @@ class StorageTest(unittest.TestCase):
 
   @patch(
       'wp1.storage.CREDENTIALS', {
-          Environment.DEVELOPMENT: {
+          Environment.TEST: {
               'STORAGE': {
                   'key': 'test_key',
                   'secret': 'test_secret',
@@ -51,7 +52,7 @@ class StorageTest(unittest.TestCase):
               }
           }
       })
-  @patch('wp1.storage.ENV', Environment.DEVELOPMENT)
+  @patch('wp1.storage.ENV', Environment.TEST)
   @patch('wp1.storage.KiwixStorage')
   def test_connect_storage_checks_permissions(self, patched_kiwixstorage):
     s3_mock = MagicMock()

--- a/wp1/web/app.py
+++ b/wp1/web/app.py
@@ -33,7 +33,7 @@ def get_redis_creds():
   try:
     from wp1.credentials import ENV, CREDENTIALS
     return CREDENTIALS[ENV]['REDIS']
-  except ImportError:
+  except (ImportError, KeyError):
     print('No REDIS_CREDS found, using defaults.')
     return None
 
@@ -42,7 +42,7 @@ def get_secret_key():
   try:
     from wp1.credentials import ENV, CREDENTIALS
     return CREDENTIALS[ENV]['SESSION']['secret_key']
-  except ImportError:
+  except (ImportError, KeyError):
     print('No secret_key found, using defaults.')
     return 'WP1'
 

--- a/wp1/web/base_web_testcase.py
+++ b/wp1/web/base_web_testcase.py
@@ -6,66 +6,14 @@ from flask import appcontext_pushed, g
 import fakeredis
 import pymysql
 
-from wp1.base_db_test import parse_sql
+from wp1.base_db_test import BaseCombinedDbTest
 from wp1.web.app import create_app
 
 
-class BaseWebTestcase(unittest.TestCase):
-
-  def _connect_wp_one_db(self):
-    return pymysql.connect(host='localhost',
-                           db='enwp10_test',
-                           user='root',
-                           charset=None,
-                           use_unicode=False,
-                           cursorclass=pymysql.cursors.DictCursor)
-
-  def _connect_wiki_db(self):
-    return pymysql.connect(host='localhost',
-                           db='enwikip_test',
-                           user='root',
-                           charset=None,
-                           use_unicode=False,
-                           cursorclass=pymysql.cursors.DictCursor)
-
-  def _cleanup_wp_one_db(self):
-    stmts = parse_sql('wp10_test.down.sql')
-    with self.wp10db.cursor() as cursor:
-      for stmt in stmts:
-        cursor.execute(stmt)
-    self.wp10db.commit()
-    self.wp10db.close()
-
-  def _setup_wp_one_db(self):
-    self.wp10db = self._connect_wp_one_db()
-    stmts = parse_sql('wp10_test.up.sql')
-    with self.wp10db.cursor() as cursor:
-      for stmt in stmts:
-        cursor.execute(stmt)
-    self.wp10db.commit()
-
-  def _cleanup_wiki_db(self):
-    stmts = parse_sql('wiki_test.down.sql')
-    with self.wikidb.cursor() as cursor:
-      for stmt in stmts:
-        cursor.execute(stmt)
-    self.wikidb.commit()
-    self.wikidb.close()
-
-  def _setup_wiki_db(self):
-    self.wikidb = self._connect_wiki_db()
-    stmts = parse_sql('wiki_test.up.sql')
-    with self.wikidb.cursor() as cursor:
-      for stmt in stmts:
-        cursor.execute(stmt)
-    self.wikidb.commit()
+class BaseWebTestcase(BaseCombinedDbTest):
 
   def setUp(self):
-    self.addCleanup(self._cleanup_wiki_db)
-    self._setup_wiki_db()
-
-    self.addCleanup(self._cleanup_wp_one_db)
-    self._setup_wp_one_db()
+    super().setUp()
 
     self.redis = fakeredis.FakeStrictRedis()
 
@@ -79,7 +27,7 @@ class BaseWebTestcase(unittest.TestCase):
     def set_wiki_db():
 
       def handler(sender, **kwargs):
-        g.wikidb = self._connect_wiki_db()
+        g.wikidb = self.connect_wiki_db()
 
       with appcontext_pushed.connected_to(handler, app):
         yield
@@ -88,7 +36,7 @@ class BaseWebTestcase(unittest.TestCase):
     def set_wp10_db():
 
       def handler(sender, **kwargs):
-        g.wp10db = self._connect_wp_one_db()
+        g.wp10db = self.connect_wp_one_db()
 
       with appcontext_pushed.connected_to(handler, app):
         yield

--- a/wp1/web/oauth.py
+++ b/wp1/web/oauth.py
@@ -15,9 +15,10 @@ try:
   handshaker = Handshaker("https://en.wikipedia.org/w/index.php",
                           consumer_token)
   homepage_url = CREDENTIALS[ENV]['CLIENT_URL']['homepage']
-except ImportError:
-  print('No credentials.py file found, Please add your '
-        'mwoauth credentials in credentials.py')
+except (ImportError, KeyError):
+  print(
+      'No credentials.py file found, or credentials malformed, Please add your '
+      'mwoauth credentials in credentials.py')
   ENV = None
   CREDENTIALS = None
   handshaker = None

--- a/wp1/web/projects_test.py
+++ b/wp1/web/projects_test.py
@@ -3,7 +3,6 @@ import json
 from unittest.mock import patch
 
 from wp1.logic import project as logic_project
-from wp1.base_db_test import get_test_connect_creds
 from wp1.web.app import create_app
 from wp1.web.base_web_testcase import BaseWebTestcase
 from wp1.environment import Environment

--- a/wp1/wiki_db_test.py
+++ b/wp1/wiki_db_test.py
@@ -1,14 +1,11 @@
 import unittest
 import unittest.mock
 
-from wp1.base_db_test import get_test_connect_creds
 from wp1.environment import Environment
 from wp1 import wiki_db
 
 
 class WikiDbTest(unittest.TestCase):
 
-  @unittest.mock.patch('wp1.db.ENV', Environment.DEVELOPMENT)
-  @unittest.mock.patch('wp1.db.CREDENTIALS', get_test_connect_creds())
-  def test_connect_works_with_creds(self):
+  def test_connect_works(self):
     self.assertIsNotNone(wiki_db.connect())

--- a/wp1/wp10_db_test.py
+++ b/wp1/wp10_db_test.py
@@ -1,14 +1,11 @@
 import unittest
 import unittest.mock
 
-from wp1.base_db_test import get_test_connect_creds
 from wp1.environment import Environment
 from wp1 import wp10_db
 
 
 class Wp10DbTest(unittest.TestCase):
 
-  @unittest.mock.patch('wp1.db.ENV', Environment.DEVELOPMENT)
-  @unittest.mock.patch('wp1.db.CREDENTIALS', get_test_connect_creds())
-  def test_connect_works_with_creds(self):
+  def test_connect_works(self):
     self.assertIsNotNone(wp10_db.connect())


### PR DESCRIPTION
As explained in #472, unit tests were taking too long on a development machine with local MySQL or MariaDB. This change provides a test database in docker-compose-test.yml that developers can run, which is set up to discard data and have no durability. This makes the tests run much faster.

In acknowledgement that developers might not want to run this test database and may wish to provide their own, this PR also adds a `Environment.TEST` value to the `Environment` enum. The TEST environment contains credentials for the wp10db and the wikidb, but nothing else. This PR also contains updates to additional files that expected credentials.py to be missing in tests.

Overall, this is a good change because it makes the test database configurable (at all, which it wasn't before). It also allows a developer to leave their credentials.py file in place and not have to "move it out of the way" for nosetests, which was something that caused credentials to be leaked in the past.