### PR TITLE
Fix critical bug which doesn't allow Simple builders to be materialized

### DIFF
--- a/wp1/base_db_test.py
+++ b/wp1/base_db_test.py
@@ -6,6 +6,7 @@ import sys
 import pymysql
 
 from wp1.environment import Environment
+from wp1.models.wp10.selection import Selection
 
 logger = logging.getLogger(__name__)
 
@@ -142,3 +143,10 @@ class BaseCombinedDbTest(BaseWikiDbTest, BaseWpOneDbTest):
 
     self.addCleanup(self._cleanup_wp_one_db)
     self._setup_wp_one_db()
+
+
+def get_first_selection(wp10db):
+  with wp10db.cursor() as cursor:
+    cursor.execute('SELECT * from selections LIMIT 1')
+    db_selection = cursor.fetchone()
+    return Selection(**db_selection)

--- a/wp1/selection/abstract_builder_test.py
+++ b/wp1/selection/abstract_builder_test.py
@@ -1,17 +1,10 @@
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
-from wp1.base_db_test import BaseWpOneDbTest
+from wp1.base_db_test import BaseWpOneDbTest, get_first_selection
 from wp1.models.wp10.builder import Builder
 from wp1.models.wp10.selection import Selection
 from wp1.selection.abstract_builder import AbstractBuilder
-
-
-def _get_first_selection(wp10db):
-  with wp10db.cursor() as cursor:
-    cursor.execute('SELECT * from selections LIMIT 1')
-    db_selection = cursor.fetchone()
-    return Selection(**db_selection)
 
 
 class TestBuilder(AbstractBuilder):
@@ -36,7 +29,7 @@ class AbstractBuilderTest(BaseWpOneDbTest):
   def test_materialize_creates_selection(self):
     self.test_builder.materialize(self.s3, self.wp10db, self.builder,
                                   'text/tab-separated-values')
-    actual = _get_first_selection(self.wp10db)
+    actual = get_first_selection(self.wp10db)
     self.assertEqual(actual.s_content_type, b'text/tab-separated-values')
     self.assertEqual(actual.s_builder_id, b'1a-2b-3c-4d')
 
@@ -44,14 +37,14 @@ class AbstractBuilderTest(BaseWpOneDbTest):
   def test_materialize_selection_id(self, mock_uuid4):
     self.test_builder.materialize(self.s3, self.wp10db, self.builder,
                                   'text/tab-separated-values')
-    actual = _get_first_selection(self.wp10db)
+    actual = get_first_selection(self.wp10db)
     self.assertEqual(actual.s_id, b'abcd-1234')
 
   @patch('wp1.models.wp10.selection.uuid.uuid4', return_value='abcd-1234')
   def test_materialize_selection_object_key(self, mock_uuid4):
     self.test_builder.materialize(self.s3, self.wp10db, self.builder,
                                   'text/tab-separated-values')
-    actual = _get_first_selection(self.wp10db)
+    actual = get_first_selection(self.wp10db)
     self.assertEqual(
         actual.s_object_key, b'selections/wp1.selection.models.simple/'
         b'abcd-1234/My Builder.tsv')
@@ -61,7 +54,7 @@ class AbstractBuilderTest(BaseWpOneDbTest):
   def test_materialize_selection_updated_at(self, mock_utcnow):
     self.test_builder.materialize(self.s3, self.wp10db, self.builder,
                                   'text/tab-separated-values')
-    actual = _get_first_selection(self.wp10db)
+    actual = get_first_selection(self.wp10db)
     self.assertEqual(actual.s_updated_at, b'20201225105544')
 
   @patch('wp1.models.wp10.selection.uuid.uuid4', return_value='abcd-1234')

--- a/wp1/selection/models/simple.py
+++ b/wp1/selection/models/simple.py
@@ -26,18 +26,17 @@ class Builder(AbstractBuilder):
   def build(self, content_type, **params):
     if content_type != 'text/tab-separated-values':
       raise ValueError('Unrecognized content type')
-    if len(params) == 1:
-      if 'list' not in params:
-        raise ValueError(
-            f'Missing required param: list, unnecessary argument given: {list(params.keys())[0]}'
-        )
-      list_minus_comments = [
-          line.strip()
-          for line in params['list']
-          if line.strip() != '' and not line.startswith('#')
-      ]
-      return '\n'.join(list_minus_comments).encode('utf-8')
-    raise ValueError('Additional unnecessary params present')
+    if 'list' not in params:
+      raise ValueError(
+          f'Missing required param: list, unnecessary argument given: {list(params.keys())[0]}'
+      )
+
+    list_minus_comments = [
+        line.strip()
+        for line in params['list']
+        if line.strip() != '' and not line.startswith('#')
+    ]
+    return '\n'.join(list_minus_comments).encode('utf-8')
 
   def validate(self, **params):
     if not params['list']:

--- a/wp1/selection/models/sparql.py
+++ b/wp1/selection/models/sparql.py
@@ -84,8 +84,12 @@ class Builder(AbstractBuilder):
     if not project:
       raise ValueError('Expected project, got: %r' % project)
 
+    params_query = params.get('query')
+    if not params_query:
+      raise ValueError('Expected param "query", got: %r' % params_query)
+
     query_variable = params.get('queryVariable')
-    parse_results = parser.parseQuery(params['query'])
+    parse_results = parser.parseQuery(params_query)
     query = algebra.translateQuery(parse_results, initNs=WIKIDATA_PREFIXES)
     self.instrument_query(query.algebra, project, query_variable=query_variable)
     modified_query = algebra.translateAlgebra(query)


### PR DESCRIPTION
I didn't write a bug report for this issue, because once I discovered it, I realized it was a p0 in production and immediately started fixing it.

The bug is that Simple builder `build` method was written such that if it didn't have exactly 1 param named `list`, it would throw a ValueError. This is suboptimal, because as we see in #524 it is necessary to pass the project name as a param, generically to all builders. Indeed, there may be cases in the future where new params are necessary to pass down from the AbstractBuilder.

The real problem was the missing tests for SimpleBuilder.materialize and SparqlBuilder.materialize. Although there were tests for those methods in AbstractBuilder, they didn't take into account the specific build methods of the subclass.

This PR fixes the immediate bug and adds the missing tests.