### PR TITLE
Change selection URL to redirect to latest version

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -436,6 +436,26 @@ paths:
           description: 'The id of the builder to update.'
           schema:
             type: string
+  /builders/{builderId}/selection/latest.{ext}:
+    get:
+      summary: 'Return a redirect to the latest materialization of the given builder in the given format.'
+      operationId: getBuilderSelectionLatest
+      responses:
+        302:
+          description: 'Successful operation, redirect to the list in the s3-like storage.'
+      parameters:
+        - name: builderId
+          in: path
+          required: true
+          description: 'The id of the builder whose latest selection should be retrieved.'
+          schema:
+            type: string
+        - name: ext
+          in: path
+          required: true
+          description: 'The requested extension of the selection list to be redirected to.'
+          schema:
+            type: string
   /selection/simple/lists:
     get:
       summary: 'Return list details from database'

--- a/wp1/constants.py
+++ b/wp1/constants.py
@@ -42,3 +42,6 @@ CONTENT_TYPE_TO_EXT = {
     'application/vnd.ms-excel': 'xls',
     b'application/vnd.ms-excel': 'xls',
 }
+
+EXT_TO_CONTENT_TYPE = dict(
+    (ext, ct) for ct, ext in CONTENT_TYPE_TO_EXT.items() if isinstance(ct, str))

--- a/wp1/credentials.py.e2e
+++ b/wp1/credentials.py.e2e
@@ -58,6 +58,9 @@ CREDENTIALS = {
             'port': 3306,
             'db': 'enwp10_test',
         },
+        'CLIENT_URL': {
+            'api': 'http://test.server.fake'
+        },
     },
     Environment.PRODUCTION: {},
 }

--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -130,6 +130,9 @@ CREDENTIALS = {
             'port': 6600,
             'db': 'enwp10_test',
         },
+        'CLIENT_URL': {
+            'api': 'http://test.server.fake'
+        },
     },
 
     # EDIT: Remove the next line after you've provided actual production credentials.

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -132,8 +132,9 @@ def latest_selection_url(wp10db, builder_id, ext):
            WHERE b.b_id = %s''', (content_type, builder_id))
     data = cursor.fetchone()
   if data is None:
-    logger.warning('Could not find latest selection for builder id=%s',
-                   builder_id)
+    logger.warning(
+        'Could not find latest selection for builder id=%s, content_type=%s',
+        builder_id, content_type)
     return None
 
   return logic_selection.url_for(data['object_key'].decode('utf-8'))

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -44,7 +44,7 @@ class BuilderTest(BaseWpOneDbTest):
       's_updated_at': 1577249084,
       's_content_type': 'text/tab-separated-values',
       's_extension': 'tsv',
-      's_url': 'http://credentials.not.found.fake/selections/foo/1234/name.tsv'
+      's_url': 'http://test.server.fake/v1/builders/1/selection/latest.tsv'
   }]
 
   expected_lists_with_multiple_selections = [{
@@ -57,7 +57,7 @@ class BuilderTest(BaseWpOneDbTest):
       's_updated_at': 1577249084,
       's_content_type': 'text/tab-separated-values',
       's_extension': 'tsv',
-      's_url': 'http://credentials.not.found.fake/object_key_1',
+      's_url': 'http://test.server.fake/v1/builders/1/selection/latest.tsv',
   }, {
       'id': 1,
       'name': 'My Builder',
@@ -68,7 +68,7 @@ class BuilderTest(BaseWpOneDbTest):
       's_updated_at': 1577249084,
       's_content_type': 'application/vnd.ms-excel',
       's_extension': 'xls',
-      's_url': 'http://credentials.not.found.fake/object_key_2',
+      's_url': 'http://test.server.fake/v1/builders/1/selection/latest.xls',
   }]
 
   expected_lists_with_no_selections = [{
@@ -85,26 +85,16 @@ class BuilderTest(BaseWpOneDbTest):
   }]
 
   expected_lists_with_unmapped_selections = [{
-      'id':
-          1,
-      'name':
-          'My Builder',
-      'project':
-          'en.wikipedia.fake',
-      'created_at':
-          1577249084,
-      'updated_at':
-          1577249084,
-      's_id':
-          '1',
-      's_updated_at':
-          1577249084,
-      's_content_type':
-          'foo/bar-baz',
-      's_extension':
-          '???',
-      's_url':
-          'http://credentials.not.found.fake/selections/wp1.selection.models.simple/1/My%20Builder.%3F%3F%3F',
+      'id': 1,
+      'name': 'My Builder',
+      'project': 'en.wikipedia.fake',
+      'created_at': 1577249084,
+      'updated_at': 1577249084,
+      's_id': '1',
+      's_updated_at': 1577249084,
+      's_content_type': 'foo/bar-baz',
+      's_extension': '???',
+      's_url': None,
   }]
 
   def _insert_builder(self, version=None):

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -48,7 +48,8 @@ def url_for_selection(selection):
 def url_for(object_key):
   if not object_key:
     raise ValueError('Cannot get url for empty object_key')
-  path = urllib.parse.quote(object_key)
+  path = urllib.parse.quote(
+      object_key if isinstance(object_key, str) else object_key.decode('utf-8'))
   return '%s/%s' % (S3_PUBLIC_URL, path)
 
 

--- a/wp1/logic/selection_test.py
+++ b/wp1/logic/selection_test.py
@@ -178,6 +178,13 @@ class SelectionTest(BaseWpOneDbTest):
         'http://credentials.not.found.fake/selections/foo.bar.model/abcd-1234/selection.tsv',
         actual)
 
+  def test_url_for_bytes(self):
+    actual = logic_selection.url_for(
+        b'selections/foo.bar.model/abcd-1234/selection.tsv')
+    self.assertEqual(
+        'http://credentials.not.found.fake/selections/foo.bar.model/abcd-1234/selection.tsv',
+        actual)
+
   def test_url_for_none_object_id(self):
     with self.assertRaises(ValueError):
       logic_selection.url_for(None)

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -77,3 +77,15 @@ def get_builder(builder_id):
     flask.abort(404)
 
   return flask.jsonify(builder.to_web_dict())
+
+
+@builders.route('/<builder_id>/selection/latest.<ext>')
+def latest_selection_for_builder(builder_id, ext):
+  wp10db = get_db('wp10db')
+
+  url = logic_builder.latest_selection_url(wp10db, builder_id, ext)
+  if not url:
+    print(404)
+    flask.abort(404)
+
+  return flask.redirect(url, code=302)

--- a/wp1/web/selection_test.py
+++ b/wp1/web/selection_test.py
@@ -23,7 +23,7 @@ class SelectionTest(BaseWebTestcase):
           's_updated_at': 1608893744,
           's_content_type': 'text/tab-separated-values',
           's_extension': 'tsv',
-          's_url': 'http://credentials.not.found.fake/object_key'
+          's_url': 'http://test.server.fake/v1/builders/1/selection/latest.tsv'
       }],
   }
 
@@ -38,7 +38,7 @@ class SelectionTest(BaseWebTestcase):
           's_updated_at': 1608893744,
           's_content_type': 'text/tab-separated-values',
           's_extension': 'tsv',
-          's_url': 'http://credentials.not.found.fake/object_key_1'
+          's_url': 'http://test.server.fake/v1/builders/1/selection/latest.tsv'
       }, {
           'id': 1,
           'name': 'name',
@@ -49,7 +49,7 @@ class SelectionTest(BaseWebTestcase):
           's_updated_at': 1608893744,
           's_content_type': 'application/vnd.ms-excel',
           's_extension': 'xls',
-          's_url': 'http://credentials.not.found.fake/object_key_2'
+          's_url': 'http://test.server.fake/v1/builders/1/selection/latest.xls'
       }]
   }
 


### PR DESCRIPTION
Fixes #432

Instead of returning URLs that point to the object storage directly, the selection API now returns URLs that point to a new endpoint on the WP1 API server, that 302 redirects to the object storage. See the attached issue for more details.