### PR TITLE
Comments and whitespace in Simple builders

### DIFF
--- a/wp1-frontend/src/components/SimpleList.vue
+++ b/wp1-frontend/src/components/SimpleList.vue
@@ -59,7 +59,8 @@
                 v-on:blur="validationOnBlur"
                 v-model="builder.articles"
                 :placeholder="
-                  'Eiffel_Tower\nStatue_of_Liberty\nFreedom_Monument_(Baghdad)\nGeorge-Étienne_Cartier_Monument'
+                  'Eiffel_Tower\nStatue_of_Liberty\nFreedom_Monument_(Baghdad)\nGeorge-Étienne_Cartier_Monument' +
+                    '\n\n# Whitespace and comments starting with # are ignored'
                 "
                 class="form-control my-list"
                 rows="13"

--- a/wp1/selection/models/simple_builder.py
+++ b/wp1/selection/models/simple_builder.py
@@ -13,9 +13,9 @@ class SimpleBuilder(AbstractBuilder):
             f'Missing required param: list, unnecessary argument given: {list(params.keys())[0]}'
         )
       list_minus_comments = [
-          l.strip()
-          for l in params['list']
-          if l.strip() != '' and not l.startswith('#')
+          line.strip()
+          for line in params['list']
+          if line.strip() != '' and not line.startswith('#')
       ]
       return '\n'.join(list_minus_comments).encode('utf-8')
     raise ValueError('Additional unnecessary params present')

--- a/wp1/selection/models/simple_builder.py
+++ b/wp1/selection/models/simple_builder.py
@@ -12,8 +12,6 @@ class SimpleBuilder(AbstractBuilder):
         raise ValueError(
             f'Missing required param: list, unnecessary argument given: {list(params.keys())[0]}'
         )
-      for l in params['list']:
-        print(repr(l), repr(l.strip()))
       list_minus_comments = [
           l for l in params['list'] if l.strip() != '' and not l.startswith('#')
       ]

--- a/wp1/selection/models/simple_builder.py
+++ b/wp1/selection/models/simple_builder.py
@@ -13,7 +13,9 @@ class SimpleBuilder(AbstractBuilder):
             f'Missing required param: list, unnecessary argument given: {list(params.keys())[0]}'
         )
       list_minus_comments = [
-          l for l in params['list'] if l.strip() != '' and not l.startswith('#')
+          l.strip()
+          for l in params['list']
+          if l.strip() != '' and not l.startswith('#')
       ]
       return '\n'.join(list_minus_comments).encode('utf-8')
     raise ValueError('Additional unnecessary params present')

--- a/wp1/selection/models/simple_builder.py
+++ b/wp1/selection/models/simple_builder.py
@@ -8,11 +8,16 @@ class SimpleBuilder(AbstractBuilder):
     if content_type != 'text/tab-separated-values':
       raise ValueError('Unrecognized content type')
     if len(params) == 1:
-      if 'list' in params:
-        return '\n'.join(params['list']).encode('utf-8')
-      raise ValueError(
-          f'Missing required param: list, unnecessary argument given: {list(params.keys())[0]}'
-      )
+      if 'list' not in params:
+        raise ValueError(
+            f'Missing required param: list, unnecessary argument given: {list(params.keys())[0]}'
+        )
+      for l in params['list']:
+        print(repr(l), repr(l.strip()))
+      list_minus_comments = [
+          l for l in params['list'] if l.strip() != '' and not l.startswith('#')
+      ]
+      return '\n'.join(list_minus_comments).encode('utf-8')
     raise ValueError('Additional unnecessary params present')
 
   def validate(self, **params):
@@ -25,6 +30,9 @@ class SimpleBuilder(AbstractBuilder):
     for item in params['list']:
       is_valid = True
       item = item.strip().replace(" ", "_")
+      # Ignore lines that are only whitespace or that start with a comment
+      if item == '' or item.startswith('#'):
+        continue
       decoded_item = urllib.parse.unquote(item)
       len_item = len(decoded_item.encode("utf-8"))
       char_set = ["#", "<", ">", "[", "]", "{", "}", "|"]

--- a/wp1/selection/models/simple_builder_test.py
+++ b/wp1/selection/models/simple_builder_test.py
@@ -48,6 +48,32 @@ of text than an actual article name.', 'Not_an_<article_name>',
     with self.assertRaises(ValueError):
       simple_test_builder.build('text/tab-separated-values', **params)
 
+  def test_build_ignores_comments(self):
+    simple_test_builder = SimpleBuilder()
+    expected = b'Eiffel_Tower\nStatue_of_Liberty\nLiberty_(personification)'
+    params = {
+        'list': [
+            '# Starting with a comment', '\n', 'Eiffel_Tower', '# Comment here',
+            '# Consecutive comments', 'Statue_of_Liberty',
+            '###Comment with lots of #', 'Liberty_(personification)',
+            '#Ending with a comment#'
+        ]
+    }
+    actual = simple_test_builder.build('text/tab-separated-values', **params)
+    self.assertEqual(expected, actual)
+
+  def test_build_ignores_whitespace(self):
+    simple_test_builder = SimpleBuilder()
+    expected = b'Eiffel_Tower\nStatue_of_Liberty\nLiberty_(personification)'
+    params = {
+        'list': [
+            '\n', '  Eiffel_Tower', '\n\t  \n  \t', 'Statue_of_Liberty  ',
+            '   ', 'Liberty_(personification)', '\n\n\n'
+        ],
+    }
+    actual = simple_test_builder.build('text/tab-separated-values', **params)
+    self.assertEqual(expected, actual)
+
   def test_validate_items(self):
     simple_builder_test = SimpleBuilder()
     expected = ([
@@ -74,3 +100,35 @@ of text than an actual article name.', 'Not_an_<article_name>',
     params = {'list': []}
     actual = simple_test_builder.validate(**params)
     self.assertEqual(([], [], ['Empty List']), actual)
+
+  def test_validate_whitespace_lines_ignored(self):
+    simple_builder_test = SimpleBuilder()
+    expected = ([
+        'Eiffel_Tower', 'Statue_of_Liberty', 'Liberty_(personification)'
+    ], [], [])
+    params = {
+        'list': [
+            '\n', '  Eiffel_Tower', '\n\t  \n  \t', 'Statue_of_Liberty  ',
+            '   ', 'Liberty_(personification)', '\n\n\n'
+        ],
+        'project': 'project_name'
+    }
+    actual = simple_builder_test.validate(**params)
+    self.assertEqual(expected, actual)
+
+  def test_validate_comments_ignored(self):
+    simple_builder_test = SimpleBuilder()
+    expected = ([
+        'Eiffel_Tower', 'Statue_of_Liberty', 'Liberty_(personification)'
+    ], [], [])
+    params = {
+        'list': [
+            '# Starting with a comment', '\n', 'Eiffel_Tower', '# Comment here',
+            '# Consecutive comments', 'Statue_of_Liberty',
+            '###Comment with lots of #', 'Liberty_(personification)',
+            '#Ending with a comment#'
+        ],
+        'project': 'project_name'
+    }
+    actual = simple_builder_test.validate(**params)
+    self.assertEqual(expected, actual)


### PR DESCRIPTION
Fixes #435

Allows users to put comments starting with "#" and any whitespace they like in their Simple buiilders. These are ignored at both validation and selection building time.

The result of this is that selections materialized with builders with comments have only the articles and none of the comments/whitespace, but the builders retain that information for the user's use.