### PR TITLE
Check for the query variable in the given SPARQL

### DIFF
--- a/wp1/selection/models/sparql.py
+++ b/wp1/selection/models/sparql.py
@@ -9,6 +9,8 @@ from rdflib.plugins.sparql.parserutils import CompValue
 from wp1.constants import WIKIDATA_PREFIXES, WP1_USER_AGENT
 from wp1.selection.abstract_builder import AbstractBuilder
 
+DEFAULT_QUERY_VARIABLE = 'article'
+
 
 class Builder(AbstractBuilder):
   '''
@@ -47,7 +49,7 @@ class Builder(AbstractBuilder):
     undefined behavior for anything else.
     '''
     if not query_variable:
-      query_variable = 'article'
+      query_variable = DEFAULT_QUERY_VARIABLE
     else:
       query_variable = query_variable.lstrip('?')
 
@@ -126,6 +128,11 @@ class Builder(AbstractBuilder):
       # The query cannot be parsed as SPARQL, invalid syntax.
       return ('', params['query'],
               ['Could not parse query, are you sure it\'s valid SPARQL?'])
+
+    qv = params.get('queryVariable', DEFAULT_QUERY_VARIABLE)
+    if qv not in params['query']:
+      return ('', params['query'],
+              ['The query variable "%s" did not appear in the query' % qv])
 
     try:
       query = algebra.translateQuery(parse_results, initNs=WIKIDATA_PREFIXES)

--- a/wp1/selection/models/sparql_test.py
+++ b/wp1/selection/models/sparql_test.py
@@ -156,7 +156,8 @@ class SparqlBuilderTest(BaseWpOneDbTest):
                                   queryVariable='cat')
 
   def test_validate(self):
-    actual = self.builder.validate(query=self.cats_uk_us_after_1950)
+    actual = self.builder.validate(query=self.cats_uk_us_after_1950,
+                                   queryVariable='cat')
 
     self.assertEqual(('', '', []), actual)
 
@@ -180,6 +181,12 @@ class SparqlBuilderTest(BaseWpOneDbTest):
 
   def test_validate_missing_prefix(self):
     query = 'SELECT ?foo WHERE { ?foo blah:x ?bar }'
-    actual = self.builder.validate(query=query)
+    actual = self.builder.validate(query=query, queryVariable='foo')
 
     self.assertEqual(('', query, ['Unknown namespace prefix : blah']), actual)
+
+  def test_validate_missing_query_variable(self):
+    actual = self.builder.validate(query=self.cats_uk_us_after_1950)
+    self.assertEqual(
+        ('', self.cats_uk_us_after_1950,
+         ['The query variable "article" did not appear in the query']), actual)


### PR DESCRIPTION
Fixes #523.

It's not actually necessary to check that the query variable appears in the `SELECT`, because we don't need to select it. As long as it is bound to something in the `WHERE` clause, we can join with it's article URLs, which is what we're actually after.