### PR TITLE
Version builders and selections, and store object_key on selection

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -9,6 +9,10 @@ database credentials).
 All migrations are in the `migrations` folder. See the YoYo docs for more details on how
 to add a new migration.
 
+If you get an "unknown column 'foo'" or similar message when running nosetests, make sure
+you've added the effects of the migration to the schema in wp10_test.up.sql. If you've
+added a new table, also make sure it's torn down in wp10_test.down.sql.
+
 See the sections in the main README on:
 
 1. Migrating the dev database.

--- a/db/migrations/20220813_01_rhr0D-add-current-version-column-to-builders.py
+++ b/db/migrations/20220813_01_rhr0D-add-current-version-column-to-builders.py
@@ -1,0 +1,13 @@
+"""
+Add current_version column to builders
+"""
+
+from yoyo import step
+
+__depends__ = {'20210724_03_C7FOH-selections-table'}
+
+steps = [
+    step(
+        "ALTER TABLE builders ADD COLUMN (b_current_version VARBINARY(255) NOT NULL)",
+        "ALTER TABLE builders DROP COLUMN b_current_version")
+]

--- a/db/migrations/20220813_01_rhr0D-add-current-version-column-to-builders.py
+++ b/db/migrations/20220813_01_rhr0D-add-current-version-column-to-builders.py
@@ -4,10 +4,11 @@ Add current_version column to builders
 
 from yoyo import step
 
-__depends__ = {'20210724_03_C7FOH-selections-table'}
+__depends__ = {'20210813_02_g8XdS-fix-selections-timestamp-columns'}
 
 steps = [
     step(
-        "ALTER TABLE builders ADD COLUMN (b_current_version VARBINARY(255) NOT NULL)",
-        "ALTER TABLE builders DROP COLUMN b_current_version")
+        "ALTER TABLE builders ADD COLUMN (b_current_version INTEGER NOT NULL DEFAULT 0)",
+        "ALTER TABLE builders DROP COLUMN b_current_version"),
+    step("UPDATE builders SET b_current_version = 1")
 ]

--- a/db/migrations/20220813_02_Yqp7y-add-version-column-to-selections.py
+++ b/db/migrations/20220813_02_Yqp7y-add-version-column-to-selections.py
@@ -1,0 +1,13 @@
+"""
+Add version column to selections
+"""
+
+from yoyo import step
+
+__depends__ = {'20220813_01_rhr0D-add-current-version-column-to-builders'}
+
+steps = [
+    step("ALTER TABLE selections ADD COLUMN (s_version INTEGER NOT NULL)",
+         "ALTER TABLE selections DROP COLUMN s_version"),
+    step("UPDATE selections SET s_version = 1")
+]

--- a/db/migrations/20220818_01_5x0T9-add-object-key-column-to-selections.py
+++ b/db/migrations/20220818_01_5x0T9-add-object-key-column-to-selections.py
@@ -1,0 +1,49 @@
+"""
+Add object_key column to selections
+"""
+
+from yoyo import group, step
+
+import wp1.logic.selection as logic_selection
+from wp1.redis_db import connect
+from wp1.selection.models.simple_builder import SimpleBuilder
+from wp1 import queues
+
+__depends__ = {'20220813_02_Yqp7y-add-version-column-to-selections'}
+
+
+def add_object_keys(conn):
+  cursor = conn.cursor()
+  cursor.execute('''SELECT s.s_id, s.s_content_type, b.b_model, b.b_name
+                    FROM selections AS s JOIN builders AS b ON s.s_builder_id = b.b_id
+            ''')
+  data = cursor.fetchall()
+  for row in data:
+    object_key = logic_selection.object_key_for(row[0].decode('utf-8'),
+                                                row[1].decode('utf-8'),
+                                                row[2].decode('utf-8'),
+                                                name=row[3].decode('utf-8'),
+                                                use_legacy_schema=True)
+    cursor.execute(
+        '''UPDATE selections
+           SET s_object_key = %s WHERE s_id = %s''', (object_key, row[0]))
+
+
+def re_materialize_builders(conn):
+  redis = connect()
+
+  cursor = conn.cursor()
+  cursor.execute('''SELECT b_id FROM builders''')
+  data = cursor.fetchall()
+  for row in data:
+    queues.enqueue_materialize(redis, SimpleBuilder, row[0],
+                               'text/tab-separated-values')
+
+
+steps = [
+    step(
+        "ALTER TABLE selections ADD COLUMN (s_object_key VARBINARY(255) NOT NULL)",
+        "ALTER TABLE selections DROP COLUMN s_object_key"),
+    step(add_object_keys),
+    step(re_materialize_builders),
+]

--- a/docker/dev-db/README.md
+++ b/docker/dev-db/README.md
@@ -14,8 +14,11 @@ The dev database will need to be migrated in the following circumstances:
 To migrate, cd to the `db/dev` directory and run the following command:
 
 ```bash
-yoyo apply
+PYTHONPATH=$PYTHONPATH:../.. yoyo apply
 ```
+
+The `PYTHONPATH` environment variable is necessary because some of the migrations
+import wp1 code in order to complete the migration.
 
 The YoYo Migrations application will read the data in `db/dev/yoyo.ini` and attempt
 to apply any necessary migrations to your database. If there are migrations to apply,

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -140,10 +140,7 @@ def get_builders_with_selections(wp10db, user_id):
               CONTENT_TYPE_TO_EXT.get(content_type, '???')
               if has_selection else None,
           's_url':
-              logic_selection.url_for(selection_id,
-                                      content_type,
-                                      b['b_model'].decode('utf-8'),
-                                      name=b['b_name'].decode('utf-8'))
+              logic_selection.url_for(b['s_object_key'])
               if has_selection else None,
       })
     return result

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -49,6 +49,22 @@ def insert_builder(wp10db, builder):
   return id_
 
 
+def update_current_version(wp10db, builder, version):
+  with wp10db.cursor() as cursor:
+    cursor.execute(
+        '''UPDATE builders
+      SET b_current_version=%(version)s
+      WHERE b_id = %(b_id)s AND b_user_id = %(b_user_id)s
+      ''', {
+            'version': version,
+            'b_id': builder.b_id,
+            'b_user_id': builder.b_user_id
+        })
+    rowcount = cursor.rowcount
+  wp10db.commit()
+  return rowcount > 0
+
+
 def update_builder(wp10db, builder):
   with wp10db.cursor() as cursor:
     cursor.execute(
@@ -88,7 +104,9 @@ def get_builders_with_selections(wp10db, user_id):
   with wp10db.cursor() as cursor:
     cursor.execute(
         '''SELECT * FROM selections
-                      RIGHT JOIN builders ON selections.s_builder_id=builders.b_id
+                      RIGHT JOIN builders
+                      ON selections.s_builder_id=builders.b_id
+                        AND selections.s_version=builders.b_current_version
                       WHERE b_user_id=%(b_user_id)s
                       ORDER BY selections.s_id ASC''', {'b_user_id': user_id})
     data = cursor.fetchall()

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -140,8 +140,10 @@ def get_builders_with_selections(wp10db, user_id):
               CONTENT_TYPE_TO_EXT.get(content_type, '???')
               if has_selection else None,
           's_url':
-              logic_selection.url_for(selection_id, content_type,
-                                      b['b_model'].decode('utf-8'))
+              logic_selection.url_for(selection_id,
+                                      content_type,
+                                      b['b_model'].decode('utf-8'),
+                                      name=b['b_name'].decode('utf-8'))
               if has_selection else None,
       })
     return result

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -54,7 +54,7 @@ class BuilderTest(BaseWpOneDbTest):
       's_extension':
           'tsv',
       's_url':
-          'http://credentials.not.found.fake/selections/wp1.selection.models.simple/1.tsv'
+          'http://credentials.not.found.fake/selections/wp1.selection.models.simple/1/My%20Builder.tsv'
   }]
 
   expected_lists_with_multiple_selections = [{
@@ -77,7 +77,7 @@ class BuilderTest(BaseWpOneDbTest):
       's_extension':
           'tsv',
       's_url':
-          'http://credentials.not.found.fake/selections/wp1.selection.models.simple/1.tsv',
+          'http://credentials.not.found.fake/selections/wp1.selection.models.simple/1/My%20Builder.tsv',
   }, {
       'id':
           1,
@@ -98,7 +98,7 @@ class BuilderTest(BaseWpOneDbTest):
       's_extension':
           'xls',
       's_url':
-          'http://credentials.not.found.fake/selections/wp1.selection.models.simple/2.xls',
+          'http://credentials.not.found.fake/selections/wp1.selection.models.simple/2/My%20Builder.xls',
   }]
 
   expected_lists_with_no_selections = [{
@@ -134,7 +134,7 @@ class BuilderTest(BaseWpOneDbTest):
       's_extension':
           '???',
       's_url':
-          'http://credentials.not.found.fake/selections/wp1.selection.models.simple/1.???',
+          'http://credentials.not.found.fake/selections/wp1.selection.models.simple/1/My%20Builder.%3F%3F%3F',
   }]
 
   def _insert_builder(self, version=None):

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -35,70 +35,40 @@ class BuilderTest(BaseWpOneDbTest):
   }
 
   expected_lists = [{
-      'id':
-          1,
-      'name':
-          'My Builder',
-      'project':
-          'en.wikipedia.fake',
-      'created_at':
-          1577249084,
-      'updated_at':
-          1577249084,
-      's_id':
-          '1',
-      's_updated_at':
-          1577249084,
-      's_content_type':
-          'text/tab-separated-values',
-      's_extension':
-          'tsv',
-      's_url':
-          'http://credentials.not.found.fake/selections/wp1.selection.models.simple/1/My%20Builder.tsv'
+      'id': 1,
+      'name': 'My Builder',
+      'project': 'en.wikipedia.fake',
+      'created_at': 1577249084,
+      'updated_at': 1577249084,
+      's_id': '1',
+      's_updated_at': 1577249084,
+      's_content_type': 'text/tab-separated-values',
+      's_extension': 'tsv',
+      's_url': 'http://credentials.not.found.fake/selections/foo/1234/name.tsv'
   }]
 
   expected_lists_with_multiple_selections = [{
-      'id':
-          1,
-      'name':
-          'My Builder',
-      'project':
-          'en.wikipedia.fake',
-      'created_at':
-          1577249084,
-      'updated_at':
-          1577249084,
-      's_id':
-          '1',
-      's_updated_at':
-          1577249084,
-      's_content_type':
-          'text/tab-separated-values',
-      's_extension':
-          'tsv',
-      's_url':
-          'http://credentials.not.found.fake/selections/wp1.selection.models.simple/1/My%20Builder.tsv',
+      'id': 1,
+      'name': 'My Builder',
+      'project': 'en.wikipedia.fake',
+      'created_at': 1577249084,
+      'updated_at': 1577249084,
+      's_id': '1',
+      's_updated_at': 1577249084,
+      's_content_type': 'text/tab-separated-values',
+      's_extension': 'tsv',
+      's_url': 'http://credentials.not.found.fake/object_key_1',
   }, {
-      'id':
-          1,
-      'name':
-          'My Builder',
-      'project':
-          'en.wikipedia.fake',
-      'created_at':
-          1577249084,
-      'updated_at':
-          1577249084,
-      's_id':
-          '2',
-      's_updated_at':
-          1577249084,
-      's_content_type':
-          'application/vnd.ms-excel',
-      's_extension':
-          'xls',
-      's_url':
-          'http://credentials.not.found.fake/selections/wp1.selection.models.simple/2/My%20Builder.xls',
+      'id': 1,
+      'name': 'My Builder',
+      'project': 'en.wikipedia.fake',
+      'created_at': 1577249084,
+      'updated_at': 1577249084,
+      's_id': '2',
+      's_updated_at': 1577249084,
+      's_content_type': 'application/vnd.ms-excel',
+      's_extension': 'xls',
+      's_url': 'http://credentials.not.found.fake/object_key_2',
   }]
 
   expected_lists_with_no_selections = [{
@@ -154,11 +124,15 @@ class BuilderTest(BaseWpOneDbTest):
     self.wp10db.commit()
     return id_
 
-  def _insert_selection(self, id_, content_type, version=1):
+  def _insert_selection(self,
+                        id_,
+                        content_type,
+                        version=1,
+                        object_key='selections/foo/1234/name.tsv'):
     with self.wp10db.cursor() as cursor:
       cursor.execute(
-          'INSERT INTO selections VALUES (%s, 1, %s, "20191225044444", %s)',
-          (id_, content_type, version))
+          'INSERT INTO selections VALUES (%s, 1, %s, "20191225044444", %s, %s)',
+          (id_, content_type, version, object_key))
     self.wp10db.commit()
 
   def _get_builder_by_user_id(self):
@@ -247,8 +221,12 @@ class BuilderTest(BaseWpOneDbTest):
   @patch('wp1.models.wp10.builder.utcnow',
          return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
   def test_get_builders_with_multiple_selections(self, mock_utcnow):
-    self._insert_selection(1, 'text/tab-separated-values')
-    self._insert_selection(2, 'application/vnd.ms-excel')
+    self._insert_selection(1,
+                           'text/tab-separated-values',
+                           object_key='object_key_1')
+    self._insert_selection(2,
+                           'application/vnd.ms-excel',
+                           object_key='object_key_2')
     self._insert_builder()
     article_data = logic_builder.get_builders_with_selections(
         self.wp10db, '1234')
@@ -294,7 +272,10 @@ class BuilderTest(BaseWpOneDbTest):
   @patch('wp1.models.wp10.builder.utcnow',
          return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
   def test_get_builders_with_unmapped_content_type(self, mock_utcnow):
-    self._insert_selection(1, 'foo/bar-baz')
+    self._insert_selection(
+        1,
+        'foo/bar-baz',
+        object_key='selections/wp1.selection.models.simple/1/My Builder.???')
     self._insert_builder()
     article_data = logic_builder.get_builders_with_selections(
         self.wp10db, '1234')

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -14,21 +14,35 @@ def insert_selection(wp10db, selection):
   with wp10db.cursor() as cursor:
     cursor.execute(
         '''INSERT INTO selections
-      (s_id, s_builder_id, s_content_type, s_updated_at)
-      VALUES (%(s_id)s, %(s_builder_id)s, %(s_content_type)s, %(s_updated_at)s)
+      (s_id, s_builder_id, s_version, s_content_type, s_updated_at)
+      VALUES (%(s_id)s, %(s_builder_id)s, %(s_version)s, %(s_content_type)s, %(s_updated_at)s)
     ''', attr.asdict(selection))
   wp10db.commit()
 
 
+def get_next_version(wp10db, builder_id, content_type):
+  with wp10db.cursor() as cursor:
+    cursor.execute(
+        '''SELECT MAX(s_version) as version FROM selections
+      WHERE s_builder_id = %s AND s_content_type = %s
+      ''', (builder_id, content_type))
+    data = cursor.fetchall()
+  version = data[0]['version']
+  if version is None:
+    return 1
+  else:
+    return version + 1
+
+
 def url_for_selection(selection, model):
   if not selection:
-    raise ValueError('Cannot get url for None selection')
+    raise ValueError('Cannot get url for empty selection')
   return '%s/%s' % (S3_PUBLIC_URL, object_key_for_selection(selection, model))
 
 
 def url_for(selection_id, content_type, model):
   if not selection_id:
-    raise ValueError('Cannot get url for None selection_id')
+    raise ValueError('Cannot get url for empty selection_id')
   if not model:
     raise ValueError('Expected WP1 model name, got: %r' % model)
   return '%s/%s' % (S3_PUBLIC_URL,
@@ -37,7 +51,7 @@ def url_for(selection_id, content_type, model):
 
 def object_key_for(selection_id, content_type, model):
   if not selection_id:
-    raise ValueError('Cannot get object key for None selection_id')
+    raise ValueError('Cannot get object key for empty selection_id')
   if not model:
     raise ValueError('Expected WP1 model name, got: %r' % model)
   ext = CONTENT_TYPE_TO_EXT.get(content_type, '???')
@@ -50,6 +64,6 @@ def object_key_for(selection_id, content_type, model):
 
 def object_key_for_selection(selection, model):
   if not selection:
-    raise ValueError('Cannot get object key for None selection')
+    raise ValueError('Cannot get object key for empty selection')
   return object_key_for(selection.s_id.decode('utf-8'),
                         selection.s_content_type.decode('utf-8'), model)

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -41,7 +41,8 @@ def get_next_version(wp10db, builder_id, content_type):
 def url_for_selection(selection, model, name=None):
   if not selection:
     raise ValueError('Cannot get url for empty selection')
-  path = urllib.parse.quote(object_key_for_selection(selection, model, name))
+  path = urllib.parse.quote(
+      object_key_for_selection(selection, model, name=name))
   return '%s/%s' % (S3_PUBLIC_URL, path)
 
 
@@ -51,11 +52,15 @@ def url_for(selection_id, content_type, model, name=None):
   if not model:
     raise ValueError('Expected WP1 model name, got: %r' % model)
   path = urllib.parse.quote(
-      object_key_for(selection_id, content_type, model, name))
+      object_key_for(selection_id, content_type, model, name=name))
   return '%s/%s' % (S3_PUBLIC_URL, path)
 
 
-def object_key_for(selection_id, content_type, model, name=None):
+def object_key_for(selection_id,
+                   content_type,
+                   model,
+                   name=None,
+                   use_legacy_schema=False):
   if not selection_id:
     raise ValueError('Cannot get object key for empty selection_id')
   if not model:
@@ -63,6 +68,13 @@ def object_key_for(selection_id, content_type, model, name=None):
   if name is None:
     name = DEFAULT_SELECTION_NAME
   ext = CONTENT_TYPE_TO_EXT.get(content_type, '???')
+  if use_legacy_schema:
+    return 'selections/%(model)s/%(id)s.%(ext)s' % {
+        'model': model,
+        'id': selection_id,
+        'ext': ext,
+    }
+
   return 'selections/%(model)s/%(id)s/%(name)s.%(ext)s' % {
       'model': model,
       'id': selection_id,
@@ -71,8 +83,14 @@ def object_key_for(selection_id, content_type, model, name=None):
   }
 
 
-def object_key_for_selection(selection, model, name=None):
+def object_key_for_selection(selection,
+                             model,
+                             name=None,
+                             use_legacy_schema=False):
   if not selection:
     raise ValueError('Cannot get object key for empty selection')
   return object_key_for(selection.s_id.decode('utf-8'),
-                        selection.s_content_type.decode('utf-8'), model, name)
+                        selection.s_content_type.decode('utf-8'),
+                        model,
+                        name=name,
+                        use_legacy_schema=use_legacy_schema)

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -39,7 +39,7 @@ def get_next_version(wp10db, builder_id, content_type):
     return version + 1
 
 
-def url_for_selection(selection, model, name=None):
+def url_for_selection(selection):
   if not selection:
     raise ValueError('Cannot get url for empty selection')
   return url_for(selection.s_object_key)

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -18,8 +18,9 @@ def insert_selection(wp10db, selection):
   with wp10db.cursor() as cursor:
     cursor.execute(
         '''INSERT INTO selections
-      (s_id, s_builder_id, s_version, s_content_type, s_updated_at)
-      VALUES (%(s_id)s, %(s_builder_id)s, %(s_version)s, %(s_content_type)s, %(s_updated_at)s)
+      (s_id, s_builder_id, s_version, s_content_type, s_updated_at, s_object_key)
+      VALUES (%(s_id)s, %(s_builder_id)s, %(s_version)s, %(s_content_type)s,
+      %(s_updated_at)s, %(s_object_key)s)
     ''', attr.asdict(selection))
   wp10db.commit()
 
@@ -41,18 +42,13 @@ def get_next_version(wp10db, builder_id, content_type):
 def url_for_selection(selection, model, name=None):
   if not selection:
     raise ValueError('Cannot get url for empty selection')
-  path = urllib.parse.quote(
-      object_key_for_selection(selection, model, name=name))
-  return '%s/%s' % (S3_PUBLIC_URL, path)
+  return url_for(selection.s_object_key)
 
 
-def url_for(selection_id, content_type, model, name=None):
-  if not selection_id:
-    raise ValueError('Cannot get url for empty selection_id')
-  if not model:
-    raise ValueError('Expected WP1 model name, got: %r' % model)
-  path = urllib.parse.quote(
-      object_key_for(selection_id, content_type, model, name=name))
+def url_for(object_key):
+  if not object_key:
+    raise ValueError('Cannot get url for empty object_key')
+  path = urllib.parse.quote(object_key)
   return '%s/%s' % (S3_PUBLIC_URL, path)
 
 

--- a/wp1/logic/selection_test.py
+++ b/wp1/logic/selection_test.py
@@ -115,13 +115,13 @@ class SelectionTest(BaseWpOneDbTest):
   def test_object_key_for_selection(self):
     actual = logic_selection.object_key_for_selection(self.selection,
                                                       'foo.bar.model')
-    self.assertEqual('selections/foo.bar.model/deadbeef.tsv', actual)
+    self.assertEqual('selections/foo.bar.model/deadbeef/selection.tsv', actual)
 
   def test_object_key_for_selection_unknown_content_type(self):
     self.selection.s_content_type = b'foo/bar-baz'
     actual = logic_selection.object_key_for_selection(self.selection,
                                                       'foo.bar.model')
-    self.assertEqual('selections/foo.bar.model/deadbeef.???', actual)
+    self.assertEqual('selections/foo.bar.model/deadbeef/selection.???', actual)
 
   def test_object_key_for_selection_none_selection(self):
     with self.assertRaises(ValueError):
@@ -135,7 +135,7 @@ class SelectionTest(BaseWpOneDbTest):
     actual = logic_selection.object_key_for('abcd-1234',
                                             'text/tab-separated-values',
                                             'foo.bar.model')
-    self.assertEqual('selections/foo.bar.model/abcd-1234.tsv', actual)
+    self.assertEqual('selections/foo.bar.model/abcd-1234/selection.tsv', actual)
 
   def test_object_key_for_none_selection_id(self):
     with self.assertRaises(ValueError):
@@ -144,7 +144,7 @@ class SelectionTest(BaseWpOneDbTest):
 
   def test_object_key_for_none_content_type(self):
     actual = logic_selection.object_key_for('abcd-1234', None, 'foo.bar.model')
-    self.assertEqual('selections/foo.bar.model/abcd-1234.???', actual)
+    self.assertEqual('selections/foo.bar.model/abcd-1234/selection.???', actual)
 
   def test_object_key_for_none_model(self):
     with self.assertRaises(ValueError):
@@ -154,7 +154,7 @@ class SelectionTest(BaseWpOneDbTest):
   def test_url_for_selection(self):
     actual = logic_selection.url_for_selection(self.selection, 'foo.bar.model')
     self.assertEqual(
-        'http://credentials.not.found.fake/selections/foo.bar.model/deadbeef.tsv',
+        'http://credentials.not.found.fake/selections/foo.bar.model/deadbeef/selection.tsv',
         actual)
 
   def test_url_for_selection_none_selection(self):
@@ -169,7 +169,7 @@ class SelectionTest(BaseWpOneDbTest):
     actual = logic_selection.url_for('abcd-1234', 'text/tab-separated-values',
                                      'foo.bar.model')
     self.assertEqual(
-        'http://credentials.not.found.fake/selections/foo.bar.model/abcd-1234.tsv',
+        'http://credentials.not.found.fake/selections/foo.bar.model/abcd-1234/selection.tsv',
         actual)
 
   def test_url_for_none_selection_id(self):
@@ -180,9 +180,76 @@ class SelectionTest(BaseWpOneDbTest):
   def test_url_for_none_content_type(self):
     actual = logic_selection.url_for('abcd-1234', None, 'foo.bar.model')
     self.assertEqual(
-        'http://credentials.not.found.fake/selections/foo.bar.model/abcd-1234.???',
+        'http://credentials.not.found.fake/selections/foo.bar.model/abcd-1234/selection.%3F%3F%3F',
         actual)
 
   def test_url_for_none_model(self):
     with self.assertRaises(ValueError):
       logic_selection.url_for('abcd-1234', 'text/tab-separated-values', None)
+
+  def test_object_key_for_selection_with_name(self):
+    actual = logic_selection.object_key_for_selection(self.selection,
+                                                      'foo.bar.model',
+                                                      name='name')
+    self.assertEqual('selections/foo.bar.model/deadbeef/name.tsv', actual)
+
+  def test_object_key_for_selection_unknown_content_type_and_name(self):
+    self.selection.s_content_type = b'foo/bar-baz'
+    actual = logic_selection.object_key_for_selection(self.selection,
+                                                      'foo.bar.model',
+                                                      name='name')
+    self.assertEqual('selections/foo.bar.model/deadbeef/name.???', actual)
+
+  def test_object_key_for(self):
+    actual = logic_selection.object_key_for('abcd-1234',
+                                            'text/tab-separated-values',
+                                            'foo.bar.model',
+                                            name='name')
+    self.assertEqual('selections/foo.bar.model/abcd-1234/name.tsv', actual)
+
+  def test_object_key_for_none_content_type_and_name(self):
+    actual = logic_selection.object_key_for('abcd-1234',
+                                            None,
+                                            'foo.bar.model',
+                                            name='name')
+    self.assertEqual('selections/foo.bar.model/abcd-1234/name.???', actual)
+
+  def test_url_for_selection_with_name(self):
+    actual = logic_selection.url_for_selection(self.selection,
+                                               'foo.bar.model',
+                                               name='name')
+    self.assertEqual(
+        'http://credentials.not.found.fake/selections/foo.bar.model/deadbeef/name.tsv',
+        actual)
+
+  def test_url_for_with_name(self):
+    actual = logic_selection.url_for('abcd-1234',
+                                     'text/tab-separated-values',
+                                     'foo.bar.model',
+                                     name='name')
+    self.assertEqual(
+        'http://credentials.not.found.fake/selections/foo.bar.model/abcd-1234/name.tsv',
+        actual)
+
+  def test_url_for_none_selection_id_with_name(self):
+    with self.assertRaises(ValueError):
+      logic_selection.url_for(None, 'text/tab-separated-values',
+                              'foo.bar.model')
+
+  def test_url_for_none_content_type_and_name(self):
+    actual = logic_selection.url_for('abcd-1234',
+                                     None,
+                                     'foo.bar.model',
+                                     name='name')
+    self.assertEqual(
+        'http://credentials.not.found.fake/selections/foo.bar.model/abcd-1234/name.%3F%3F%3F',
+        actual)
+
+  def test_url_for_quotes_url(self):
+    actual = logic_selection.url_for('abcd-1234',
+                                     'text/tab-separated-values',
+                                     'foo.bar.model',
+                                     name='My Nåmé')
+    self.assertEqual(
+        'http://credentials.not.found.fake/selections/foo.bar.model/abcd-1234/My%20N%C3%A5m%C3%A9.tsv',
+        actual)

--- a/wp1/logic/selection_test.py
+++ b/wp1/logic/selection_test.py
@@ -193,6 +193,13 @@ class SelectionTest(BaseWpOneDbTest):
                                                       name='name')
     self.assertEqual('selections/foo.bar.model/deadbeef/name.tsv', actual)
 
+  def test_object_key_for_selection_with_name_and_legacy_schema(self):
+    actual = logic_selection.object_key_for_selection(self.selection,
+                                                      'foo.bar.model',
+                                                      name='name',
+                                                      use_legacy_schema=True)
+    self.assertEqual('selections/foo.bar.model/deadbeef.tsv', actual)
+
   def test_object_key_for_selection_unknown_content_type_and_name(self):
     self.selection.s_content_type = b'foo/bar-baz'
     actual = logic_selection.object_key_for_selection(self.selection,

--- a/wp1/models/wp10/builder.py
+++ b/wp1/models/wp10/builder.py
@@ -23,6 +23,7 @@ class Builder:
   b_id = attr.ib(default=None)
   b_created_at = attr.ib(default=None)
   b_updated_at = attr.ib(default=None)
+  b_current_version = attr.ib(default=0)
 
   @property
   def created_at_dt(self):

--- a/wp1/models/wp10/selection.py
+++ b/wp1/models/wp10/selection.py
@@ -16,6 +16,7 @@ class Selection:
 
   s_builder_id = attr.ib()
   s_content_type = attr.ib()
+  s_version = attr.ib()
   # This is required, but is set by the set_id method below.
   s_id = attr.ib(default=None)
   s_updated_at = attr.ib(default=None)

--- a/wp1/models/wp10/selection.py
+++ b/wp1/models/wp10/selection.py
@@ -19,6 +19,8 @@ class Selection:
   s_version = attr.ib()
   # This is required, but is set by the set_id method below.
   s_id = attr.ib(default=None)
+  # This is required, but set after the selection is uploaded to s3-like storage.
+  s_object_key = attr.ib(default=None)
   s_updated_at = attr.ib(default=None)
   # The data that is stored in the backend s3-like storage. Not saved to the database.
   data = attr.ib(default=None)

--- a/wp1/models/wp10/selection_test.py
+++ b/wp1/models/wp10/selection_test.py
@@ -12,6 +12,7 @@ class ModelsSelectionTest(BaseWpOneDbTest):
     self.selection = Selection(s_id='deadbeef',
                                s_builder_id=100,
                                s_content_type='text/tab-separated-values',
+                               s_version=1,
                                s_updated_at=b'20190830112844')
 
   def test_updated_at_dt(self):

--- a/wp1/selection/abstract_builder.py
+++ b/wp1/selection/abstract_builder.py
@@ -14,7 +14,9 @@ class AbstractBuilder:
 
   def _upload_to_storage(self, s3, selection, builder):
     object_key = logic_selection.object_key_for_selection(
-        selection, builder.b_model.decode('utf-8'))
+        selection,
+        builder.b_model.decode('utf-8'),
+        name=builder.b_name.decode('utf-8'))
 
     upload_data = io.BytesIO()
     upload_data.write(selection.data)

--- a/wp1/selection/abstract_builder.py
+++ b/wp1/selection/abstract_builder.py
@@ -23,6 +23,7 @@ class AbstractBuilder:
     upload_data.seek(0)
     logger.info('Uploading to path: %s ' % object_key)
     s3.upload_fileobj(upload_data, key=object_key)
+    selection.s_object_key = object_key
 
   def materialize(self, s3, wp10db, builder, content_type):
     params = json.loads(builder.b_params)

--- a/wp1/selection/abstract_builder.py
+++ b/wp1/selection/abstract_builder.py
@@ -3,6 +3,7 @@ import json
 import logging
 
 from wp1.constants import CONTENT_TYPE_TO_EXT
+import wp1.logic.builder as logic_builder
 import wp1.logic.selection as logic_selection
 from wp1.models.wp10.selection import Selection
 
@@ -23,9 +24,12 @@ class AbstractBuilder:
 
   def materialize(self, s3, wp10db, builder, content_type):
     params = json.loads(builder.b_params)
+    next_version = logic_selection.get_next_version(wp10db, builder.b_id,
+                                                    content_type)
 
     selection = Selection(s_content_type=content_type.encode('utf-8'),
-                          s_builder_id=builder.b_id)
+                          s_builder_id=builder.b_id,
+                          s_version=next_version)
     selection.set_id()
     selection.data = self.build(content_type, **params)
     selection.set_updated_at_now()
@@ -34,6 +38,7 @@ class AbstractBuilder:
     logger.info('Saving selection %s to database' %
                 selection.s_id.decode('utf-8'))
     logic_selection.insert_selection(wp10db, selection)
+    logic_builder.update_current_version(wp10db, builder, next_version)
 
   def build(self, content_type, **params):
     raise NotImplementedError()

--- a/wp1/selection/abstract_builder_test.py
+++ b/wp1/selection/abstract_builder_test.py
@@ -62,5 +62,6 @@ class AbstractBuilderTest(BaseWpOneDbTest):
     data = self.s3.upload_fileobj.call_args[0][0]
     object_key = self.s3.upload_fileobj.call_args[1]['key']
     self.assertEqual(b'a\nb\nc', data.read())
-    self.assertEqual('selections/wp1.selection.models.simple/abcd-1234.tsv',
-                     object_key)
+    self.assertEqual(
+        'selections/wp1.selection.models.simple/abcd-1234/My Builder.tsv',
+        object_key)

--- a/wp1/selection/abstract_builder_test.py
+++ b/wp1/selection/abstract_builder_test.py
@@ -47,6 +47,15 @@ class AbstractBuilderTest(BaseWpOneDbTest):
     actual = _get_first_selection(self.wp10db)
     self.assertEqual(actual.s_id, b'abcd-1234')
 
+  @patch('wp1.models.wp10.selection.uuid.uuid4', return_value='abcd-1234')
+  def test_materialize_selection_object_key(self, mock_uuid4):
+    self.test_builder.materialize(self.s3, self.wp10db, self.builder,
+                                  'text/tab-separated-values')
+    actual = _get_first_selection(self.wp10db)
+    self.assertEqual(
+        actual.s_object_key, b'selections/wp1.selection.models.simple/'
+        b'abcd-1234/My Builder.tsv')
+
   @patch('wp1.models.wp10.selection.utcnow',
          return_value=datetime(2020, 12, 25, 10, 55, 44))
   def test_materialize_selection_updated_at(self, mock_utcnow):

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -42,9 +42,10 @@ def _create_or_update_builder(data, builder_id=None):
   if builder_id is None:
     flask.abort(404)
 
-  if not is_update:
-    queues.enqueue_materialize(redis, SimpleBuilder, builder_id,
-                               'text/tab-separated-values')
+  # The builder has been updated. Enqueue a task to materialize selections and
+  # update the current version.
+  queues.enqueue_materialize(redis, SimpleBuilder, builder_id,
+                             'text/tab-separated-values')
   return flask.jsonify({'success': True, 'items': {}})
 
 

--- a/wp1/web/selection_test.py
+++ b/wp1/web/selection_test.py
@@ -14,72 +14,42 @@ class SelectionTest(BaseWebTestcase):
 
   expected_list_data = {
       'builders': [{
-          'id':
-              1,
-          'name':
-              'name',
-          'project':
-              'project_name',
-          'created_at':
-              1608893744,
-          'updated_at':
-              1608893744,
-          's_id':
-              '1',
-          's_updated_at':
-              1608893744,
-          's_content_type':
-              'text/tab-separated-values',
-          's_extension':
-              'tsv',
-          's_url':
-              'http://credentials.not.found.fake/selections/model/1/name.tsv'
+          'id': 1,
+          'name': 'name',
+          'project': 'project_name',
+          'created_at': 1608893744,
+          'updated_at': 1608893744,
+          's_id': '1',
+          's_updated_at': 1608893744,
+          's_content_type': 'text/tab-separated-values',
+          's_extension': 'tsv',
+          's_url': 'http://credentials.not.found.fake/object_key'
       }],
   }
 
   expected_lists_with_multiple_selections = {
       'builders': [{
-          'id':
-              1,
-          'name':
-              'name',
-          'project':
-              'project_name',
-          'created_at':
-              1608893744,
-          'updated_at':
-              1608893744,
-          's_id':
-              '1',
-          's_updated_at':
-              1608893744,
-          's_content_type':
-              'text/tab-separated-values',
-          's_extension':
-              'tsv',
-          's_url':
-              'http://credentials.not.found.fake/selections/model/1/name.tsv'
+          'id': 1,
+          'name': 'name',
+          'project': 'project_name',
+          'created_at': 1608893744,
+          'updated_at': 1608893744,
+          's_id': '1',
+          's_updated_at': 1608893744,
+          's_content_type': 'text/tab-separated-values',
+          's_extension': 'tsv',
+          's_url': 'http://credentials.not.found.fake/object_key_1'
       }, {
-          'id':
-              1,
-          'name':
-              'name',
-          'project':
-              'project_name',
-          'created_at':
-              1608893744,
-          'updated_at':
-              1608893744,
-          's_id':
-              '2',
-          's_updated_at':
-              1608893744,
-          's_content_type':
-              'application/vnd.ms-excel',
-          's_extension':
-              'xls',
-          's_url':
-              'http://credentials.not.found.fake/selections/model/2/name.xls'
+          'id': 1,
+          'name': 'name',
+          'project': 'project_name',
+          'created_at': 1608893744,
+          'updated_at': 1608893744,
+          's_id': '2',
+          's_updated_at': 1608893744,
+          's_content_type': 'application/vnd.ms-excel',
+          's_extension': 'xls',
+          's_url': 'http://credentials.not.found.fake/object_key_2'
       }]
   }
 
@@ -107,7 +77,7 @@ class SelectionTest(BaseWebTestcase):
         VALUES ('name', '1234', 'project_name', 'model', '20201225105544', '20201225105544', 1)
       ''')
         cursor.execute(
-            'INSERT INTO selections VALUES (1, 1, "text/tab-separated-values", "20201225105544", 1)'
+            'INSERT INTO selections VALUES (1, 1, "text/tab-separated-values", "20201225105544", 1, "object_key")'
         )
       self.wp10db.commit()
       with client.session_transaction() as sess:
@@ -124,10 +94,10 @@ class SelectionTest(BaseWebTestcase):
         VALUES ('name', '1234', 'project_name', 'model', '20201225105544', '20201225105544', 1)
       ''')
         cursor.execute(
-            'INSERT INTO selections VALUES (1, 1, "text/tab-separated-values", "20201225105544", 1)'
+            'INSERT INTO selections VALUES (1, 1, "text/tab-separated-values", "20201225105544", 1, "object_key_1")'
         )
         cursor.execute(
-            'INSERT INTO selections VALUES (2, 1, "application/vnd.ms-excel", "20201225105544", 1)'
+            'INSERT INTO selections VALUES (2, 1, "application/vnd.ms-excel", "20201225105544", 1, "object_key_2")'
         )
       self.wp10db.commit()
       with client.session_transaction() as sess:
@@ -155,7 +125,7 @@ class SelectionTest(BaseWebTestcase):
     with self.override_db(self.app), self.app.test_client() as client:
       with self.wp10db.cursor() as cursor:
         cursor.execute(
-            '''INSERT INTO selections VALUES (2, 1, "application/vnd.ms-excel", '20201225105544', 1)'''
+            '''INSERT INTO selections VALUES (2, 1, "application/vnd.ms-excel", '20201225105544', 1, "object_key")'''
         )
       self.wp10db.commit()
       with client.session_transaction() as sess:

--- a/wp1/web/selection_test.py
+++ b/wp1/web/selection_test.py
@@ -14,42 +14,72 @@ class SelectionTest(BaseWebTestcase):
 
   expected_list_data = {
       'builders': [{
-          'id': 1,
-          'name': 'name',
-          'project': 'project_name',
-          'created_at': 1608893744,
-          'updated_at': 1608893744,
-          's_id': '1',
-          's_updated_at': 1608893744,
-          's_content_type': 'text/tab-separated-values',
-          's_extension': 'tsv',
-          's_url': 'http://credentials.not.found.fake/selections/model/1.tsv'
+          'id':
+              1,
+          'name':
+              'name',
+          'project':
+              'project_name',
+          'created_at':
+              1608893744,
+          'updated_at':
+              1608893744,
+          's_id':
+              '1',
+          's_updated_at':
+              1608893744,
+          's_content_type':
+              'text/tab-separated-values',
+          's_extension':
+              'tsv',
+          's_url':
+              'http://credentials.not.found.fake/selections/model/1/name.tsv'
       }],
   }
 
   expected_lists_with_multiple_selections = {
       'builders': [{
-          'id': 1,
-          'name': 'name',
-          'project': 'project_name',
-          'created_at': 1608893744,
-          'updated_at': 1608893744,
-          's_id': '1',
-          's_updated_at': 1608893744,
-          's_content_type': 'text/tab-separated-values',
-          's_extension': 'tsv',
-          's_url': 'http://credentials.not.found.fake/selections/model/1.tsv'
+          'id':
+              1,
+          'name':
+              'name',
+          'project':
+              'project_name',
+          'created_at':
+              1608893744,
+          'updated_at':
+              1608893744,
+          's_id':
+              '1',
+          's_updated_at':
+              1608893744,
+          's_content_type':
+              'text/tab-separated-values',
+          's_extension':
+              'tsv',
+          's_url':
+              'http://credentials.not.found.fake/selections/model/1/name.tsv'
       }, {
-          'id': 1,
-          'name': 'name',
-          'project': 'project_name',
-          'created_at': 1608893744,
-          'updated_at': 1608893744,
-          's_id': '2',
-          's_updated_at': 1608893744,
-          's_content_type': 'application/vnd.ms-excel',
-          's_extension': 'xls',
-          's_url': 'http://credentials.not.found.fake/selections/model/2.xls'
+          'id':
+              1,
+          'name':
+              'name',
+          'project':
+              'project_name',
+          'created_at':
+              1608893744,
+          'updated_at':
+              1608893744,
+          's_id':
+              '2',
+          's_updated_at':
+              1608893744,
+          's_content_type':
+              'application/vnd.ms-excel',
+          's_extension':
+              'xls',
+          's_url':
+              'http://credentials.not.found.fake/selections/model/2/name.xls'
       }]
   }
 

--- a/wp1/web/selection_test.py
+++ b/wp1/web/selection_test.py
@@ -73,11 +73,11 @@ class SelectionTest(BaseWebTestcase):
     with self.override_db(self.app), self.app.test_client() as client:
       with self.wp10db.cursor() as cursor:
         cursor.execute('''INSERT INTO builders
-        (b_name, b_user_id, b_project, b_model, b_created_at, b_updated_at)
-        VALUES ('name', '1234', 'project_name', 'model', '20201225105544', '20201225105544')
+        (b_name, b_user_id, b_project, b_model, b_created_at, b_updated_at, b_current_version)
+        VALUES ('name', '1234', 'project_name', 'model', '20201225105544', '20201225105544', 1)
       ''')
         cursor.execute(
-            'INSERT INTO selections VALUES (1, 1, "text/tab-separated-values", "20201225105544")'
+            'INSERT INTO selections VALUES (1, 1, "text/tab-separated-values", "20201225105544", 1)'
         )
       self.wp10db.commit()
       with client.session_transaction() as sess:
@@ -90,14 +90,14 @@ class SelectionTest(BaseWebTestcase):
     with self.override_db(self.app), self.app.test_client() as client:
       with self.wp10db.cursor() as cursor:
         cursor.execute('''INSERT INTO builders
-        (b_name, b_user_id, b_project, b_model, b_created_at, b_updated_at)
-        VALUES ('name', '1234', 'project_name', 'model', '20201225105544', '20201225105544')
+        (b_name, b_user_id, b_project, b_model, b_created_at, b_updated_at, b_current_version)
+        VALUES ('name', '1234', 'project_name', 'model', '20201225105544', '20201225105544', 1)
       ''')
         cursor.execute(
-            'INSERT INTO selections VALUES (1, 1, "text/tab-separated-values", "20201225105544")'
+            'INSERT INTO selections VALUES (1, 1, "text/tab-separated-values", "20201225105544", 1)'
         )
         cursor.execute(
-            'INSERT INTO selections VALUES (2, 1, "application/vnd.ms-excel", "20201225105544")'
+            'INSERT INTO selections VALUES (2, 1, "application/vnd.ms-excel", "20201225105544", 1)'
         )
       self.wp10db.commit()
       with client.session_transaction() as sess:
@@ -111,8 +111,8 @@ class SelectionTest(BaseWebTestcase):
     with self.override_db(self.app), self.app.test_client() as client:
       with self.wp10db.cursor() as cursor:
         cursor.execute('''INSERT INTO builders
-        (b_name, b_user_id, b_project, b_model, b_created_at, b_updated_at)
-        VALUES ('name', '1234', 'project_name', 'model', '20201225105544', '20201225105544')
+        (b_name, b_user_id, b_project, b_model, b_created_at, b_updated_at, b_current_version)
+        VALUES ('name', '1234', 'project_name', 'model', '20201225105544', '20201225105544', 1)
       ''')
       self.wp10db.commit()
       with client.session_transaction() as sess:
@@ -125,7 +125,7 @@ class SelectionTest(BaseWebTestcase):
     with self.override_db(self.app), self.app.test_client() as client:
       with self.wp10db.cursor() as cursor:
         cursor.execute(
-            '''INSERT INTO selections VALUES (2, 1, "application/vnd.ms-excel", '20201225105544')'''
+            '''INSERT INTO selections VALUES (2, 1, "application/vnd.ms-excel", '20201225105544', 1)'''
         )
       self.wp10db.commit()
       with client.session_transaction() as sess:

--- a/wp10_test.up.sql
+++ b/wp10_test.up.sql
@@ -109,7 +109,8 @@ CREATE TABLE `selections` (
   s_builder_id INTEGER NOT NULL,
   s_content_type VARBINARY(255) NOT NULL,
   s_updated_at BINARY(14) NOT NULL,
-  s_version int(11) NOT NULL
+  s_version int(11) NOT NULL,
+  s_object_key VARBINARY(255) NOT NULL
 );
 
 INSERT INTO `global_rankings` (gr_type, gr_rating, gr_ranking) VALUES ('importance', 'Unknown-Class', 0);

--- a/wp10_test.up.sql
+++ b/wp10_test.up.sql
@@ -98,6 +98,7 @@ CREATE TABLE `builders` (
   b_user_id INTEGER NOT NULL,
   b_project VARBINARY(255) NOT NULL,
   b_model VARBINARY(255) NOT NULL,
+  b_current_version int(11) NOT NULL DEFAULT '0',
   b_params BLOB,
   b_created_at BINARY(14),
   b_updated_at BINARY(14)
@@ -107,7 +108,8 @@ CREATE TABLE `selections` (
   s_id VARBINARY(255) NOT NULL PRIMARY KEY,
   s_builder_id INTEGER NOT NULL,
   s_content_type VARBINARY(255) NOT NULL,
-  s_updated_at BINARY(14) NOT NULL
+  s_updated_at BINARY(14) NOT NULL,
+  s_version int(11) NOT NULL
 );
 
 INSERT INTO `global_rankings` (gr_type, gr_rating, gr_ranking) VALUES ('importance', 'Unknown-Class', 0);


### PR DESCRIPTION
This is pre-work needed for #432 

We add a `version` column to selections and a `current_version` column to builders. Only selections that match the `current_version` of a builder are displayed in the interface (but see #487).

When a builder is updated and selections are re-materialized, the version increments by one. In the future, the download link will be a redirect to the most recent version.

The builder name is now used as part of the object_key of the selections. We also start storing the `object_key` (the s3-like storage key) of the selection in the database. This allows us to resolve the URL of the selection even when the builder name changes. Previously we were calculating these values on the fly.

This change contains no UI updates, besides returning the proper object_key for selections.