### PR TITLE
Parse SPARQL queries, and materialize them using Wikidata SPARQL service

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ gunicorn==19.9.0
 identify==1.4.6
 idna==2.8
 importlib-metadata==0.19
+isodate==0.6.1
 itsdangerous==1.1.0
 Jinja2==2.11.3
 jmespath==0.10.0
@@ -47,6 +48,7 @@ PyMySQL==0.9.3
 pyparsing==3.0.9
 python-dateutil==2.8.0
 PyYAML==5.4.1
+rdflib==6.2.0
 redis==4.3.4
 requests==2.25.1
 requests-oauthlib==1.0.0

--- a/wp1-frontend/cypress/fixtures/sparql_builder.json
+++ b/wp1-frontend/cypress/fixtures/sparql_builder.json
@@ -1,6 +1,6 @@
 {
   "params": {
-    "query": "SELECT ?foo FROM bar",
+    "query": "SELECT ?foo WHERE {}",
     "queryVariable": ""
   },
   "model": "wp1.selection.models.sparql",

--- a/wp1-frontend/cypress/integration/updateSparqlList.js
+++ b/wp1-frontend/cypress/integration/updateSparqlList.js
@@ -9,10 +9,10 @@ describe('the update SPARQL list page', () => {
 
     describe('and the builder is found', () => {
       beforeEach(() => {
-        cy.intercept('GET', 'v1/builders/1', {
+        cy.intercept('GET', 'v1/builders/2', {
           fixture: 'sparql_builder.json',
         });
-        cy.visit('/#/selections/sparql/1');
+        cy.visit('/#/selections/sparql/2');
       });
 
       it('successfully loads', () => {});
@@ -27,35 +27,33 @@ describe('the update SPARQL list page', () => {
         cy.get('#listName > .form-control').should('have.value', 'Builder 2');
         cy.get('#items > .form-control').should(
           'have.value',
-          'SELECT ?foo FROM bar'
+          'SELECT ?foo WHERE {}'
         );
         cy.get('#project > select').should('have.value', 'en.wiktionary.org');
       });
 
-      it('does not show invalid list items', () => {
-        cy.get('#updateListButton').click();
-        cy.get('#items > .invalid-feedback').should('not.be.visible');
-      });
+      describe('on update success', () => {
+        beforeEach(() => {
+          cy.intercept('POST', 'v1/builders/2', {
+            fixture: 'save_list_success.json',
+          });
+        });
 
-      it('does not show invalid list name', () => {
-        cy.get('#updateListButton').click();
-        cy.get('#listName > .invalid-feedback').should('not.be.visible');
-      });
-
-      it('redirects on saving valid article names', () => {
-        cy.intercept('v1/builders/1', { fixture: 'save_list_success.json' });
-        cy.get('#updateListButton').click();
-        cy.url().should('eq', 'http://localhost:3000/#/selections/user');
+        it('redirects on saving valid article names', () => {
+          cy.intercept('v1/builders/2', { fixture: 'save_list_success.json' });
+          cy.get('#updateListButton').click();
+          cy.url().should('eq', 'http://localhost:3000/#/selections/user');
+        });
       });
     });
 
     describe('and the builder is not found', () => {
       beforeEach(() => {
-        cy.intercept('GET', 'v1/builders/1', {
+        cy.intercept('GET', 'v1/builders/2', {
           statusCode: 404,
           body: '404 NOT FOUND',
         });
-        cy.visit('/#/selections/sparql/1');
+        cy.visit('/#/selections/sparql/2');
       });
 
       it('displays the 404 text', () => {
@@ -70,7 +68,7 @@ describe('the update SPARQL list page', () => {
     });
 
     it('opens login page', () => {
-      cy.visit('/#/selections/sparql/1');
+      cy.visit('/#/selections/sparql/2');
       cy.contains('Please Log In To Continue');
       cy.get('.pt-2 > .btn');
     });

--- a/wp1-frontend/src/components/SparqlList.vue
+++ b/wp1-frontend/src/components/SparqlList.vue
@@ -62,6 +62,7 @@
             <div id="items" class="form-group m-4">
               <label for="items">Query</label>
               <textarea
+                ref="query"
                 v-on:blur="validationOnBlur"
                 v-model="builder.params.query"
                 :placeholder="
@@ -75,6 +76,7 @@
                   '  FILTER(STRSTARTS(?bandLabel, \'M\')) .\n}'
                 "
                 class="form-control my-list"
+                :class="{ 'is-invalid': !this.success }"
                 rows="13"
                 required
               ></textarea>
@@ -99,20 +101,10 @@
             </div>
           </div>
           <div
-            v-if="this.success == false || this.deleteSuccess == false"
-            id="invalid_articles"
+            v-if="!this.success || !this.deleteSuccess"
             class="form-group m-4"
           >
             <div class="errors">{{ errors }}</div>
-            <textarea
-              v-if="
-                this.success == false && this.invalid_article_names.length > 0
-              "
-              class="form-control my-list is-invalid"
-              rows="6"
-              ref="invalid"
-              v-model="invalid_article_names"
-            ></textarea>
           </div>
           <div v-if="isEditing">
             <div>
@@ -169,8 +161,6 @@ export default {
       wikiProjects: [],
       success: true,
       deleteSuccess: true,
-      valid_article_names: '',
-      invalid_article_names: '',
       errors: '',
       builder: {
         params: {
@@ -230,6 +220,7 @@ export default {
     },
     onSubmit: async function () {
       const form = this.$refs.form;
+      this.$refs.query.setCustomValidity('');
       if (!form.checkValidity()) {
         this.$refs.form_group.classList.add('was-validated');
         return;
@@ -264,12 +255,12 @@ export default {
 
       // Otherwise there were errors with the POST
       this.$refs.form_group.classList.add('was-validated');
-      this.builder.articles = data.items.valid.join('\n');
-      this.invalid_article_names = data.items.invalid.join('\n');
+      this.builder.params.query = data.items.invalid;
+      this.$refs.query.setCustomValidity('Query not valid');
       this.errors = data.items.errors.join(', ');
     },
     validationOnBlur: function (event) {
-      if (event.target.value) {
+      if (this.success && event.target.value) {
         event.target.classList.remove('is-invalid');
       } else {
         event.target.classList.add('is-invalid');

--- a/wp1/constants.py
+++ b/wp1/constants.py
@@ -79,3 +79,5 @@ WIKIDATA_PREFIXES = {
     'wikibase': 'http://wikiba.se/ontology#',
     'xsd': 'http://www.w3.org/2001/XMLSchema#',
 }
+
+WP1_USER_AGENT = 'WP 1.0 bot 1.0.0/Audiodude <audiodude@gmail.com>'

--- a/wp1/constants.py
+++ b/wp1/constants.py
@@ -45,3 +45,37 @@ CONTENT_TYPE_TO_EXT = {
 
 EXT_TO_CONTENT_TYPE = dict(
     (ext, ct) for ct, ext in CONTENT_TYPE_TO_EXT.items() if isinstance(ct, str))
+
+WIKIDATA_PREFIXES = {
+    'bd': 'http://www.bigdata.com/rdf#',
+    'cc': 'http://creativecommons.org/ns#',
+    'dct': 'http://purl.org/dc/terms/',
+    'geo': 'http://www.opengis.net/ont/geosparql#',
+    'ontolex': 'http://www.w3.org/ns/lemon/ontolex#',
+    'owl': 'http://www.w3.org/2002/07/owl#',
+    'p': 'http://www.wikidata.org/prop/',
+    'pq': 'http://www.wikidata.org/prop/qualifier/',
+    'pqn': 'http://www.wikidata.org/prop/qualifier/value-normalized/',
+    'pqv': 'http://www.wikidata.org/prop/qualifier/value/',
+    'pr': 'http://www.wikidata.org/prop/reference/',
+    'prn': 'http://www.wikidata.org/prop/reference/value-normalized/',
+    'prov': 'http://www.w3.org/ns/prov#',
+    'prv': 'http://www.wikidata.org/prop/reference/value/',
+    'ps': 'http://www.wikidata.org/prop/statement/',
+    'psn': 'http://www.wikidata.org/prop/statement/value-normalized/',
+    'psv': 'http://www.wikidata.org/prop/statement/value/',
+    'rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+    'rdfs': 'http://www.w3.org/2000/01/rdf-schema#',
+    'schema': 'http://schema.org/',
+    'skos': 'http://www.w3.org/2004/02/skos/core#',
+    'wd': 'http://www.wikidata.org/entity/',
+    'wdata': 'http://www.wikidata.org/wiki/Special:EntityData/',
+    'wdno': 'http://www.wikidata.org/prop/novalue/',
+    'wdref': 'http://www.wikidata.org/reference/',
+    'wds': 'http://www.wikidata.org/entity/statement/',
+    'wdt': 'http://www.wikidata.org/prop/direct/',
+    'wdtn': 'http://www.wikidata.org/prop/direct-normalized/',
+    'wdv': 'http://www.wikidata.org/value/',
+    'wikibase': 'http://wikiba.se/ontology#',
+    'xsd': 'http://www.w3.org/2001/XMLSchema#',
+}

--- a/wp1/selection/models/sparql.py
+++ b/wp1/selection/models/sparql.py
@@ -1,10 +1,66 @@
+from pyparsing.exceptions import ParseException
+from rdflib.term import Literal, URIRef, Variable
+from rdflib.plugins.sparql import algebra
+from rdflib.plugins.sparql import parser
+from rdflib.plugins.sparql.parserutils import CompValue
+
+from wp1.constants import WIKIDATA_PREFIXES
 from wp1.selection.abstract_builder import AbstractBuilder
 
 
 class Builder(AbstractBuilder):
 
+  def add_url_select(self, a, query_variable=None):
+    if query_variable is None:
+      query_variable = 'article'
+
+    def modify_query(node):
+      if getattr(node, 'name', None) == 'Project':
+        node.PV.append(Variable('_wp1_0'))
+      elif getattr(node, 'name', None) == 'BGP':
+        p1 = node
+        p2_vars = set((Variable('_wp1_0'), Variable(query_variable)))
+        p2 = CompValue('BGP',
+                       _vars=p2_vars,
+                       triples=[(Variable('_wp1_0'),
+                                 URIRef('http://schema.org/inLanguage'),
+                                 Literal('en')),
+                                (Variable('_wp1_0'),
+                                 URIRef('http://schema.org/isPartOf'),
+                                 URIRef('https://en.wikipedia.org/')),
+                                (Variable('_wp1_0'),
+                                 URIRef('http://schema.org/about'),
+                                 Variable(query_variable))])
+        total_vars = node._vars.union(p2_vars)
+        join = CompValue('LeftJoin', _vars=total_vars, p1=p1, p2=p2)
+        return join
+
+    algebra.traverse(a, visitPre=modify_query)
+
   def build(self, content_type, **params):
-    return str(params).encode('utf-8')
+    parse_results = parser.parseQuery(params['query'])
+    query = algebra.translateQuery(parse_results, initNs=WIKIDATA_PREFIXES)
+    self.add_url_select(
+        query.algebra,
+        params['queryVariable'] if params['queryVariable'] else None)
+    modified_query = algebra.translateAlgebra(query)
+    return modified_query.encode('utf-8')
+
+    # TODO: send modified_query to Wikidata SPARQL endpoint
 
   def validate(self, **params):
+    try:
+      parse_results = parser.parseQuery(params['query'])
+    except ParseException as pe:
+      # The query cannot be parsed as SPARQL, invalid syntax.
+      return ('', params['query'],
+              ['Could not parse query, are you sure it\'s valid SPARQL?'])
+
+    try:
+      query = algebra.translateQuery(parse_results, initNs=WIKIDATA_PREFIXES)
+    except Exception as e:
+      # In testing, this was most common when the query contained
+      # an undefined prefix.
+      return ('', params['query'], e.args[0])
+
     return ('', '', [])

--- a/wp1/selection/models/sparql.py
+++ b/wp1/selection/models/sparql.py
@@ -61,6 +61,6 @@ class Builder(AbstractBuilder):
     except Exception as e:
       # In testing, this was most common when the query contained
       # an undefined prefix.
-      return ('', params['query'], e.args[0])
+      return ('', params['query'], [e.args[0]])
 
     return ('', '', [])

--- a/wp1/selection/models/sparql_test.py
+++ b/wp1/selection/models/sparql_test.py
@@ -1,0 +1,102 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from wp1.selection.models.sparql import Builder as SparqlBuilder
+
+
+class SparqlBuilderTest(unittest.TestCase):
+  cats_uk_us_after_1950 = '''
+    #Cats born in the UK or US after 1950
+    SELECT ?cat
+    WHERE
+    {
+      ?cat wdt:P31 wd:Q146;
+          wdt:P569 ?birth.
+      { ?cat wdt:P19 wd:Q30. }
+      UNION
+      { ?cat wdt:P19 wd:Q145. }
+      FILTER(YEAR(?birth) > 1950)
+    }
+  '''
+
+  json_return_value = {
+      'results': {
+          'bindings': [{
+              'foo': {},
+              '_wp1_0': {
+                  'value': 'https://en.wikipedia.org/wiki/Foo'
+              }
+          }]
+      }
+  }
+
+  expanded_query = (
+      'SELECT ?cat ?_wp1_0{FILTER(YEAR(?birth) > '
+      '"1950"^^<http://www.w3.org/2001/XMLSchema#integer>) ?cat '
+      '<http://www.wikidata.org/prop/direct/P31> '
+      '<http://www.wikidata.org/entity/Q146>.?cat '
+      '<http://www.wikidata.org/prop/direct/P569> ?birth.OPTIONAL{?_wp1_0 '
+      '<http://schema.org/inLanguage> "en".?_wp1_0 <http://schema.org/isPartOf> '
+      '<https://en.wikipedia.org/>.?_wp1_0 <http://schema.org/about> ?cat.}{?cat '
+      '<http://www.wikidata.org/prop/direct/P19> '
+      '<http://www.wikidata.org/entity/Q30>.OPTIONAL{?_wp1_0 '
+      '<http://schema.org/inLanguage> "en".?_wp1_0 <http://schema.org/isPartOf> '
+      '<https://en.wikipedia.org/>.?_wp1_0 <http://schema.org/about> '
+      '?cat.}}UNION{?cat <http://www.wikidata.org/prop/direct/P19> '
+      '<http://www.wikidata.org/entity/Q145>.OPTIONAL{?_wp1_0 '
+      '<http://schema.org/inLanguage> "en".?_wp1_0 <http://schema.org/isPartOf> '
+      '<https://en.wikipedia.org/>.?_wp1_0 <http://schema.org/about> ?cat.}}}')
+
+  def setUp(self):
+    self.builder = SparqlBuilder()
+
+  @patch('wp1.selection.models.sparql.requests')
+  def test_build(self, mock_requests):
+    response = MagicMock()
+    response.json.return_value = self.json_return_value
+    mock_requests.post.return_value = response
+
+    actual = self.builder.build('text/tab-separated-values',
+                                query=self.cats_uk_us_after_1950,
+                                queryVariable='cat')
+
+    mock_requests.post.assert_called_once_with(
+        'https://query.wikidata.org/sparql',
+        headers={
+            'User-Agent': 'WP 1.0 bot 1.0.0/Audiodude <audiodude@gmail.com>'
+        },
+        data={
+            'query': self.expanded_query,
+            'format': 'json'
+        })
+    response.json.assert_called_once()
+    self.assertEqual(b'Foo', actual)
+
+  def test_validate(self):
+    actual = self.builder.validate(query=self.cats_uk_us_after_1950)
+
+    self.assertEqual(('', '', []), actual)
+
+  def test_validate_no_parse(self):
+    invalid_queries = [
+        'Hello World!',
+        'SELECT blah blah foo',
+        'SELECT ?foo',
+        'SELECT ?foo FROM bar',
+        'SELECT ?foo WHERE ?foo wdt:P19 ?bar',
+        'SELECT ?foo WHERE { ?foo wdt:P19 ?bar ?baz. }',
+        'SELECT ?foo WHERE { {?foo wdt:P19 ?bar.} UNION { ?baz.} }',
+    ]
+
+    for query in invalid_queries:
+      actual = self.builder.validate(query=query)
+
+      self.assertEqual(
+          ('', query,
+           ['Could not parse query, are you sure it\'s valid SPARQL?']), actual)
+
+  def test_validate_missing_prefix(self):
+    query = 'SELECT ?foo WHERE { ?foo blah:x ?bar }'
+    actual = self.builder.validate(query=query)
+
+    self.assertEqual(('', query, ['Unknown namespace prefix : blah']), actual)


### PR DESCRIPTION
Fixes #479 

This PR adds a dependency on [rdflib](https://github.com/RDFLib/rdflib/) to parse SPARQL queries. For initial validation, any query that doesn't parse is sent back to the frontend with a message about parsing errors. Additionally, any query which parses, but contains prefix outside the standard list of Wikidata included prologue PREFIXes (referenced from [here](https://www.wikidata.org/wiki/EntitySchema:E49)) is also rejected.

Once the query has been parsed, it is stored in the enwp10 db with the builder. When it is time for the builder to materialize the query into a list of articles, the query is munged to include a `_wp1_0` variable and a LEFT JOIN (`OPTIONAL`) clause, which selects the article URL based on the token (`queryVariable`) that was selected in the frontend. This is important: the backend needs to know what variable represents the entity that the query is attempting to select in order to get wikipedia URLs for that entity. This works by using RDFLib infrastructure to edit an abstract "query algebra" (instead of naive string manipulation), so it inherently ignores comments and whitespace and is resilient to all different classes of query formulation (eg additional variables in the SELECT clause are not a problem).

TODO: Make this work with pagination of the Wikidata endpoint, so that queries with arbitrarily long result sets can be materialized (#519)

TODO: Make this work for any project that Wikidata supports, not just en.wikipedia.org (#520)