### PR TITLE
Retroactively fix broken migration, just in case

### DIFF
--- a/db/migrations/20220905_01_4yJzk-change-builder-id-column.py
+++ b/db/migrations/20220905_01_4yJzk-change-builder-id-column.py
@@ -12,11 +12,12 @@ def update_builder_id(conn):
   cursor = conn.cursor()
   cursor.execute('SELECT b_id FROM builders')
   for row in cursor.fetchall():
+    new_id = str(uuid.uuid4()).encode('utf-8')
     cursor.execute('UPDATE builders SET b_id = %s WHERE b_id = %s',
-                   (str(uuid.uuid4()).encode('utf-8'), row[0]))
+                   (new_id, row[0]))
     cursor.execute(
         'UPDATE selections SET s_builder_id = %s WHERE s_builder_id = %s',
-        (str(uuid.uuid4()).encode('utf-8'), row[0]))
+        (new_id, row[0]))
 
 
 def restore_builder_id(conn):


### PR DESCRIPTION
The migration added in the last PR had a bug. In case it needs to be applied to new dev DBs or rolled back and applied again, fix it