### PR TITLE
Fix migration import

### DIFF
--- a/db/migrations/20220818_01_5x0T9-add-object-key-column-to-selections.py
+++ b/db/migrations/20220818_01_5x0T9-add-object-key-column-to-selections.py
@@ -6,7 +6,7 @@ from yoyo import group, step
 
 import wp1.logic.selection as logic_selection
 from wp1.redis_db import connect
-from wp1.selection.models.simple import SimpleBuilder
+from wp1.selection.models.simple import Builder as SimpleBuilder
 from wp1 import queues
 
 __depends__ = {'20220813_02_Yqp7y-add-version-column-to-selections'}


### PR DESCRIPTION
The import path for builders changed but the migration was not updated. This means that any migration operations that require importing previous migrations would fail with an `ImportError`. This PR fixes that.