### PR TITLE
Fix config for prod jquery

### DIFF
--- a/wp1-frontend/vite.config.js
+++ b/wp1-frontend/vite.config.js
@@ -12,16 +12,6 @@ export default defineConfig({
       jQuery: 'jquery',
     }),
   ],
-  build: {
-    rollupOptions: {
-      external: ['jquery'],
-      output: {
-        globals: {
-          jquery: ['$', 'window.jQuery'],
-        },
-      },
-    },
-  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
In the previous PR (#540), the config for production was broken. The config for dev worked fine and the integration tests passed against that version. And while the frontend-build test passed and the app could build for production, the actual app was broken.

This PR fixes it, but we should look into having the Cypress integration tests run against a production build of the app, so that issues like this can be caught sooner.