### PR TITLE
Change builder IDs from monotonically increasing integer primary keys to UUIDs

### DIFF
--- a/db/migrations/20220905_01_4yJzk-change-builder-id-column.py
+++ b/db/migrations/20220905_01_4yJzk-change-builder-id-column.py
@@ -1,0 +1,43 @@
+"""
+Change builder id column
+"""
+import uuid
+
+from yoyo import step
+
+__depends__ = {'20220904_01_sroTV-change-params-field-in-builders-to-longblob'}
+
+
+def update_builder_id(conn):
+  cursor = conn.cursor()
+  cursor.execute('SELECT b_id FROM builders')
+  for row in cursor.fetchall():
+    cursor.execute('UPDATE builders SET b_id = %s WHERE b_id = %s',
+                   (str(uuid.uuid4()).encode('utf-8'), row[0]))
+    cursor.execute(
+        'UPDATE selections SET s_builder_id = %s WHERE s_builder_id = %s',
+        (str(uuid.uuid4()).encode('utf-8'), row[0]))
+
+
+def restore_builder_id(conn):
+  cursor = conn.cursor()
+  cursor.execute('SELECT b_id FROM builders ORDER BY b_created_at')
+  for id_, row in enumerate(cursor.fetchall()):
+    cursor.execute('UPDATE builders SET b_id = %s WHERE b_id = %s',
+                   (id_ + 1, row[0]))
+    cursor.execute(
+        'UPDATE selections SET s_builder_id = %s WHERE s_builder_id = %s',
+        (id_ + 1, row[0]))
+
+
+steps = [
+    step(
+        "ALTER TABLE builders CHANGE COLUMN b_id b_id VARBINARY(255) NOT NULL",
+        "ALTER TABLE builders CHANGE COLUMN b_id b_id INTEGER NOT NULL AUTO_INCREMENT"
+    ),
+    step(
+        "ALTER TABLE selections CHANGE COLUMN s_builder_id s_builder_id VARBINARY(255) NOT NULL",
+        "ALTER TABLE selections CHANGE COLUMN s_builder_id s_builder_id INTEGER NOT NULL"
+    ),
+    step(update_builder_id, restore_builder_id),
+]

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -103,7 +103,6 @@ def delete_builder(wp10db, user_id, builder_id):
            WHERE b.b_user_id = %s AND b.b_id = %s
         ''', (user_id, builder_id))
     rowcount = cursor.rowcount
-    print(rowcount)
 
   # Delete the object keys from the s3-like backend
   s3_success = logic_selection.delete_keys_from_storage(keys_to_delete)
@@ -179,8 +178,6 @@ def latest_selection_url(wp10db, builder_id, ext):
 
 def get_builders_with_selections(wp10db, user_id):
   with wp10db.cursor() as cursor:
-    cursor.execute('SELECT * FROM builders')
-    print(cursor.fetchall())
     cursor.execute(
         '''SELECT * FROM selections
            RIGHT JOIN builders

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -11,19 +11,8 @@ from wp1.selection.models.simple_builder import SimpleBuilder
 
 class BuilderTest(BaseWpOneDbTest):
 
-  builder = Builder(
-      b_name=b'My Builder',
-      b_user_id=1234,
-      b_project=b'en.wikipedia.fake',
-      b_model=b'wp1.selection.models.simple',
-      b_params=b'{"list": ["a", "b", "c"]}',
-      b_created_at=b'20191225044444',
-      b_updated_at=b'20191225044444',
-      b_current_version=1,
-  )
-
   expected_builder = {
-      'b_id': 1,
+      'b_id': b'1a-2b-3c-4d',
       'b_name': b'My Builder',
       'b_user_id': 1234,
       'b_project': b'en.wikipedia.fake',
@@ -35,44 +24,77 @@ class BuilderTest(BaseWpOneDbTest):
   }
 
   expected_lists = [{
-      'id': 1,
-      'name': 'My Builder',
-      'project': 'en.wikipedia.fake',
-      'created_at': 1577249084,
-      'updated_at': 1577249084,
-      's_id': '1',
-      's_updated_at': 1577249084,
-      's_content_type': 'text/tab-separated-values',
-      's_extension': 'tsv',
-      's_url': 'http://test.server.fake/v1/builders/1/selection/latest.tsv'
+      'id':
+          '1a-2b-3c-4d',
+      'name':
+          'My Builder',
+      'project':
+          'en.wikipedia.fake',
+      'created_at':
+          1577249084,
+      'updated_at':
+          1577249084,
+      's_id':
+          '1',
+      's_updated_at':
+          1577249084,
+      's_content_type':
+          'text/tab-separated-values',
+      's_extension':
+          'tsv',
+      's_url':
+          'http://test.server.fake/v1/builders/1a-2b-3c-4d/selection/latest.tsv'
   }]
 
-  expected_lists_with_multiple_selections = [{
-      'id': 1,
-      'name': 'My Builder',
-      'project': 'en.wikipedia.fake',
-      'created_at': 1577249084,
-      'updated_at': 1577249084,
-      's_id': '1',
-      's_updated_at': 1577249084,
-      's_content_type': 'text/tab-separated-values',
-      's_extension': 'tsv',
-      's_url': 'http://test.server.fake/v1/builders/1/selection/latest.tsv',
-  }, {
-      'id': 1,
-      'name': 'My Builder',
-      'project': 'en.wikipedia.fake',
-      'created_at': 1577249084,
-      'updated_at': 1577249084,
-      's_id': '2',
-      's_updated_at': 1577249084,
-      's_content_type': 'application/vnd.ms-excel',
-      's_extension': 'xls',
-      's_url': 'http://test.server.fake/v1/builders/1/selection/latest.xls',
-  }]
+  expected_lists_with_multiple_selections = [
+      {
+          'id':
+              '1a-2b-3c-4d',
+          'name':
+              'My Builder',
+          'project':
+              'en.wikipedia.fake',
+          'created_at':
+              1577249084,
+          'updated_at':
+              1577249084,
+          's_id':
+              '2',
+          's_updated_at':
+              1577249084,
+          's_content_type':
+              'application/vnd.ms-excel',
+          's_extension':
+              'xls',
+          's_url':
+              'http://test.server.fake/v1/builders/1a-2b-3c-4d/selection/latest.xls',
+      },
+      {
+          'id':
+              '1a-2b-3c-4d',
+          'name':
+              'My Builder',
+          'project':
+              'en.wikipedia.fake',
+          'created_at':
+              1577249084,
+          'updated_at':
+              1577249084,
+          's_id':
+              '1',
+          's_updated_at':
+              1577249084,
+          's_content_type':
+              'text/tab-separated-values',
+          's_extension':
+              'tsv',
+          's_url':
+              'http://test.server.fake/v1/builders/1a-2b-3c-4d/selection/latest.tsv',
+      },
+  ]
 
   expected_lists_with_no_selections = [{
-      'id': 1,
+      'id': '1a-2b-3c-4d',
       'name': 'My Builder',
       'project': 'en.wikipedia.fake',
       'created_at': 1577249084,
@@ -85,7 +107,7 @@ class BuilderTest(BaseWpOneDbTest):
   }]
 
   expected_lists_with_unmapped_selections = [{
-      'id': 1,
+      'id': '1a-2b-3c-4d',
       'name': 'My Builder',
       'project': 'en.wikipedia.fake',
       'created_at': 1577249084,
@@ -102,24 +124,25 @@ class BuilderTest(BaseWpOneDbTest):
       current_version = 1
     value_dict = attr.asdict(self.builder)
     value_dict['b_current_version'] = current_version
+    value_dict['b_id'] = b'1a-2b-3c-4d'
     with self.wp10db.cursor() as cursor:
       cursor.execute(
           '''INSERT INTO builders
-         (b_name, b_user_id, b_project, b_params, b_model, b_created_at, b_updated_at,
-         b_current_version)
-         VALUES (%(b_name)s, %(b_user_id)s, %(b_project)s, %(b_params)s, %(b_model)s,
-         %(b_created_at)s, %(b_updated_at)s, %(b_current_version)s)
-        ''', value_dict)
-      id_ = cursor.lastrowid
+               (b_id, b_name, b_user_id, b_project, b_params, b_model, b_created_at,
+                b_updated_at, b_current_version)
+             VALUES
+               (%(b_id)s, %(b_name)s, %(b_user_id)s, %(b_project)s, %(b_params)s,
+                %(b_model)s, %(b_created_at)s, %(b_updated_at)s, %(b_current_version)s)
+          ''', value_dict)
     self.wp10db.commit()
-    return id_
+    return value_dict['b_id']
 
   def _insert_selection(self,
                         id_,
                         content_type,
                         version=1,
                         object_key='selections/foo/1234/name.tsv',
-                        builder_id=1):
+                        builder_id=b'1a-2b-3c-4d'):
     with self.wp10db.cursor() as cursor:
       cursor.execute(
           'INSERT INTO selections VALUES (%s, %s, %s, "20191225044444", %s, %s)',
@@ -133,9 +156,24 @@ class BuilderTest(BaseWpOneDbTest):
       db_lists = cursor.fetchone()
       return db_lists
 
+  def setUp(self):
+    super().setUp()
+    self.builder = Builder(
+        b_id=b'1a-2b-3c-4d',
+        b_name=b'My Builder',
+        b_user_id=1234,
+        b_project=b'en.wikipedia.fake',
+        b_model=b'wp1.selection.models.simple',
+        b_params=b'{"list": ["a", "b", "c"]}',
+        b_created_at=b'20191225044444',
+        b_updated_at=b'20191225044444',
+        b_current_version=1,
+    )
+
   @patch('wp1.models.wp10.builder.utcnow',
          return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
-  def test_create_or_update_builder_create(self, mock_utcnow):
+  @patch('wp1.models.wp10.builder.builder_id', return_value=b'1a-2b-3c-4d')
+  def test_create_or_update_builder_create(self, mock_builder_id, mock_utcnow):
     logic_builder.create_or_update_builder(self.wp10db, 'My Builder', '1234',
                                            'en.wikipedia.fake', 'a\nb\nc')
     actual = self._get_builder_by_user_id()
@@ -145,9 +183,10 @@ class BuilderTest(BaseWpOneDbTest):
          return_value=datetime.datetime(2020, 1, 1, 5, 55, 55))
   def test_create_or_update_builder_update(self, mock_utcnow):
     id_ = self._insert_builder()
-    logic_builder.create_or_update_builder(self.wp10db, 'Builder 2', '1234',
-                                           'zz.wikipedia.fake', 'a\nb\nc\nd',
-                                           id_)
+    actual = logic_builder.create_or_update_builder(self.wp10db, 'Builder 2',
+                                                    '1234', 'zz.wikipedia.fake',
+                                                    'a\nb\nc\nd', id_)
+    self.assertTrue(actual)
     expected = dict(**self.expected_builder)
     expected['b_name'] = b'Builder 2'
     expected['b_project'] = b'zz.wikipedia.fake'
@@ -159,16 +198,18 @@ class BuilderTest(BaseWpOneDbTest):
 
   @patch('wp1.models.wp10.builder.utcnow',
          return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
-  def test_insert_builder(self, mock_utcnow):
+  @patch('wp1.models.wp10.builder.builder_id', return_value=b'1a-2b-3c-4d')
+  def test_insert_builder(self, mock_builder_id, mock_utcnow):
     logic_builder.insert_builder(self.wp10db, self.builder)
     actual = self._get_builder_by_user_id()
     self.assertEqual(self.expected_builder, actual)
 
   @patch('wp1.models.wp10.builder.utcnow',
          return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
-  def test_insert_builder_returns_id(self, mock_utcnow):
+  @patch('wp1.models.wp10.builder.builder_id', return_value=b'1a-2b-3c-4d')
+  def test_insert_builder_returns_id(self, mock_builder_id, mock_utcnow):
     actual = logic_builder.insert_builder(self.wp10db, self.builder)
-    self.assertEqual(1, actual)
+    self.assertEqual(b'1a-2b-3c-4d', actual)
 
   def test_get_builder(self):
     id_ = self._insert_builder()
@@ -205,8 +246,7 @@ class BuilderTest(BaseWpOneDbTest):
   def test_get_builders(self, mock_utcnow):
     self._insert_selection(1, 'text/tab-separated-values')
     self._insert_builder()
-    article_data = logic_builder.get_builders_with_selections(
-        self.wp10db, '1234')
+    article_data = logic_builder.get_builders_with_selections(self.wp10db, 1234)
     self.assertEqual(self.expected_lists, article_data)
 
   @patch('wp1.models.wp10.builder.utcnow',
@@ -219,23 +259,21 @@ class BuilderTest(BaseWpOneDbTest):
                            'application/vnd.ms-excel',
                            object_key='object_key_2')
     self._insert_builder()
-    article_data = logic_builder.get_builders_with_selections(
-        self.wp10db, '1234')
+    article_data = logic_builder.get_builders_with_selections(self.wp10db, 1234)
     self.assertEqual(self.expected_lists_with_multiple_selections, article_data)
 
   @patch('wp1.models.wp10.builder.utcnow',
          return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
   def test_get_builders_with_no_selections(self, mock_utcnow):
     self._insert_builder()
-    article_data = logic_builder.get_builders_with_selections(
-        self.wp10db, '1234')
+    article_data = logic_builder.get_builders_with_selections(self.wp10db, 1234)
     self.assertEqual(self.expected_lists_with_no_selections, article_data)
 
   @patch('wp1.models.wp10.builder.utcnow',
          return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
   def test_get_builders_empty_lists(self, mock_utcnow):
     self._insert_selection(1, 'text/tab-separated-values')
-    self._insert_builder()
+    id_ = self._insert_builder()
     article_data = logic_builder.get_builders_with_selections(
         self.wp10db, '0000')
     self.assertEqual([], article_data)
@@ -247,9 +285,8 @@ class BuilderTest(BaseWpOneDbTest):
     self._insert_selection(2, 'application/vnd.ms-excel', 1)
     self._insert_selection(3, 'text/tab-separated-values', 2)
     self._insert_selection(4, 'application/vnd.ms-excel', 2)
-    self._insert_builder()
-    article_data = logic_builder.get_builders_with_selections(
-        self.wp10db, '1234')
+    id_ = self._insert_builder()
+    article_data = logic_builder.get_builders_with_selections(self.wp10db, id_)
     self.assertEqual(self.expected_lists_with_multiple_selections, article_data)
 
   @patch('wp1.models.wp10.builder.utcnow',
@@ -292,7 +329,7 @@ class BuilderTest(BaseWpOneDbTest):
   def test_update_builder_wrong_id(self):
     self._insert_builder()
     builder = Builder(
-        b_id=100,  # Wrong ID
+        b_id=b'100',  # Wrong ID
         b_name=b'My Builder',
         b_user_id=1234,
         b_project=b'en.wikipedia.fake',
@@ -305,7 +342,7 @@ class BuilderTest(BaseWpOneDbTest):
   def test_update_builder_success(self):
     self._insert_builder()
     builder = Builder(
-        b_id=1,
+        b_id=b'1a-2b-3c-4d',
         b_name=b'My Builder',
         b_user_id=1234,
         b_project=b'en.wikipedia.fake',
@@ -317,7 +354,7 @@ class BuilderTest(BaseWpOneDbTest):
 
   def test_update_builder_updates_fields(self):
     self._insert_builder()
-    builder = Builder(b_id=1,
+    builder = Builder(b_id=b'1a-2b-3c-4d',
                       b_name=b'Builder 2',
                       b_user_id=1234,
                       b_project=b'zz.wikipedia.fake',
@@ -449,7 +486,7 @@ class BuilderTest(BaseWpOneDbTest):
   def test_delete_builder_user_builder_id_unmatched(self, patched_selection):
     builder_id = self._insert_builder_with_multiple_version_selections()
 
-    actual = logic_builder.delete_builder(self.wp10db, 1234, -1)
+    actual = logic_builder.delete_builder(self.wp10db, 1234, 'abcd')
 
     self.assertFalse(actual['db_delete_success'])
 

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -260,7 +260,11 @@ class BuilderTest(BaseWpOneDbTest):
                            object_key='object_key_2')
     self._insert_builder()
     article_data = logic_builder.get_builders_with_selections(self.wp10db, 1234)
-    self.assertEqual(self.expected_lists_with_multiple_selections, article_data)
+    self.assertEqual(
+        set(
+            tuple(d.items())
+            for d in self.expected_lists_with_multiple_selections),
+        set(tuple(d.items()) for d in article_data))
 
   @patch('wp1.models.wp10.builder.utcnow',
          return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))

--- a/wp1/logic/project.py
+++ b/wp1/logic/project.py
@@ -133,13 +133,13 @@ def project_names_to_update(wikidb):
   # steps and if we don't exhaust it now, it will get truncated.
   for category_page in list(projects_in_root):
     if BY_QUALITY not in category_page.page_title:
-      print('Skipping %s -- it does not have quality in title' %
-            category_page.page_title.decode('utf-8'))
+      logger.info('Skipping %s -- it does not have quality in title' %
+                  category_page.page_title.decode('utf-8'))
       continue
 
     if RE_REJECT_GENERIC.match(category_page.page_title):
-      print('Skipping %r -- it is a generic "articles by quality"' %
-            category_page)
+      logger.info('Skipping %r -- it is a generic "articles by quality"' %
+                  category_page)
       continue
 
     yield category_page.base_title

--- a/wp1/logic/project_test.py
+++ b/wp1/logic/project_test.py
@@ -298,7 +298,6 @@ class UpdateProjectCategoriesByKindTest(BaseCombinedDbTest):
 
     expected = dict(
         (p[3].decode('utf-8'), (p[1], p[4])) for p in self.quality_pages)
-    self.maxDiff = None
     self.assertEqual(expected, rating_to_category)
 
   def test_update_importance(self):

--- a/wp1/logic/rating.py
+++ b/wp1/logic/rating.py
@@ -104,7 +104,7 @@ def _project_rating_query(project_name,
   else:
     query += ' LIMIT %s' % limit
 
-  print(query)
+  logger.debug(query)
   return query
 
 

--- a/wp1/logic/selection_test.py
+++ b/wp1/logic/selection_test.py
@@ -20,7 +20,7 @@ class SelectionTest(BaseWpOneDbTest):
     super().setUp()
     self.selection = Selection(
         s_id=b'deadbeef',
-        s_builder_id=100,
+        s_builder_id=b'100',
         s_content_type=b'text/tab-separated-values',
         s_version=1,
         s_updated_at=b'20190830112844',
@@ -41,6 +41,7 @@ class SelectionTest(BaseWpOneDbTest):
     self.wp10db.commit()
 
   def test_insert_selection(self):
+    self.maxDiff = None
     logic_selection.insert_selection(self.wp10db, self.selection)
     actual = _get_selection(self.wp10db)
     self.assertEqual(self.selection, actual)

--- a/wp1/models/wp10/builder.py
+++ b/wp1/models/wp10/builder.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import logging
+import uuid
 
 import attr
 
@@ -8,6 +9,10 @@ from wp1.constants import TS_FORMAT_WP10
 from wp1.timestamp import utcnow
 
 logger = logging.getLogger(__name__)
+
+
+def builder_id():
+  return str(uuid.uuid4()).encode('utf-8')
 
 
 @attr.s
@@ -19,7 +24,7 @@ class Builder:
   b_project = attr.ib()
   b_model = attr.ib()
   b_params = attr.ib()
-  # The ID for Builders can be auto-assigned, so it is not required. See the migration file.
+  # Needs to be set before insertion into the database
   b_id = attr.ib(default=None)
   b_created_at = attr.ib(default=None)
   b_updated_at = attr.ib(default=None)
@@ -66,3 +71,6 @@ class Builder:
         'project': self.b_project.decode('utf-8'),
         'articles': articles,
     }
+
+  def set_id(self):
+    self.b_id = builder_id()

--- a/wp1/models/wp10/rating_test.py
+++ b/wp1/models/wp10/rating_test.py
@@ -6,7 +6,6 @@ class RatingModelTest(BaseWpOneDbTest):
 
   def setUp(self):
     super().setUp()
-    self.maxDiff = None
     self.rating = Rating(r_project=b'Test Project',
                          r_namespace=4,
                          r_article=b'Test article pages',

--- a/wp1/models/wp10/selection.py
+++ b/wp1/models/wp10/selection.py
@@ -43,4 +43,4 @@ class Selection:
     self.set_updated_at_dt(utcnow())
 
   def set_id(self):
-    self.s_id = str(uuid.uuid4()).encode()
+    self.s_id = str(uuid.uuid4()).encode('utf-8')

--- a/wp1/selection/abstract_builder_test.py
+++ b/wp1/selection/abstract_builder_test.py
@@ -26,7 +26,7 @@ class AbstractBuilderTest(BaseWpOneDbTest):
     super().setUp()
     self.s3 = MagicMock()
     self.test_builder = TestBuilder()
-    self.builder = Builder(b_id=100,
+    self.builder = Builder(b_id=b'1a-2b-3c-4d',
                            b_name=b'My Builder',
                            b_user_id=1234,
                            b_project=b'en.wikipedia.fake',
@@ -38,7 +38,7 @@ class AbstractBuilderTest(BaseWpOneDbTest):
                                   'text/tab-separated-values')
     actual = _get_first_selection(self.wp10db)
     self.assertEqual(actual.s_content_type, b'text/tab-separated-values')
-    self.assertEqual(actual.s_builder_id, 100)
+    self.assertEqual(actual.s_builder_id, b'1a-2b-3c-4d')
 
   @patch('wp1.models.wp10.selection.uuid.uuid4', return_value='abcd-1234')
   def test_materialize_selection_id(self, mock_uuid4):

--- a/wp1/web/__init__.py
+++ b/wp1/web/__init__.py
@@ -6,8 +6,9 @@ try:
   #  The credentials module isn't checked in and may be missing
   from wp1.credentials import ENV, CREDENTIALS
 except ImportError:
-  print('No credentials.py file found, Please add your '
-        'mwoauth credentials in credentials.py')
+  print(
+      'No credentials.py file found, Please add your credentials in credentials.py'
+  )
   ENV = None
   CREDENTIALS = None
 

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -99,7 +99,6 @@ def latest_selection_for_builder(builder_id, ext):
 
   url = logic_builder.latest_selection_url(wp10db, builder_id, ext)
   if not url:
-    print(404)
     flask.abort(404)
 
   return flask.redirect(url, code=302)

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -28,6 +28,7 @@ class BuildersTest(BaseWebTestcase):
   successful_response = {'success': True, 'items': {}}
 
   builder = Builder(
+      b_id=b'1a-2b-3c-4d',
       b_name=b'My Builder',
       b_user_id=1234,
       b_project=b'en.wikipedia.fake',
@@ -42,13 +43,15 @@ class BuildersTest(BaseWebTestcase):
     with self.wp10db.cursor() as cursor:
       cursor.execute(
           '''INSERT INTO builders
-         (b_name, b_user_id, b_project, b_params, b_model, b_created_at, b_updated_at, b_current_version)
-         VALUES (%(b_name)s, %(b_user_id)s, %(b_project)s, %(b_params)s, %(b_model)s,
-                 %(b_created_at)s, %(b_updated_at)s, %(b_current_version)s)
+               (b_id, b_name, b_user_id, b_project, b_params, b_model,
+                b_created_at, b_updated_at, b_current_version)
+             VALUES
+               (%(b_id)s, %(b_name)s, %(b_user_id)s, %(b_project)s,
+                %(b_params)s, %(b_model)s, %(b_created_at)s,
+                %(b_updated_at)s, %(b_current_version)s)
         ''', attr.asdict(self.builder))
-      id_ = cursor.lastrowid
     self.wp10db.commit()
-    return id_
+    return self.builder.b_id.decode('utf-8')
 
   def _insert_selections(self, builder_id):
     with self.wp10db.cursor() as cursor:

--- a/wp1/web/projects_test.py
+++ b/wp1/web/projects_test.py
@@ -470,8 +470,6 @@ class ProjectTest(BaseWebTestcase):
       rv = client.get('/v1/projects/Project 0/category_links')
       self.assertEqual('200 OK', rv.status)
 
-      self.maxDiff = None
-
       data = json.loads(rv.data)
       self.assertEqual(self.EXPECTED_CATEGORY_LINKS, data)
 
@@ -484,8 +482,6 @@ class ProjectTest(BaseWebTestcase):
     with self.override_db(self.app), self.app.test_client() as client:
       rv = client.get('/v1/projects/Project 0/category_links/sorted')
       self.assertEqual('200 OK', rv.status)
-
-      self.maxDiff = None
 
       data = json.loads(rv.data)
       self.assertEqual(self.EXPECTED_CATEGORY_LINKS_SORTED, data)

--- a/wp1/web/selection_test.py
+++ b/wp1/web/selection_test.py
@@ -14,48 +14,81 @@ class SelectionTest(BaseWebTestcase):
 
   expected_list_data = {
       'builders': [{
-          'id': 1,
-          'name': 'name',
-          'project': 'project_name',
-          'created_at': 1608893744,
-          'updated_at': 1608893744,
-          's_id': '1',
-          's_updated_at': 1608893744,
-          's_content_type': 'text/tab-separated-values',
-          's_extension': 'tsv',
-          's_url': 'http://test.server.fake/v1/builders/1/selection/latest.tsv'
+          'id':
+              '1a-2b-3c-4d',
+          'name':
+              'name',
+          'project':
+              'project_name',
+          'created_at':
+              1608893744,
+          'updated_at':
+              1608893744,
+          's_id':
+              '1',
+          's_updated_at':
+              1608893744,
+          's_content_type':
+              'text/tab-separated-values',
+          's_extension':
+              'tsv',
+          's_url':
+              'http://test.server.fake/v1/builders/1a-2b-3c-4d/selection/latest.tsv'
       }],
   }
 
   expected_lists_with_multiple_selections = {
-      'builders': [{
-          'id': 1,
-          'name': 'name',
-          'project': 'project_name',
-          'created_at': 1608893744,
-          'updated_at': 1608893744,
-          's_id': '1',
-          's_updated_at': 1608893744,
-          's_content_type': 'text/tab-separated-values',
-          's_extension': 'tsv',
-          's_url': 'http://test.server.fake/v1/builders/1/selection/latest.tsv'
-      }, {
-          'id': 1,
-          'name': 'name',
-          'project': 'project_name',
-          'created_at': 1608893744,
-          'updated_at': 1608893744,
-          's_id': '2',
-          's_updated_at': 1608893744,
-          's_content_type': 'application/vnd.ms-excel',
-          's_extension': 'xls',
-          's_url': 'http://test.server.fake/v1/builders/1/selection/latest.xls'
-      }]
+      'builders': [
+          {
+              'id':
+                  '1a-2b-3c-4d',
+              'name':
+                  'name',
+              'project':
+                  'project_name',
+              'created_at':
+                  1608893744,
+              'updated_at':
+                  1608893744,
+              's_id':
+                  '2',
+              's_updated_at':
+                  1608893744,
+              's_content_type':
+                  'application/vnd.ms-excel',
+              's_extension':
+                  'xls',
+              's_url':
+                  'http://test.server.fake/v1/builders/1a-2b-3c-4d/selection/latest.xls'
+          },
+          {
+              'id':
+                  '1a-2b-3c-4d',
+              'name':
+                  'name',
+              'project':
+                  'project_name',
+              'created_at':
+                  1608893744,
+              'updated_at':
+                  1608893744,
+              's_id':
+                  '1',
+              's_updated_at':
+                  1608893744,
+              's_content_type':
+                  'text/tab-separated-values',
+              's_extension':
+                  'tsv',
+              's_url':
+                  'http://test.server.fake/v1/builders/1a-2b-3c-4d/selection/latest.tsv'
+          },
+      ]
   }
 
   expected_lists_with_no_selections = {
       'builders': [{
-          'id': 1,
+          'id': '1a-2b-3c-4d',
           'name': 'name',
           'project': 'project_name',
           'created_at': 1608893744,
@@ -73,11 +106,11 @@ class SelectionTest(BaseWebTestcase):
     with self.override_db(self.app), self.app.test_client() as client:
       with self.wp10db.cursor() as cursor:
         cursor.execute('''INSERT INTO builders
-        (b_name, b_user_id, b_project, b_model, b_created_at, b_updated_at, b_current_version)
-        VALUES ('name', '1234', 'project_name', 'model', '20201225105544', '20201225105544', 1)
+        (b_id, b_name, b_user_id, b_project, b_model, b_created_at, b_updated_at, b_current_version)
+        VALUES ('1a-2b-3c-4d', 'name', '1234', 'project_name', 'model', '20201225105544', '20201225105544', 1)
       ''')
         cursor.execute(
-            'INSERT INTO selections VALUES (1, 1, "text/tab-separated-values", "20201225105544", 1, "object_key")'
+            'INSERT INTO selections VALUES (1, \'1a-2b-3c-4d\', "text/tab-separated-values", "20201225105544", 1, "object_key")'
         )
       self.wp10db.commit()
       with client.session_transaction() as sess:
@@ -90,14 +123,14 @@ class SelectionTest(BaseWebTestcase):
     with self.override_db(self.app), self.app.test_client() as client:
       with self.wp10db.cursor() as cursor:
         cursor.execute('''INSERT INTO builders
-        (b_name, b_user_id, b_project, b_model, b_created_at, b_updated_at, b_current_version)
-        VALUES ('name', '1234', 'project_name', 'model', '20201225105544', '20201225105544', 1)
+        (b_id, b_name, b_user_id, b_project, b_model, b_created_at, b_updated_at, b_current_version)
+        VALUES ('1a-2b-3c-4d', 'name', '1234', 'project_name', 'model', '20201225105544', '20201225105544', 1)
       ''')
         cursor.execute(
-            'INSERT INTO selections VALUES (1, 1, "text/tab-separated-values", "20201225105544", 1, "object_key_1")'
+            'INSERT INTO selections VALUES (1, \'1a-2b-3c-4d\', "text/tab-separated-values", "20201225105544", 1, "object_key_1")'
         )
         cursor.execute(
-            'INSERT INTO selections VALUES (2, 1, "application/vnd.ms-excel", "20201225105544", 1, "object_key_2")'
+            'INSERT INTO selections VALUES (2, \'1a-2b-3c-4d\', "application/vnd.ms-excel", "20201225105544", 1, "object_key_2")'
         )
       self.wp10db.commit()
       with client.session_transaction() as sess:
@@ -111,8 +144,8 @@ class SelectionTest(BaseWebTestcase):
     with self.override_db(self.app), self.app.test_client() as client:
       with self.wp10db.cursor() as cursor:
         cursor.execute('''INSERT INTO builders
-        (b_name, b_user_id, b_project, b_model, b_created_at, b_updated_at, b_current_version)
-        VALUES ('name', '1234', 'project_name', 'model', '20201225105544', '20201225105544', 1)
+        (b_id, b_name, b_user_id, b_project, b_model, b_created_at, b_updated_at, b_current_version)
+        VALUES ('1a-2b-3c-4d', 'name', '1234', 'project_name', 'model', '20201225105544', '20201225105544', 1)
       ''')
       self.wp10db.commit()
       with client.session_transaction() as sess:
@@ -125,7 +158,7 @@ class SelectionTest(BaseWebTestcase):
     with self.override_db(self.app), self.app.test_client() as client:
       with self.wp10db.cursor() as cursor:
         cursor.execute(
-            '''INSERT INTO selections VALUES (2, 1, "application/vnd.ms-excel", '20201225105544', 1, "object_key")'''
+            '''INSERT INTO selections VALUES (2, \'1a-2b-3c-4d\', "application/vnd.ms-excel", '20201225105544', 1, "object_key")'''
         )
       self.wp10db.commit()
       with client.session_transaction() as sess:

--- a/wp1/web/selection_test.py
+++ b/wp1/web/selection_test.py
@@ -136,8 +136,13 @@ class SelectionTest(BaseWebTestcase):
       with client.session_transaction() as sess:
         sess['user'] = self.USER
       rv = client.get('/v1/selection/simple/lists')
-      self.assertEqual(self.expected_lists_with_multiple_selections,
-                       rv.get_json())
+      self.assertEqual(
+          set(
+              tuple(sorted((d.items()))) for d in
+              self.expected_lists_with_multiple_selections['builders']),
+          set(
+              tuple(sorted(tuple(d.items())))
+              for d in rv.get_json()['builders']))
 
   def test_list_with_no_selections(self):
     self.app = create_app()

--- a/wp10_test.up.sql
+++ b/wp10_test.up.sql
@@ -93,7 +93,7 @@ CREATE TABLE `users` (
 );
 
 CREATE TABLE `builders` (
-  b_id INTEGER NOT NULL PRIMARY KEY AUTO_INCREMENT,
+  b_id VARBINARY(255) NOT NULL PRIMARY KEY,
   b_name VARBINARY(255) NOT NULL,
   b_user_id INTEGER NOT NULL,
   b_project VARBINARY(255) NOT NULL,
@@ -106,7 +106,7 @@ CREATE TABLE `builders` (
 
 CREATE TABLE `selections` (
   s_id VARBINARY(255) NOT NULL PRIMARY KEY,
-  s_builder_id INTEGER NOT NULL,
+  s_builder_id VARBINARY(255) NOT NULL,
   s_content_type VARBINARY(255) NOT NULL,
   s_updated_at BINARY(14) NOT NULL,
   s_version int(11) NOT NULL,


### PR DESCRIPTION
Fixes #501 

The migration generates a new ID for all builders, a UUID. It updates all materialized selections to reference the new ID. This means that old URLs of the form `https://api.wp1.openzim.org/v1/builders/15/selection/latest.tsv` will now be something like `https://api.wp1.openzim.org/v1/builders/e1af5673-3929-4c3c-84c5-63e37369b6db/selection/latest.tsv`, and the old URL will no longer function.

A reverse migration is provided, just in case.

The code and tests have been updated to deal with builder IDs as byte strings.