### PR TITLE
Add support for deleting builders and associated selections

### DIFF
--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -133,6 +133,11 @@ CREDENTIALS = {
         'CLIENT_URL': {
             'api': 'http://test.server.fake'
         },
+        'STORAGE': {
+            'key': 'test_key',
+            'secret': 'test_secret',
+            'bucket': 'org-kiwix-dev-wp1',
+        },
     },
 
     # EDIT: Remove the next line after you've provided actual production credentials.

--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -101,6 +101,7 @@ CREDENTIALS = {
             'domains': ['http://localhost:3000'],
             'homepage': 'http://localhost:3000/#/',
             's3': 'https://org-kiwix-dev-wp1.s3.us-west-1.wasabisys.com',
+            'api': 'http://localhost:5000',
         },
 
         # Configuration for the storage backend for storing selection lists.
@@ -197,6 +198,7 @@ CREDENTIALS = {
     #       'domains': ['http://wp1.openzim.org', 'https://wp1.openzim.org'],
     #       'homepage': 'https://wp1.openzim.org/#/',
     #       's3': 'https://org-kiwix-wp1.s3.us-west-1.wasabisys.com',
+    #       'api': 'https://api.wp1.openzim.org',
     #   },
 
     # Configuration for the storage backend for storing selection lists.

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -81,6 +81,7 @@ def update_builder(wp10db, builder):
 
 
 def delete_builder(wp10db, user_id, builder_id):
+  logger.warning('%s %s' % (user_id, builder_id))
   with wp10db.cursor() as cursor:
     cursor.execute(
         '''SELECT s.s_object_key as object_key FROM selections AS s

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -42,9 +42,10 @@ def insert_builder(wp10db, builder):
   with wp10db.cursor() as cursor:
     cursor.execute(
         '''INSERT INTO builders
-        (b_name, b_user_id, b_project, b_params, b_model, b_created_at, b_updated_at)
-        VALUES (%(b_name)s, %(b_user_id)s, %(b_project)s, %(b_params)s, %(b_model)s, %(b_created_at)s, %(b_updated_at)s)
-      ''', attr.asdict(builder))
+             (b_name, b_user_id, b_project, b_params, b_model, b_created_at, b_updated_at)
+           VALUES (%(b_name)s, %(b_user_id)s, %(b_project)s, %(b_params)s, %(b_model)s,
+                   %(b_created_at)s, %(b_updated_at)s)
+        ''', attr.asdict(builder))
     id_ = cursor.lastrowid
   wp10db.commit()
   return id_
@@ -54,9 +55,9 @@ def update_current_version(wp10db, builder, version):
   with wp10db.cursor() as cursor:
     cursor.execute(
         '''UPDATE builders
-      SET b_current_version=%(version)s
-      WHERE b_id = %(b_id)s AND b_user_id = %(b_user_id)s
-      ''', {
+           SET b_current_version=%(version)s
+           WHERE b_id = %(b_id)s AND b_user_id = %(b_user_id)s
+        ''', {
             'version': version,
             'b_id': builder.b_id,
             'b_user_id': builder.b_user_id
@@ -70,11 +71,32 @@ def update_builder(wp10db, builder):
   with wp10db.cursor() as cursor:
     cursor.execute(
         '''UPDATE builders
-      SET b_name = %(b_name)s, b_project = %(b_project)s, b_params = %(b_params)s, b_model = %(b_model)s,
-          b_updated_at = %(b_updated_at)s
-      WHERE b_id = %(b_id)s AND b_user_id = %(b_user_id)s
-      ''', attr.asdict(builder))
+          SET b_name = %(b_name)s, b_project = %(b_project)s, b_params = %(b_params)s, b_model = %(b_model)s,
+              b_updated_at = %(b_updated_at)s
+          WHERE b_id = %(b_id)s AND b_user_id = %(b_user_id)s
+        ''', attr.asdict(builder))
     rowcount = cursor.rowcount
+  wp10db.commit()
+  return rowcount > 0
+
+
+def delete_builder(wp10db, user_id, builder_id):
+  with wp10db.cursor() as cursor:
+    cursor.execute(
+        '''SELECT s.s_object_key as object_key FROM selections AS s
+           JOIN builders AS b ON b.b_id = s.s_builder_id
+           WHERE b.b_user_id = %s AND b.b_id = %s
+        ''', (user_id, builder_id))
+    object_ids_to_delete = [d['object_key'] for d in cursor.fetchall()]
+    cursor.execute(
+        '''DELETE b, s FROM builders AS b
+           JOIN selections AS s ON s.s_builder_id = b.b_id
+           WHERE b.b_user_id = %s AND b.b_id = %s
+        ''', (user_id, builder_id))
+    rowcount = cursor.rowcount
+
+  # TODO: delete the object keys from s3
+
   wp10db.commit()
   return rowcount > 0
 
@@ -129,7 +151,8 @@ def latest_selection_url(wp10db, builder_id, ext):
              ON s.s_builder_id = b.b_id
              AND s.s_version = b.b_current_version
              AND s.s_content_type = %s
-           WHERE b.b_id = %s''', (content_type, builder_id))
+           WHERE b.b_id = %s
+        ''', (content_type, builder_id))
     data = cursor.fetchone()
   if data is None:
     logger.warning(
@@ -148,7 +171,8 @@ def get_builders_with_selections(wp10db, user_id):
              ON selections.s_builder_id=builders.b_id
              AND selections.s_version=builders.b_current_version
            WHERE b_user_id=%(b_user_id)s
-           ORDER BY selections.s_id ASC''', {'b_user_id': user_id})
+           ORDER BY selections.s_id ASC
+        ''', {'b_user_id': user_id})
     data = cursor.fetchall()
 
     builders = {}

--- a/wp1/storage_test.py
+++ b/wp1/storage_test.py
@@ -12,6 +12,7 @@ class StorageTest(unittest.TestCase):
     with self.assertRaises(ValueError):
       actual = connect_storage()
 
+  @patch('wp1.storage.CREDENTIALS', {Environment.TEST: {}})
   @patch('wp1.storage.ENV', Environment.TEST)
   def test_connect_storage_raises_if_no_credentials(self):
     with self.assertRaises(ValueError):

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -79,6 +79,20 @@ def get_builder(builder_id):
   return flask.jsonify(builder.to_web_dict())
 
 
+@builders.route('/<builder_id>/delete', methods=['POST'])
+@authenticate
+def delete_builder(builder_id):
+  wp10db = get_db('wp10db')
+  user_id = flask.session['user']['identity']['sub']
+
+  status = logic_builder.delete_builder(wp10db, user_id, builder_id)
+
+  if not status['db_delete_success']:
+    flask.abort(404)
+
+  return {'status': '204'}
+
+
 @builders.route('/<builder_id>/selection/latest.<ext>')
 def latest_selection_for_builder(builder_id, ext):
   wp10db = get_db('wp10db')


### PR DESCRIPTION
This PR provides the infrastructure and frontend (full feature) for deleting builders and any selections associated with them. It will remove the builders and selections from the database and attempt to delete the object keys for the selections from the s3-like storage. Currently the return value of the s3 RPC is not checked and it could fail, with orphaned files being left in s3. Bug #491 tracks fixing this.

There is a bit of confusion around the terminology here. The backend refers to the named entity which defines the blueprint for creating an article list as a "builder", and the materialized list itself which is stored in s3 as a "selection". The frontend refers to the builder as "Simple Selection" and when you save or delete one it says "Save/Delete List". The frontend also conflates the concepts of builders and selections when listing the "My Selections" table, because it includes the name and dates from the builder, but the download link and "download updated" date from the selection. There can possibly be multiple selections with the same "name" in this table, as we add support for different output formats for simple builders and others.