### PR TITLE
Refactor Simple and SPARQL create/edit pages to a single component

### DIFF
--- a/wp1-frontend/cypress/fixtures/save_sparql_failure.json
+++ b/wp1-frontend/cypress/fixtures/save_sparql_failure.json
@@ -1,0 +1,6 @@
+{
+    "success": false,
+    "items": {
+      "errors": ["The query was not valid"]
+    }
+  }

--- a/wp1-frontend/cypress/fixtures/save_sparql_success.json
+++ b/wp1-frontend/cypress/fixtures/save_sparql_success.json
@@ -1,0 +1,1 @@
+{ "success": true, "items": {} }

--- a/wp1-frontend/cypress/integration/createSparqlList.spec.js
+++ b/wp1-frontend/cypress/integration/createSparqlList.spec.js
@@ -18,12 +18,11 @@ describe('the create SPARQL builder page', () => {
 
     it('validates list name on clicking save', () => {
       cy.get('#saveListButton').click();
-      cy.get('#listName').contains('Please provide a valid selection name');
+      cy.get('#listName').contains('Please provide a valid list name');
     });
 
     it('validates textbox on clicking save', () => {
       cy.get('#saveListButton').click();
-      cy.get('#listName > .invalid-feedback').should('be.visible');
       cy.get('#items > .invalid-feedback').should('be.visible');
     });
 
@@ -37,6 +36,47 @@ describe('the create SPARQL builder page', () => {
       cy.get('#items > .form-control').click();
       cy.get('#listName > .form-control').click();
       cy.get('#items > .invalid-feedback').should('be.visible');
+    });
+
+    it('displays server validation errors', () => {
+      cy.get('#listName > .form-control').click().type('List Name');
+      cy.get('#items > .form-control').click().type('SELECT ?foo');
+
+      cy.intercept('v1/builders/', { fixture: 'save_sparql_failure.json' });
+      cy.get('#saveListButton').click();
+
+      cy.get('#items > .form-control').should('have.value', 'SELECT ?foo');
+      cy.get('.errors').contains('The query was not valid');
+    });
+
+    it('saves successfully after fixing invalid query', () => {
+      cy.intercept('v1/builders/', (req) => {
+        if (req.body.params.query.indexOf('WHERE') === -1) {
+          // First request is missing a WHERE clause.
+          req.reply({
+            statusCode: 200,
+            fixture: 'save_sparql_failure.json',
+          });
+        } else {
+          // Second request has WHERE and is valid.
+          req.reply({
+            statusCode: 200,
+            fixture: 'save_sparql_success.json',
+          });
+        }
+      });
+
+      cy.get('#listName > .form-control').click().type('List Name');
+      cy.get('#items > .form-control').click().type('SELECT ?foo');
+      cy.get('#saveListButton').click();
+
+      cy.get('#items > .form-control')
+        .click()
+        .clear()
+        .type('SELECT ?foo WHERE {}', { parseSpecialCharSequences: false });
+
+      cy.get('#saveListButton').click();
+      cy.url().should('eq', 'http://localhost:3000/#/selections/user');
     });
 
     it('redirects on saving valid builder', () => {

--- a/wp1-frontend/cypress/integration/updateSimpleList.js
+++ b/wp1-frontend/cypress/integration/updateSimpleList.js
@@ -32,13 +32,11 @@ describe('the update simple list page', () => {
         cy.get('#project > select').should('have.value', 'en.wiktionary.org');
       });
 
-      it('does not show invalid list items', () => {
-        cy.get('#updateListButton').click();
+      it('does not show invalid list items', () => {      
         cy.get('#items > .invalid-feedback').should('not.be.visible');
       });
 
       it('does not show invalid list name', () => {
-        cy.get('#updateListButton').click();
         cy.get('#listName > .invalid-feedback').should('not.be.visible');
       });
 
@@ -46,7 +44,8 @@ describe('the update simple list page', () => {
         cy.get('#items > .form-control').click().type('\nStatue of#Liberty');
         cy.intercept('v1/builders/1', { fixture: 'save_list_failure.json' });
         cy.get('#updateListButton').click();
-        cy.get('#items > .form-control').should('have.value', 'Eiffel_Tower');
+        cy.get('#items > .form-control').should('have.value',
+          'Eiffel_Tower\nStatue_of_Liberty\nStatue of#Liberty');
         cy.get('#invalid_articles').contains(
           'The list contained the following invalid characters: #'
         );

--- a/wp1-frontend/src/components/SimpleBuilder.vue
+++ b/wp1-frontend/src/components/SimpleBuilder.vue
@@ -1,0 +1,82 @@
+<template>
+  <BaseBuilder
+    :listName="'Simple Selection'"
+    :model="'wp1.selection.models.simple'"
+    :params="params"
+    :invalidItems="invalidItems"
+    @onBuilderLoaded="onBuilderLoaded"
+    @onBeforeSubmit="onBeforeSubmit"
+    @onValidationError="onValidationError"
+  >
+    <template #create-desc>
+      Use this tool to create an article selection list for the Wikipedia
+      project of your choice. Your selection will be saved in public cloud
+      storage and can be accessed through URLs that will be provided once it has
+      been saved.
+    </template>
+    <template #extra-params="{ success }">
+      <div id="items" class="form-group m-4">
+        <label for="items">Items</label>
+        <textarea
+          ref="list"
+          v-on:blur="validationOnBlur"
+          v-model="articles"
+          :placeholder="
+            'Eiffel_Tower\nStatue_of_Liberty\nFreedom_Monument_(Baghdad)\n' +
+            'George-Étienne_Cartier_Monument\n\n# Whitespace and comments ' +
+            'starting with # are ignored' +
+            '\n' +
+            success
+          "
+          class="form-control my-list"
+          :class="{ 'is-invalid': !success }"
+          rows="13"
+          required
+        ></textarea>
+        <div class="invalid-feedback">Please provide valid items</div>
+      </div>
+    </template>
+  </BaseBuilder>
+</template>
+
+<script>
+import BaseBuilder from './BaseBuilder.vue';
+
+export default {
+  components: { BaseBuilder },
+  name: 'SimpleBuilder',
+  data: function () {
+    return {
+      articles: '',
+      invalidItems: '',
+      params: {},
+    };
+  },
+  methods: {
+    validationOnBlur: function (event) {
+      if (event.target.value) {
+        event.target.classList.remove('is-invalid');
+      } else {
+        event.target.classList.add('is-invalid');
+      }
+    },
+    onBuilderLoaded: function (builder) {
+      this.articles = builder.params.list.join('\n');
+    },
+    onBeforeSubmit: function () {
+      this.$refs.list.setCustomValidity('');
+    },
+    onValidationError: function (data) {
+      this.invalidItems = data.items.invalid.join('\n');
+      this.$refs.list.setCustomValidity('List not valid');
+    },
+  },
+  watch: {
+    articles: function () {
+      this.params = { list: this.articles.split('\n') };
+    },
+  },
+};
+</script>
+
+<style scoped></style>

--- a/wp1-frontend/src/components/SparqlBuilder.vue
+++ b/wp1-frontend/src/components/SparqlBuilder.vue
@@ -1,0 +1,96 @@
+<template>
+  <BaseBuilder
+    :listName="'SPARQL Selection'"
+    :model="'wp1.selection.models.sparql'"
+    :params="params"
+    @onBeforeSubmit="onBeforeSubmit"
+    @onValidationError="onValidationError"
+    @onBuilderLoaded="onBuilderLoaded"
+  >
+    <template #create-desc>
+      Use this tool to create an article selection list for the Wikipedia
+      project of your choice, using a SPARQL query. The query can either be
+      entered directly or provided via a Wikidata query service URL. Your
+      selection will be saved in public cloud storage and can be accessed
+      through URLs that will be provided once it has been saved.
+    </template>
+    <template #extra-params="{ success }">
+      <div id="items" class="form-group m-4">
+        <label for="items">Query</label>
+        <textarea
+          ref="query"
+          v-on:blur="validationOnBlur"
+          v-model="params.query"
+          :placeholder="
+            '#Rock bands that start with &quot;M&quot;\n' +
+            'SELECT ?article ?bandLabel\n' +
+            'WHERE\n' +
+            '{\n' +
+            '  ?article wdt:P31 wd:Q5741069 .\n' +
+            '  ?article rdfs:label ?bandLabel .\n' +
+            '  FILTER(LANG(?bandLabel) = &quot;en&quot;) .\n' +
+            '  FILTER(STRSTARTS(?bandLabel, \'M\')) .\n}' +
+            success
+          "
+          class="form-control my-list"
+          :class="{ 'is-invalid': !success }"
+          rows="13"
+          required
+        ></textarea>
+        <div class="invalid-feedback">Please provide a valid query</div>
+      </div>
+      <div id="queryVariable" class="m-4">
+        <label for="queryVariable">Query variable</label>
+        <p class="explanation">
+          The variable in your query that represents the Wikidata entity whose
+          article URLs should be retrieved. This will default to
+          <span style="white-space: nowrap">"?article"</span>, for when your
+          query already selects a variable named "?article". Note: this variable
+          must appear in the SELECT clause of your query.
+        </p>
+        <input
+          v-on:blur="validationOnBlur"
+          v-model="params.queryVariable"
+          type="text"
+          placeholder="?article"
+          class="form-control my-list"
+        />
+      </div>
+    </template>
+  </BaseBuilder>
+</template>
+
+<script>
+import BaseBuilder from './BaseBuilder.vue';
+
+export default {
+  components: { BaseBuilder },
+  name: 'SparqlBuilder',
+  data: function () {
+    return {
+      params: {},
+    };
+  },
+  methods: {
+    validationOnBlur: function (event) {
+      if (event.target.value) {
+        event.target.classList.remove('is-invalid');
+      } else {
+        event.target.classList.add('is-invalid');
+      }
+    },
+    onBuilderLoaded: function (builder) {
+      console.log(builder);
+      this.params = builder.params;
+    },
+    onBeforeSubmit: function () {
+      this.$refs.query.setCustomValidity('');
+    },
+    onValidationError: function () {
+      this.$refs.query.setCustomValidity('List not valid');
+    },
+  },
+};
+</script>
+
+<style scoped></style>

--- a/wp1-frontend/src/main.js
+++ b/wp1-frontend/src/main.js
@@ -10,8 +10,8 @@ import VueRouter from 'vue-router';
 
 import App from './App.vue';
 import ArticlePage from './components/ArticlePage.vue';
-import SimpleList from './components/SimpleList.vue';
-import SparqlList from './components/SparqlList.vue';
+import SimpleBuilder from './components/SimpleBuilder.vue';
+import SparqlBuilder from './components/SparqlBuilder.vue';
 import ComparePage from './components/ComparePage.vue';
 import IndexPage from './components/IndexPage.vue';
 import MyLists from './components/MyLists.vue';
@@ -96,28 +96,28 @@ const routes = [
   },
   {
     path: '/selections/simple',
-    component: SimpleList,
+    component: SimpleBuilder,
     meta: {
       title: () => BASE_TITLE + ' - Create Simple Selection',
     },
   },
   {
     path: '/selections/sparql',
-    component: SparqlList,
+    component: SparqlBuilder,
     meta: {
       title: () => BASE_TITLE + ' - Create SPARQL Selection',
     },
   },
   {
     path: '/selections/simple/:builder_id',
-    component: SimpleList,
+    component: SimpleBuilder,
     meta: {
       title: () => BASE_TITLE + ' - Edit Simple Selection',
     },
   },
   {
     path: '/selections/sparql/:builder_id',
-    component: SparqlList,
+    component: SparqlBuilder,
     meta: {
       title: () => BASE_TITLE + ' - Edit SPARQL Selection',
     },


### PR DESCRIPTION
When the SPARQL creation/edit page was written, it was copied verbatim from the SimpleList.vue create/edit page. Some changes were made, but the pages stayed basically the same. Now, with fixes for issues such as #521 required, it makes sense to pay off this tech debt and consolidate the two into a single page, with parameters passed by each specific page and callbacks where appropriate.

This has the added benefit that it greatly simplifies the process for someone in the future adding their own Builder module to the app.