### PR TITLE
If materialization fails, show error messages in Selection List view as well as on the edit page

### DIFF
--- a/db/migrations/20221113_01_GslXq-add-status-columns-to-selections.py
+++ b/db/migrations/20221113_01_GslXq-add-status-columns-to-selections.py
@@ -1,0 +1,13 @@
+"""
+Add status columns to selections
+"""
+
+from yoyo import step
+
+__depends__ = {'20221023_01_lwlVT-create-custom-table'}
+
+steps = [
+    step(
+        'ALTER TABLE selections ADD COLUMN s_status VARBINARY(255) DEFAULT "OK"',
+        'ALTER TABLE selections DROP COLUMN s_status'),
+]

--- a/db/migrations/20221113_02_dcHfR-add-error-messages-column-to-selections.py
+++ b/db/migrations/20221113_02_dcHfR-add-error-messages-column-to-selections.py
@@ -1,0 +1,12 @@
+"""
+Add error_messages column to selections
+"""
+
+from yoyo import step
+
+__depends__ = {'20221113_01_GslXq-add-status-columns-to-selections'}
+
+steps = [
+    step("ALTER TABLE selections ADD COLUMN s_error_messages BLOB",
+         "ALTER TABLE selections DROP COLUMN s_error_messages")
+]

--- a/db/migrations/20221113_03_xzm65-allow-selections-null-object-key.py
+++ b/db/migrations/20221113_03_xzm65-allow-selections-null-object-key.py
@@ -1,0 +1,14 @@
+"""
+Allow selections NULL object key
+"""
+
+from yoyo import step
+
+__depends__ = {'20221113_02_dcHfR-add-error-messages-column-to-selections'}
+
+steps = [
+    step(
+        "ALTER TABLE selections MODIFY COLUMN s_object_key VARBINARY(255)",
+        "ALTER TABLE selections MODIFY COLUMN s_object_key VARBINARY(255) NOT NULL"
+    )
+]

--- a/openapi.yml
+++ b/openapi.yml
@@ -459,23 +459,43 @@ paths:
                     type: array
                     items:
                       type: object
+                      description: 'Each item in this array represents a Selection, with the corresponding Builder data destructured and included as well.'
                       properties:
                         id:
                           type: string
+                        created_at:
+                          type: number
+                          description: 'Unix timestamp when the Builder was created.'
+                        updated_at:
+                          type: number
+                          description: 'Unix timestamp when the Builder was last updated.'
                         name:
                           type: string
                         project:
                           type: string
-                        selections:
-                          type: object
-                          description: Empty when selections are missing
-                          properties:
-                            s_id:
-                              type: string
-                            content_type:
-                              type: string
-                            selection_url:
-                              type: string
+                        model:
+                          type: string
+                        s_id:
+                          type: string
+                          description: 'The id of the latest materialized selection of this content_type.'
+                        s_created_at:
+                          type: number
+                          description: 'Unix timestamp when the Selection was created.'
+                        s_updated_at:
+                          type: number
+                          description: 'Unix timestamp when the Selection was last updated.'
+                        s_content_type:
+                          type: string
+                          description: 'MIME type of the content of this selection. A builder can have multiple selections with different content_types.'
+                        s_extension:
+                          type: string
+                          description: 'The three letter extension that corresponds to the content type.'
+                        s_url:
+                          type: string
+                          description: 'The URL for the data of this selection. This will likely be a redirect.'
+                        s_status:
+                          type: string
+                          description: 'An enum-like value that is either null (there is no meaningful status to report), FAILED (building the selection failed permanently), or CAN_RETRY (building the selection failed but can be retried).'
 
 components:
   schemas:

--- a/openapi.yml
+++ b/openapi.yml
@@ -537,6 +537,24 @@ components:
         params:
           type: object
           description: 'The parameters of the Builder that are used to materialize the Selection. This varies depending on the model.'
+        selection_errors:
+          type: array
+          description: 'Any errors that occurred while materializing the Builder, and whether they are retryable'
+          items:
+            type: object
+            properties:
+              error_messages:
+                type: array
+                description: 'The raw error messages returned from the API server'
+                items:
+                  type: string
+              ext:
+                type: string
+                description: 'The extension for the selection for which materialization was attempted'
+              status:
+                type: string
+                description: 'Either "CAN_RETRY" if the error is retryable, or "FATAL" if not'
+
     Project:
       type: object
       properties:

--- a/wp1-frontend/cypress/e2e/myLists.cy.js
+++ b/wp1-frontend/cypress/e2e/myLists.cy.js
@@ -11,7 +11,7 @@ describe('the user selection list page', () => {
     it('successfully loads', () => {});
 
     it('displays the datatables view', () => {
-      cy.get('.dataTables_info').contains('Showing 1 to 2 of 2 entries');
+      cy.get('.dataTables_info').contains('Showing 1 to 6 of 6 entries');
     });
 
     it('displays list and its contents', () => {
@@ -26,6 +26,34 @@ describe('the user selection list page', () => {
       listTd.parent('tr').within((td) => {
         cy.get('td').eq(4).contains('-');
         cy.get('td').eq(5).get('div').should('have.class', 'loader');
+      });
+    });
+
+    it('displays a spinner if the selection is newer than the builder', () => {
+      const listTd = cy.contains('td', 'updated list');
+      listTd.parent('tr').within((td) => {
+        cy.get('td').eq(5).get('div').should('have.class', 'loader');
+      });
+    });
+
+    it('displays a spinner if the selection has error and is retrying', () => {
+      const listTd = cy.contains('td', 'in retry');
+      listTd.parent('tr').within((td) => {
+        cy.get('td').eq(5).get('div').should('have.class', 'loader');
+      });
+    });
+
+    it('displays error message for list with permanent error', () => {
+      const listTd = cy.contains('td', 'permanent error');
+      listTd.parent('tr').within((td) => {
+        cy.get('td').eq(5).get('div').should('contain', 'FAILED');
+      });
+    });
+
+    it('displays error message for list with retryable failure', () => {
+      const listTd = cy.contains('td', 'retryable error');
+      listTd.parent('tr').within((td) => {
+        cy.get('td').eq(5).get('div').should('contain', 'FAILED');
       });
     });
 

--- a/wp1-frontend/cypress/e2e/myLists.cy.js
+++ b/wp1-frontend/cypress/e2e/myLists.cy.js
@@ -23,38 +23,42 @@ describe('the user selection list page', () => {
 
     it('displays a spinner for download of list with no selection', () => {
       const listTd = cy.contains('td', 'sparql list');
-      listTd.parent('tr').within((td) => {
+      listTd.parent('tr').within(() => {
         cy.get('td').eq(4).contains('-');
         cy.get('td').eq(5).get('div').should('have.class', 'loader');
       });
     });
 
     it('displays a spinner if the selection is newer than the builder', () => {
-      const listTd = cy.contains('td', 'updated list');
-      listTd.parent('tr').within((td) => {
-        cy.get('td').eq(5).get('div').should('have.class', 'loader');
-      });
+      cy.contains('td', 'updated list')
+        .parent('tr')
+        .within(() => {
+          cy.get('td').eq(5).get('div').should('have.class', 'loader');
+        });
     });
 
     it('displays a spinner if the selection has error and is retrying', () => {
-      const listTd = cy.contains('td', 'in retry');
-      listTd.parent('tr').within((td) => {
-        cy.get('td').eq(5).get('div').should('have.class', 'loader');
-      });
+      cy.contains('td', 'in retry')
+        .parent('tr')
+        .within(() => {
+          cy.get('td').eq(5).get('div').should('have.class', 'loader');
+        });
     });
 
     it('displays error message for list with permanent error', () => {
-      const listTd = cy.contains('td', 'permanent error');
-      listTd.parent('tr').within((td) => {
-        cy.get('td').eq(5).get('div').should('contain', 'FAILED');
-      });
+      cy.contains('td', 'permanent error')
+        .parent('tr')
+        .within(() => {
+          cy.get('td').eq(5).get('div').should('contain', 'FAILED');
+        });
     });
 
     it('displays error message for list with retryable failure', () => {
-      const listTd = cy.contains('td', 'retryable error');
-      listTd.parent('tr').within((td) => {
-        cy.get('td').eq(5).get('div').should('contain', 'FAILED');
-      });
+      cy.contains('td', 'retryable error')
+        .parent('tr')
+        .within(() => {
+          cy.get('td').eq(5).get('div').should('contain', 'FAILED');
+        });
     });
 
     it('takes the user to the simple edit screen when simple edit is clicked', () => {

--- a/wp1-frontend/cypress/e2e/updateSimpleList.cy.js
+++ b/wp1-frontend/cypress/e2e/updateSimpleList.cy.js
@@ -3,16 +3,21 @@
 describe('the update simple list page', () => {
   describe('when the user is logged in', () => {
     beforeEach(() => {
-      cy.intercept('v1/sites/', { fixture: 'sites.json' });
-      cy.intercept('v1/oauth/identify', { fixture: 'identity.json' });
+      cy.intercept('v1/sites/', { fixture: 'sites.json' }).as('sites');
+      cy.intercept('v1/oauth/identify', { fixture: 'identity.json' }).as(
+        'identity'
+      );
     });
 
     describe('and the builder is found', () => {
       beforeEach(() => {
         cy.intercept('GET', 'v1/builders/1', {
           fixture: 'simple_builder.json',
-        });
+        }).as('builder');
         cy.visit('/#/selections/simple/1');
+        cy.wait('@sites');
+        cy.wait('@identity');
+        cy.wait('@builder');
       });
 
       it('successfully loads', () => {});
@@ -85,6 +90,40 @@ describe('the update simple list page', () => {
           cy.get('#updateListButton').click();
           cy.get('#updateListButton').should('have.attr', 'disabled');
         });
+      });
+    });
+
+    describe('and the builder has fatal errors', () => {
+      beforeEach(() => {
+        cy.intercept('GET', 'v1/builders/1', {
+          fixture: 'simple_builder_fatal_error.json',
+        });
+        cy.visit('/#/selections/simple/1');
+      });
+
+      it('displays the error div', () => {
+        cy.get('.materialize-error').should('be.visible');
+      });
+
+      it('disables the retry button', () => {
+        cy.get('.materialize-error .btn').should('have.attr', 'disabled');
+      });
+    });
+
+    describe('and the builder has retryable errors', () => {
+      beforeEach(() => {
+        cy.intercept('GET', 'v1/builders/1', {
+          fixture: 'simple_builder_retryable_error.json',
+        });
+        cy.visit('/#/selections/simple/1');
+      });
+
+      it('displays the error div', () => {
+        cy.get('.materialize-error').should('be.visible');
+      });
+
+      it('enables the retry button', () => {
+        cy.get('.materialize-error .btn').should('not.have.attr', 'disabled');
       });
     });
 

--- a/wp1-frontend/cypress/e2e/updateSparqlList.cy.js
+++ b/wp1-frontend/cypress/e2e/updateSparqlList.cy.js
@@ -3,16 +3,21 @@
 describe('the update SPARQL list page', () => {
   describe('when the user is logged in', () => {
     beforeEach(() => {
-      cy.intercept('v1/sites/', { fixture: 'sites.json' });
-      cy.intercept('v1/oauth/identify', { fixture: 'identity.json' });
+      cy.intercept('v1/sites/', { fixture: 'sites.json' }).as('sites');
+      cy.intercept('v1/oauth/identify', { fixture: 'identity.json' }).as(
+        'identity'
+      );
     });
 
     describe('and the builder is found', () => {
       beforeEach(() => {
         cy.intercept('GET', 'v1/builders/2', {
           fixture: 'sparql_builder.json',
-        });
+        }).as('builder');
         cy.visit('/#/selections/sparql/2');
+        cy.wait('@sites');
+        cy.wait('@identity');
+        cy.wait('@builder');
       });
 
       it('successfully loads', () => {});
@@ -107,6 +112,40 @@ describe('the update SPARQL list page', () => {
           cy.get('#updateListButton').click();
           cy.get('#updateListButton').should('have.attr', 'disabled');
         });
+      });
+    });
+
+    describe('and the builder has fatal errors', () => {
+      beforeEach(() => {
+        cy.intercept('GET', 'v1/builders/1', {
+          fixture: 'sparql_builder_fatal_error.json',
+        });
+        cy.visit('/#/selections/simple/1');
+      });
+
+      it('displays the error div', () => {
+        cy.get('.materialize-error').should('be.visible');
+      });
+
+      it('disables the retry button', () => {
+        cy.get('.materialize-error .btn').should('have.attr', 'disabled');
+      });
+    });
+
+    describe('and the builder has retryable errors', () => {
+      beforeEach(() => {
+        cy.intercept('GET', 'v1/builders/1', {
+          fixture: 'sparql_builder_retryable_error.json',
+        });
+        cy.visit('/#/selections/simple/1');
+      });
+
+      it('displays the error div', () => {
+        cy.get('.materialize-error').should('be.visible');
+      });
+
+      it('enables the retry button', () => {
+        cy.get('.materialize-error .btn').should('not.have.attr', 'disabled');
       });
     });
 

--- a/wp1-frontend/cypress/fixtures/list_data.json
+++ b/wp1-frontend/cypress/fixtures/list_data.json
@@ -27,6 +27,62 @@
       "s_content_type": null,
       "s_extension": null,
       "s_url": null
+    },
+    {
+      "created_at": 1670251154,
+      "id": "aafcc4a2-cd5c-4236-85ca-3a10d16f13aa",
+      "model": "wp1.selection.models.simple",
+      "name": "updated list",
+      "project": "en.wikipedia.org",
+      "s_content_type": "text/tab-separated-values",
+      "s_extension": "tsv",
+      "s_id": "8fb73096-d208-4a4f-9c49-52facee1747a",
+      "s_status": null,
+      "s_updated_at": 1670251157,
+      "s_url": null,
+      "updated_at": 1670261154
+    },
+    {
+      "created_at": 1669778531,
+      "id": "7368f534-27f5-4350-bfe3-23b90363df7b",
+      "model": "wp1.selection.models.sparql",
+      "name": "permanent error",
+      "project": "en.wikipedia.org",
+      "s_content_type": "text/tab-separated-values",
+      "s_extension": "tsv",
+      "s_id": "1234-abcd",
+      "s_status": "FAILED",
+      "s_updated_at": 1670253950,
+      "s_url": null,
+      "updated_at": 1670247215
+    },
+    {
+      "created_at": 1669778531,
+      "id": "7368f534-27f5-4350-bfe3-23b90363df7b",
+      "model": "wp1.selection.models.sparql",
+      "name": "retryable error",
+      "project": "en.wikipedia.org",
+      "s_content_type": "text/tab-separated-values",
+      "s_extension": "tsv",
+      "s_id": "1234-abcd",
+      "s_status": "CAN_RETRY",
+      "s_updated_at": 1670253950,
+      "s_url": null,
+      "updated_at": 1670247215
+    },
+    {
+      "created_at": 1669778531,
+      "id": "7368f534-27f5-4350-bfe3-23b90363df7b",
+      "model": "wp1.selection.models.sparql",
+      "name": "in retry",
+      "project": "en.wikipedia.org",
+      "s_content_type": "text/tab-separated-values",
+      "s_extension": "tsv",
+      "s_id": "1234-abcd",
+      "s_status": "CAN_RETRY",
+      "s_updated_at": 1670253950,
+      "s_url": null,
+      "updated_at": 1670267215
     }
   ]
 }

--- a/wp1-frontend/cypress/fixtures/simple_builder.json
+++ b/wp1-frontend/cypress/fixtures/simple_builder.json
@@ -4,5 +4,6 @@
   },
   "name": "Builder 1",
   "model": "wp1.selection.models.simple",
-  "project": "en.wiktionary.org"
+  "project": "en.wiktionary.org",
+  "selection_errors": []
 }

--- a/wp1-frontend/cypress/fixtures/simple_builder_fatal_error.json
+++ b/wp1-frontend/cypress/fixtures/simple_builder_fatal_error.json
@@ -1,0 +1,17 @@
+{
+  "params": {
+    "list": ["Eiffel_Tower", "Statue_of_Liberty"]
+  },
+  "name": "Builder 10",
+  "model": "wp1.selection.models.simple",
+  "project": "en.wiktionary.org",
+  "selection_errors": [
+    {
+      "error_messages": [
+        "Wikidata response was not valid JSON. This is usually caused by a timeout because the result set is too large."
+      ],
+      "ext": "tsv",
+      "status": "FAILED"
+    }
+  ]
+}

--- a/wp1-frontend/cypress/fixtures/simple_builder_retryable_error.json
+++ b/wp1-frontend/cypress/fixtures/simple_builder_retryable_error.json
@@ -1,0 +1,15 @@
+{
+  "params": {
+    "list": ["Eiffel_Tower", "Statue_of_Liberty"]
+  },
+  "name": "Builder 10",
+  "model": "wp1.selection.models.simple",
+  "project": "en.wiktionary.org",
+  "selection_errors": [
+    {
+      "error_messages": ["There was a timeout."],
+      "ext": "tsv",
+      "status": "CAN_RETRY"
+    }
+  ]
+}

--- a/wp1-frontend/cypress/fixtures/sparql_builder_fatal_error.json
+++ b/wp1-frontend/cypress/fixtures/sparql_builder_fatal_error.json
@@ -1,0 +1,18 @@
+{
+  "params": {
+    "query": "SELECT ?foo WHERE {}",
+    "queryVariable": ""
+  },
+  "model": "wp1.selection.models.sparql",
+  "name": "Builder 2",
+  "project": "en.wiktionary.org",
+  "selection_errors": [
+    {
+      "error_messages": [
+        "Wikidata response was not valid JSON. This is usually caused by a timeout because the result set is too large."
+      ],
+      "ext": "tsv",
+      "status": "FAILED"
+    }
+  ]
+}

--- a/wp1-frontend/cypress/fixtures/sparql_builder_retryable_error.json
+++ b/wp1-frontend/cypress/fixtures/sparql_builder_retryable_error.json
@@ -6,5 +6,11 @@
   "model": "wp1.selection.models.sparql",
   "name": "Builder 2",
   "project": "en.wiktionary.org",
-  "selection_errors": []
+  "selection_errors": [
+    {
+      "error_messages": ["There was a timeout."],
+      "ext": "tsv",
+      "status": "CAN_RETRY"
+    }
+  ]
 }

--- a/wp1-frontend/package.json
+++ b/wp1-frontend/package.json
@@ -40,6 +40,7 @@
     "axios": "^0.21.2",
     "babel-preset-vue": "^2.0.2",
     "bootstrap": "^4.4.1",
+    "bootstrap-icons": "^1.10.2",
     "cli-highlight": "^2.1.5",
     "cypress": "^10.10.0",
     "datatables.net": "^1.13.1",

--- a/wp1-frontend/src/components/BaseBuilder.vue
+++ b/wp1-frontend/src/components/BaseBuilder.vue
@@ -14,74 +14,151 @@
       Something went wrong and we couldn't retrieve the list with that ID. You
       might try again later.
     </div>
-    <div v-else class="row">
-      <div class="col-lg-6 col-md-9 m-4">
-        <h2 v-if="!isEditing" class="ml-4">New {{ listName }}</h2>
-        <h2 v-else class="ml-4">Editing {{ listName }}</h2>
-        <div v-if="!isEditing" class="ml-4 mb-4">
-          <slot name="create-desc"></slot>
+    <div v-else>
+      <div class="row">
+        <div class="col-lg-6 col-md-9 mx-4">
+          <h2 v-if="!isEditing" class="ml-4">New {{ listName }}</h2>
+          <h2 v-else class="ml-4">Editing {{ listName }}</h2>
+          <div v-if="!isEditing" class="ml-4 mb-4">
+            <slot name="create-desc"></slot>
+          </div>
         </div>
+      </div>
 
-        <form
-          ref="form"
-          v-on:submit.prevent="onSubmit"
-          class="needs-validation"
-          novalidate
-        >
-          <div ref="form_group" class="form-group">
-            <div id="project" class="m-4">
-              <label>Project</label>
-              <select v-model="builder.project" class="custom-select my-list">
-                <option v-if="wikiProjects.length == 0" selected>
-                  en.wikipedia.org
-                </option>
-                <option v-for="item in wikiProjects" v-bind:key="item">
-                  {{ item }}
-                </option>
-              </select>
+      <div class="row">
+        <div class="col-lg-6 col-md-9 mt-2 mb-0 mx-4">
+          <div v-if="hasMaterializeErrors" class="mx-4 materialize-error p-4">
+            <h4 class="materialize-header">
+              There was an error creating your selection
+            </h4>
+            <div
+              v-for="item in builder.selection_errors"
+              v-bind:key="item.error_messages[0]"
+            >
+              <div>
+                The following errors occurred when creating the .{{ item.ext }}
+                version:
+              </div>
+              <ul class="materialize-error-list">
+                <li v-for="msg in item.error_messages" v-bind:key="msg">
+                  {{ msg }}
+                </li>
+              </ul>
             </div>
-            <div id="listName" class="m-4">
-              <label for="listName">List Name</label>
-              <input
-                v-on:blur="validationOnBlur"
-                v-model="builder.name"
-                type="text"
-                placeholder="My List"
-                class="form-control my-list"
-                required
-              />
-              <div class="invalid-feedback">
-                Please provide a valid list name
+            <div v-if="materializeRetryable">
+              <div>You can attempt to retry processing this Builder.</div>
+            </div>
+            <div v-else>
+              <div>
+                Unfortunately, this error cannot be retried. Please update your
+                selection.
               </div>
             </div>
-            <slot name="extra-params" :success="success"></slot>
-          </div>
-          <div
-            v-if="this.success == false || this.deleteSuccess == false"
-            id="invalid_articles"
-            class="form-group m-4"
-          >
-            <div class="errors">{{ errors }}</div>
-            <textarea
-              v-if="this.success == false && this.computedInvalidItems"
-              class="form-control my-list is-invalid"
-              rows="6"
-              ref="invalid"
-              v-model="computedInvalidItems"
-            ></textarea>
-          </div>
-          <div v-if="isEditing">
-            <div>
+            <div class="py-2">
               <button
-                id="updateListButton"
-                type="submit"
+                v-on:click="onSubmit"
+                class="btn btn-light"
+                type="button"
+                :disabled="!materializeRetryable || processing"
+              >
+                Retry
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-6 col-md-9 mx-4">
+          <form
+            ref="form"
+            v-on:submit.prevent="onSubmit"
+            class="needs-validation"
+            novalidate
+          >
+            <div ref="form_group" class="form-group">
+              <div id="project" class="m-4">
+                <label>Project</label>
+                <select v-model="builder.project" class="custom-select my-list">
+                  <option v-if="wikiProjects.length == 0" selected>
+                    en.wikipedia.org
+                  </option>
+                  <option v-for="item in wikiProjects" v-bind:key="item">
+                    {{ item }}
+                  </option>
+                </select>
+              </div>
+              <div id="listName" class="m-4">
+                <label for="listName">List Name</label>
+                <input
+                  v-on:blur="validationOnBlur"
+                  v-model="builder.name"
+                  type="text"
+                  placeholder="My List"
+                  class="form-control my-list"
+                  required
+                />
+                <div class="invalid-feedback">
+                  Please provide a valid list name
+                </div>
+              </div>
+              <slot name="extra-params" :success="success"></slot>
+            </div>
+            <div
+              v-if="this.success == false || this.deleteSuccess == false"
+              id="invalid_articles"
+              class="form-group m-4"
+            >
+              <div class="errors">{{ errors }}</div>
+              <textarea
+                v-if="this.success == false && this.computedInvalidItems"
+                class="form-control my-list is-invalid"
+                rows="6"
+                ref="invalid"
+                v-model="computedInvalidItems"
+              ></textarea>
+            </div>
+            <div v-if="isEditing">
+              <div>
+                <button
+                  id="updateListButton"
+                  type="submit"
+                  :disabled="processing"
+                  class="btn btn-primary ml-4"
+                >
+                  Update List
+                </button>
+                <pulse-loader
+                  id="updateLoader"
+                  v-if="processing"
+                  class="loader"
+                  style="display: inline-block"
+                  :color="loaderColor"
+                  :size="loaderSize"
+                ></pulse-loader>
+              </div>
+              <div class="mt-4">
+                <button
+                  v-on:click.prevent="onDelete"
+                  id="deleteListButton"
+                  type="button"
+                  class="btn btn-danger ml-4"
+                >
+                  Delete List
+                </button>
+              </div>
+            </div>
+            <div v-else>
+              <button
+                id="saveListButton"
                 :disabled="processing"
+                type="submit"
                 class="btn-primary ml-4"
               >
-                Update List
+                Save List
               </button>
               <pulse-loader
-                id="updateLoader"
+                id="saveLoader"
                 v-if="processing"
                 class="loader"
                 style="display: inline-block"
@@ -89,40 +166,9 @@
                 :size="loaderSize"
               ></pulse-loader>
             </div>
-            <div class="mt-4">
-              <button
-                v-on:click.prevent="onDelete"
-                id="deleteListButton"
-                type="button"
-                class="btn-danger ml-4"
-              >
-                Delete List
-              </button>
-            </div>
-          </div>
-          <div v-else>
-            <button
-              id="saveListButton"
-              :disabled="processing"
-              type="submit"
-              class="btn-primary ml-4"
-            >
-              Save List
-            </button>
-            <pulse-loader
-              id="saveLoader"
-              v-if="processing"
-              class="loader"
-              style="display: inline-block"
-              :color="loaderColor"
-              :size="loaderSize"
-            ></pulse-loader>
-          </div>
-        </form>
+          </form>
+        </div>
       </div>
-    </div>
-    <div v-if="!notFound" class="row">
-      <div class="col-lg-6 col-md-9 m-4"></div>
     </div>
   </div>
   <div v-else>
@@ -163,6 +209,7 @@ export default {
       builder: {
         name: '',
         project: 'en.wikipedia.org',
+        selection_errors: [],
       },
     };
   },
@@ -178,6 +225,15 @@ export default {
     },
     computedInvalidItems: function () {
       return this.invalidItems;
+    },
+    hasMaterializeErrors: function () {
+      return this.isEditing && this.builder.selection_errors.length > 0;
+    },
+    materializeRetryable: function () {
+      return (
+        this.isEditing &&
+        !this.builder.selection_errors.some((item) => item.status == 'FAILED')
+      );
     },
   },
   created: function () {
@@ -309,6 +365,9 @@ export default {
   color: #dc3545;
 }
 
+.materialize-error {
+  background-color: pink;
+}
 .loader {
   margin-left: 1rem;
 }

--- a/wp1-frontend/src/components/BaseBuilder.vue
+++ b/wp1-frontend/src/components/BaseBuilder.vue
@@ -227,7 +227,11 @@ export default {
       return this.invalidItems;
     },
     hasMaterializeErrors: function () {
-      return this.isEditing && this.builder.selection_errors.length > 0;
+      return (
+        this.isEditing &&
+        this.builder.selection_errors &&
+        this.builder.selection_errors.length > 0
+      );
     },
     materializeRetryable: function () {
       return (

--- a/wp1-frontend/src/components/ComparePage.vue
+++ b/wp1-frontend/src/components/ComparePage.vue
@@ -129,7 +129,6 @@ export default {
   },
   watch: {
     $route: function (to) {
-      window.console.log(to.path);
       if (to.path == '/compare') {
         this.reset();
       }

--- a/wp1-frontend/src/components/MyLists.vue
+++ b/wp1-frontend/src/components/MyLists.vue
@@ -45,15 +45,35 @@
                 }}
               </td>
               <td v-else>-</td>
-              <td v-if="!isPending(item)">
+              <td v-if="!isPending(item) && !hasSelectionError(item)">
                 <a :href="item.s_url">Download {{ item.s_extension }}</a>
               </td>
-              <td v-else>
+              <td v-else-if="!hasSelectionError(item)">
                 <pulse-loader
                   class="loader"
                   :color="loaderColor"
                   :size="loaderSize"
                 ></pulse-loader>
+              </td>
+              <td v-else>
+                <div v-if="item.s_status === 'FAILED'">
+                  <span class="failed">PERMANENTLY FAILED</span>
+                  <span
+                    data-toggle="tooltip"
+                    data-placement="top"
+                    title="Materializing failed and cannot be retried"
+                    ><i class="bi bi-info-circle"></i
+                  ></span>
+                </div>
+                <div v-else-if="item.s_status === 'CAN_RETRY'">
+                  <span class="failed">FAILED, RETRYABLE</span>
+                  <span
+                    data-toggle="tooltip"
+                    data-placement="top"
+                    title="Materializing failed, but can be retried on the edit page"
+                    >[i]</span
+                  >
+                </div>
               </td>
               <td>
                 <router-link :to="editPathFor(item)"
@@ -101,6 +121,9 @@ export default {
   methods: {
     isPending: function (item) {
       return !item.s_url || item.updated_at > item.s_updated_at;
+    },
+    hasSelectionError: function (item) {
+      return item.s_status !== null;
     },
     getLists: async function () {
       let createDataTable = false;
@@ -154,10 +177,23 @@ export default {
   },
   created: function () {
     this.getLists();
+    $(function () {
+      $('[data-toggle="tooltip"]').tooltip();
+    });
   },
 };
 </script>
 
 <style scoped>
 @import '../cards.scss';
+
+.failed {
+  display: inline-block;
+  color: #dc3545;
+  margin-right: 0.75em;
+}
+
+.bi {
+  cursor: pointer;
+}
 </style>

--- a/wp1-frontend/src/components/MyLists.vue
+++ b/wp1-frontend/src/components/MyLists.vue
@@ -48,20 +48,20 @@
               <td v-if="!isPending(item) && !hasSelectionError(item)">
                 <a :href="item.s_url">Download {{ item.s_extension }}</a>
               </td>
-              <td v-else-if="!hasSelectionError(item)">
+              <td v-else-if="isPending(item)">
                 <pulse-loader
                   class="loader"
                   :color="loaderColor"
                   :size="loaderSize"
                 ></pulse-loader>
               </td>
-              <td v-else>
+              <td v-else-if="hasSelectionError(item)">
                 <div v-if="item.s_status === 'FAILED'">
                   <span class="failed">PERMANENTLY FAILED</span>
                   <span
                     data-toggle="tooltip"
                     data-placement="top"
-                    title="Materializing failed and cannot be retried"
+                    title="Creating the selection failed and cannot be retried"
                     ><i class="bi bi-info-circle"></i
                   ></span>
                 </div>
@@ -70,9 +70,9 @@
                   <span
                     data-toggle="tooltip"
                     data-placement="top"
-                    title="Materializing failed, but can be retried on the edit page"
-                    >[i]</span
-                  >
+                    title="Creating the selection failed, but can be retried on the edit page"
+                    ><i class="bi bi-info-circle"></i
+                  ></span>
                 </div>
               </td>
               <td>
@@ -120,7 +120,9 @@ export default {
   },
   methods: {
     isPending: function (item) {
-      return !item.s_url || item.updated_at > item.s_updated_at;
+      return (
+        (!item.s_url && !item.s_status) || item.updated_at > item.s_updated_at
+      );
     },
     hasSelectionError: function (item) {
       return item.s_status !== null;
@@ -146,6 +148,8 @@ export default {
             order: [[2, 'desc']],
           });
         });
+      } else {
+        $('#list-table').DataTable().columns.adjust().draw();
       }
 
       let hasPending = false;

--- a/wp1-frontend/src/components/SparqlBuilder.vue
+++ b/wp1-frontend/src/components/SparqlBuilder.vue
@@ -80,7 +80,6 @@ export default {
       }
     },
     onBuilderLoaded: function (builder) {
-      console.log(builder);
       this.params = builder.params;
     },
     onBeforeSubmit: function () {

--- a/wp1-frontend/src/main.js
+++ b/wp1-frontend/src/main.js
@@ -1,5 +1,6 @@
 import 'bootstrap';
 import 'bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap-icons/font/bootstrap-icons.css';
 
 import 'jquery';
 import 'datatables.net';

--- a/wp1-frontend/yarn.lock
+++ b/wp1-frontend/yarn.lock
@@ -1131,6 +1131,11 @@ boolbase@^1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
+bootstrap-icons@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/bootstrap-icons/-/bootstrap-icons-1.10.2.tgz#6a5729e0475e007ed82d752225645e4e6fec48d7"
+  integrity sha512-PTPYadRn1AMGr+QTSxe4ZCc+Wzv9DGZxbi3lNse/dajqV31n2/wl/7NX78ZpkvFgRNmH4ogdIQPQmxAfhEV6nA==
+
 bootstrap@^4.4.1:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.6.2.tgz#8e0cd61611728a5bf65a3a2b8d6ff6c77d5d7479"

--- a/wp1/exceptions.py
+++ b/wp1/exceptions.py
@@ -1,0 +1,10 @@
+class Wp1SelectionError(Exception):
+  pass
+
+
+class Wp1RetryableSelectionError(Wp1SelectionError):
+  pass
+
+
+class Wp1FatalSelectionError(Wp1SelectionError):
+  pass

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -195,8 +195,6 @@ def latest_selections_with_errors(wp10db, builder_id):
         builder_id)
     return None
 
-  print(data)
-
   res = []
   for db_selection in data:
     status = {
@@ -206,8 +204,13 @@ def latest_selections_with_errors(wp10db, builder_id):
             CONTENT_TYPE_TO_EXT.get(
                 db_selection['s_content_type'].decode('utf-8'), '???')
     }
-    status.update(
-        **json.loads(db_selection['s_error_messages'].decode('utf-8')))
+    if 's_error_messages' in db_selection and db_selection['s_error_messages']:
+      try:
+        error_messages = json.loads(
+            db_selection['s_error_messages'].decode('utf-8'))
+      except json.decoder.JSONDecodeError:
+        error_messages = {'error_messages': []}
+      status.update(**error_messages)
     res.append(status)
 
   return res

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -174,6 +174,9 @@ def latest_selection_url(wp10db, builder_id, ext):
         builder_id, content_type)
     return None
 
+  if data['object_key'] is None:
+    return None
+
   return logic_selection.url_for(data['object_key'].decode('utf-8'))
 
 

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -185,9 +185,9 @@ def get_builders_with_selections(wp10db, user_id):
     cursor.execute(
         '''SELECT * FROM selections
            RIGHT JOIN builders
-             ON selections.s_builder_id=builders.b_id
-             AND selections.s_version=builders.b_current_version
-           WHERE b_user_id=%(b_user_id)s
+             ON selections.s_builder_id = builders.b_id
+             AND selections.s_version = builders.b_current_version
+           WHERE b_user_id = %(b_user_id)s
            ORDER BY builders.b_updated_at DESC
         ''', {'b_user_id': user_id})
     data = cursor.fetchall()
@@ -196,6 +196,7 @@ def get_builders_with_selections(wp10db, user_id):
   result = []
   for b in data:
     has_selection = b['s_id'] is not None
+    has_status = b['s_status'] is not None
     content_type = b['s_content_type'].decode(
         'utf-8') if has_selection else None
     selection_id = b['s_id'].decode('utf-8') if has_selection else None
@@ -224,6 +225,9 @@ def get_builders_with_selections(wp10db, user_id):
             if has_selection else None,
         's_url':
             latest_url_for(b['b_id'].decode('utf-8'), content_type)
-            if has_selection else None,
+            if has_selection and not has_status else None,
+        's_status':
+            b['s_status'].decode('utf-8')
+            if has_selection and has_status else None
     })
   return result

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -44,7 +44,9 @@ class BuilderTest(BaseWpOneDbTest):
       's_extension':
           'tsv',
       's_url':
-          'http://test.server.fake/v1/builders/1a-2b-3c-4d/selection/latest.tsv'
+          'http://test.server.fake/v1/builders/1a-2b-3c-4d/selection/latest.tsv',
+      's_status':
+          None,
   }]
 
   expected_lists_with_multiple_selections = [
@@ -71,6 +73,8 @@ class BuilderTest(BaseWpOneDbTest):
               'xls',
           's_url':
               'http://test.server.fake/v1/builders/1a-2b-3c-4d/selection/latest.xls',
+          's_status':
+              None,
       },
       {
           'id':
@@ -95,6 +99,8 @@ class BuilderTest(BaseWpOneDbTest):
               'tsv',
           's_url':
               'http://test.server.fake/v1/builders/1a-2b-3c-4d/selection/latest.tsv',
+          's_status':
+              None,
       },
   ]
 
@@ -110,6 +116,7 @@ class BuilderTest(BaseWpOneDbTest):
       's_content_type': None,
       's_extension': None,
       's_url': None,
+      's_status': None,
   }]
 
   expected_lists_with_unmapped_selections = [{
@@ -124,6 +131,7 @@ class BuilderTest(BaseWpOneDbTest):
       's_content_type': 'foo/bar-baz',
       's_extension': '???',
       's_url': None,
+      's_status': None,
   }]
 
   def _insert_builder(self, current_version=None):
@@ -152,7 +160,7 @@ class BuilderTest(BaseWpOneDbTest):
                         builder_id=b'1a-2b-3c-4d'):
     with self.wp10db.cursor() as cursor:
       cursor.execute(
-          'INSERT INTO selections VALUES (%s, %s, %s, "20191225044444", %s, %s)',
+          'INSERT INTO selections VALUES (%s, %s, %s, "20191225044444", %s, %s, NULL, NULL)',
           (id_, builder_id, content_type, version, object_key))
     self.wp10db.commit()
 
@@ -383,7 +391,7 @@ class BuilderTest(BaseWpOneDbTest):
     self.assertTrue(actual)
 
     with self.wp10db.cursor() as cursor:
-      cursor.execute('SELECT * FROM builders where b_id = %s', (1,))
+      cursor.execute('SELECT * FROM builders where b_id = %s', ('1a-2b-3c-4d',))
       db_builder = cursor.fetchone()
       actual_builder = Builder(**db_builder)
     self.assertEqual(builder, actual_builder)
@@ -427,7 +435,8 @@ class BuilderTest(BaseWpOneDbTest):
     builder_id = self._insert_builder()
     self._insert_selection(1, 'text/tab-separated-values')
 
-    actual = logic_builder.latest_selection_url(self.wp10db, -1, 'tsv')
+    actual = logic_builder.latest_selection_url(self.wp10db, 'foo-bar-baz',
+                                                'tsv')
 
     self.assertIsNone(actual)
 

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -131,6 +131,7 @@ def delete_keys_from_storage(keys):
 
 def set_error_messages(selection, e):
   messages = [str(e)]
-  if e.__context__:
-    messages.append(str(e.__context__))
+  # Use __cause__ because we can use '... from e' expressions to either set or suppress the cause.
+  if e.__cause__:
+    messages.append(str(e.__cause__))
   selection.s_error_messages = json.dumps({'error_messages': messages})

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -131,6 +131,6 @@ def delete_keys_from_storage(keys):
 
 def set_error_messages(selection, e):
   messages = [str(e)]
-  if e.__cause__:
-    messages.append(str(e.__cause__))
+  if e.__context__:
+    messages.append(str(e.__context__))
   selection.s_error_messages = json.dumps({'error_messages': messages})

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -1,4 +1,5 @@
 import html
+import json
 import logging
 import urllib.parse
 
@@ -23,9 +24,10 @@ def insert_selection(wp10db, selection):
   with wp10db.cursor() as cursor:
     cursor.execute(
         '''INSERT INTO selections
-      (s_id, s_builder_id, s_version, s_content_type, s_updated_at, s_object_key)
+      (s_id, s_builder_id, s_version, s_content_type, s_updated_at,
+       s_object_key, s_status, s_error_messages)
       VALUES (%(s_id)s, %(s_builder_id)s, %(s_version)s, %(s_content_type)s,
-      %(s_updated_at)s, %(s_object_key)s)
+      %(s_updated_at)s, %(s_object_key)s, %(s_status)s, %(s_error_messages)s)
     ''', attr.asdict(selection))
   wp10db.commit()
 
@@ -125,3 +127,10 @@ def delete_keys_from_storage(keys):
   #                  (e['Key'], e['Code'], e['Message']))
 
   return fully_successful
+
+
+def set_error_messages(selection, e):
+  messages = [str(e)]
+  if e.__cause__:
+    messages.append(str(e.__cause__))
+  selection.s_error_messages = json.dumps({'error_messages': messages})

--- a/wp1/logic/selection_test.py
+++ b/wp1/logic/selection_test.py
@@ -34,9 +34,9 @@ class SelectionTest(BaseWpOneDbTest):
     with self.wp10db.cursor() as cursor:
       cursor.executemany(
           '''INSERT INTO selections
-      (s_id, s_builder_id, s_version, s_content_type, s_updated_at, s_object_key)
+      (s_id, s_builder_id, s_version, s_content_type, s_updated_at, s_object_key, s_status, s_error_messages)
       VALUES (%(s_id)s, %(s_builder_id)s, %(s_version)s, %(s_content_type)s,
-              %(s_updated_at)s, %(s_object_key)s)
+              %(s_updated_at)s, %(s_object_key)s, NULL, NULL)
     ''', selections)
     self.wp10db.commit()
 

--- a/wp1/models/wp10/selection.py
+++ b/wp1/models/wp10/selection.py
@@ -24,6 +24,8 @@ class Selection:
   s_updated_at = attr.ib(default=None)
   # The data that is stored in the backend s3-like storage. Not saved to the database.
   data = attr.ib(default=None)
+  s_status = attr.ib(default=None)
+  s_error_messages = attr.ib(default=None)
 
   @property
   def updated_at_dt(self):

--- a/wp1/selection/abstract_builder.py
+++ b/wp1/selection/abstract_builder.py
@@ -3,7 +3,7 @@ import json
 import logging
 
 from wp1.constants import CONTENT_TYPE_TO_EXT
-from wp1.exceptions import Wp1RetryableSelectionError, Wp1FatalSelectionError
+from wp1.exceptions import Wp1RetryableSelectionError, Wp1FatalSelectionError, Wp1SelectionError
 import wp1.logic.builder as logic_builder
 import wp1.logic.selection as logic_selection
 from wp1.models.wp10.selection import Selection
@@ -42,7 +42,7 @@ class AbstractBuilder:
     except Wp1RetryableSelectionError as e:
       selection.s_status = 'CAN_RETRY'
       logic_selection.set_error_messages(selection, e)
-    except Wp1FatalSelectionError as e:
+    except (Wp1FatalSelectionError, Wp1SelectionError) as e:
       selection.s_status = 'FAILED'
       logic_selection.set_error_messages(selection, e)
 

--- a/wp1/selection/abstract_builder.py
+++ b/wp1/selection/abstract_builder.py
@@ -47,7 +47,9 @@ class AbstractBuilder:
       logic_selection.set_error_messages(selection, e)
 
     selection.set_updated_at_now()
-    self._upload_to_storage(s3, selection, builder)
+    # Data might be None if build operation didn't succeed.
+    if selection.data:
+      self._upload_to_storage(s3, selection, builder)
 
     logger.info('Saving selection %s to database' %
                 selection.s_id.decode('utf-8'))

--- a/wp1/selection/abstract_builder_test.py
+++ b/wp1/selection/abstract_builder_test.py
@@ -1,7 +1,9 @@
 from datetime import datetime
+import json
 from unittest.mock import MagicMock, patch
 
 from wp1.base_db_test import BaseWpOneDbTest, get_first_selection
+from wp1.exceptions import Wp1RetryableSelectionError, Wp1FatalSelectionError
 from wp1.models.wp10.builder import Builder
 from wp1.models.wp10.selection import Selection
 from wp1.selection.abstract_builder import AbstractBuilder
@@ -11,6 +13,30 @@ class TestBuilder(AbstractBuilder):
 
   def build(self, content_type, **params):
     return '\n'.join(params['list']).encode('utf-8')
+
+
+class TestBuilderRetryable(AbstractBuilder):
+
+  def build(self, content_type, **params):
+    try:
+      int('Not an int')
+    except ValueError:
+      raise Wp1RetryableSelectionError('Could not convert to int')
+
+
+class TestBuilderFatal(AbstractBuilder):
+
+  def build(self, content_type, **params):
+    try:
+      int('Not an int')
+    except ValueError:
+      raise Wp1FatalSelectionError('Could not convert to int')
+
+
+class TestBuilderNoContext(AbstractBuilder):
+
+  def build(self, content_type, **params):
+    raise Wp1FatalSelectionError('Something broke')
 
 
 class AbstractBuilderTest(BaseWpOneDbTest):
@@ -23,13 +49,15 @@ class AbstractBuilderTest(BaseWpOneDbTest):
                            b_name=b'My Builder',
                            b_user_id=1234,
                            b_project=b'en.wikipedia.fake',
-                           b_model=b'wp1.selection.models.simple',
+                           b_model=b'wp1.selection.models.fake',
                            b_params='{"list":["a","b","c"]}')
 
   def test_materialize_creates_selection(self):
     self.test_builder.materialize(self.s3, self.wp10db, self.builder,
                                   'text/tab-separated-values')
+
     actual = get_first_selection(self.wp10db)
+
     self.assertEqual(actual.s_content_type, b'text/tab-separated-values')
     self.assertEqual(actual.s_builder_id, b'1a-2b-3c-4d')
 
@@ -37,16 +65,20 @@ class AbstractBuilderTest(BaseWpOneDbTest):
   def test_materialize_selection_id(self, mock_uuid4):
     self.test_builder.materialize(self.s3, self.wp10db, self.builder,
                                   'text/tab-separated-values')
+
     actual = get_first_selection(self.wp10db)
+
     self.assertEqual(actual.s_id, b'abcd-1234')
 
   @patch('wp1.models.wp10.selection.uuid.uuid4', return_value='abcd-1234')
   def test_materialize_selection_object_key(self, mock_uuid4):
     self.test_builder.materialize(self.s3, self.wp10db, self.builder,
                                   'text/tab-separated-values')
+
     actual = get_first_selection(self.wp10db)
+
     self.assertEqual(
-        actual.s_object_key, b'selections/wp1.selection.models.simple/'
+        actual.s_object_key, b'selections/wp1.selection.models.fake/'
         b'abcd-1234/My Builder.tsv')
 
   @patch('wp1.models.wp10.selection.utcnow',
@@ -54,16 +86,77 @@ class AbstractBuilderTest(BaseWpOneDbTest):
   def test_materialize_selection_updated_at(self, mock_utcnow):
     self.test_builder.materialize(self.s3, self.wp10db, self.builder,
                                   'text/tab-separated-values')
+
     actual = get_first_selection(self.wp10db)
+
     self.assertEqual(actual.s_updated_at, b'20201225105544')
 
   @patch('wp1.models.wp10.selection.uuid.uuid4', return_value='abcd-1234')
   def test_materialize_uploads_to_s3(self, mock_uuid4):
     self.test_builder.materialize(self.s3, self.wp10db, self.builder,
                                   'text/tab-separated-values')
+
     data = self.s3.upload_fileobj.call_args[0][0]
     object_key = self.s3.upload_fileobj.call_args[1]['key']
     self.assertEqual(b'a\nb\nc', data.read())
     self.assertEqual(
-        'selections/wp1.selection.models.simple/abcd-1234/My Builder.tsv',
+        'selections/wp1.selection.models.fake/abcd-1234/My Builder.tsv',
         object_key)
+
+  def test_materialize_retryable_error(self):
+    builder_obj = TestBuilderRetryable()
+    builder_obj.materialize(self.s3, self.wp10db, self.builder,
+                            'text/tab-separated-values')
+
+    actual = get_first_selection(self.wp10db)
+
+    self.assertEqual(b'CAN_RETRY', actual.s_status)
+
+  def test_materialize_retryable_error_messages(self):
+    builder_obj = TestBuilderRetryable()
+    builder_obj.materialize(self.s3, self.wp10db, self.builder,
+                            'text/tab-separated-values')
+
+    actual = get_first_selection(self.wp10db)
+
+    self.assertEqual(
+        {
+            'error_messages': [
+                'Could not convert to int',
+                "invalid literal for int() with base 10: 'Not an int'"
+            ]
+        }, json.loads(actual.s_error_messages))
+
+  def test_materialize_fatal_error(self):
+    builder_obj = TestBuilderFatal()
+    builder_obj.materialize(self.s3, self.wp10db, self.builder,
+                            'text/tab-separated-values')
+
+    actual = get_first_selection(self.wp10db)
+
+    self.assertEqual(b'FAILED', actual.s_status)
+
+  def test_materialize_retryable_error_messages(self):
+    builder_obj = TestBuilderFatal()
+    builder_obj.materialize(self.s3, self.wp10db, self.builder,
+                            'text/tab-separated-values')
+
+    actual = get_first_selection(self.wp10db)
+
+    self.assertEqual(
+        {
+            'error_messages': [
+                'Could not convert to int',
+                "invalid literal for int() with base 10: 'Not an int'"
+            ]
+        }, json.loads(actual.s_error_messages))
+
+  def test_materialize_retryable_error_messages(self):
+    builder_obj = TestBuilderNoContext()
+    builder_obj.materialize(self.s3, self.wp10db, self.builder,
+                            'text/tab-separated-values')
+
+    actual = get_first_selection(self.wp10db)
+
+    self.assertEqual({'error_messages': ['Something broke']},
+                     json.loads(actual.s_error_messages))

--- a/wp1/selection/models/simple.py
+++ b/wp1/selection/models/simple.py
@@ -1,4 +1,6 @@
 import urllib.parse
+
+from wp1.exceptions import Wp1FatalSelectionError
 from wp1.selection.abstract_builder import AbstractBuilder
 
 
@@ -27,9 +29,7 @@ class Builder(AbstractBuilder):
     if content_type != 'text/tab-separated-values':
       raise ValueError('Unrecognized content type')
     if 'list' not in params:
-      raise ValueError(
-          f'Missing required param: list, unnecessary argument given: {list(params.keys())[0]}'
-      )
+      raise Wp1FatalSelectionError('Missing required param: list')
 
     list_minus_comments = [
         line.strip()

--- a/wp1/selection/models/simple.py
+++ b/wp1/selection/models/simple.py
@@ -27,7 +27,7 @@ class Builder(AbstractBuilder):
 
   def build(self, content_type, **params):
     if content_type != 'text/tab-separated-values':
-      raise ValueError('Unrecognized content type')
+      raise Wp1FatalSelectionError('Unrecognized content type')
     if 'list' not in params:
       raise Wp1FatalSelectionError('Missing required param: list')
 

--- a/wp1/selection/models/simple_test.py
+++ b/wp1/selection/models/simple_test.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import MagicMock
 
 from wp1.base_db_test import BaseWpOneDbTest, get_first_selection
+from wp1.exceptions import Wp1FatalSelectionError
 from wp1.models.wp10.builder import Builder
 from wp1.selection.models.simple import Builder as SimpleBuilder
 
@@ -52,13 +53,13 @@ of text than an actual article name.', 'Not_an_<article_name>',
 
   def test_build_unrecognized_content_type(self):
     simple_test_builder = SimpleBuilder()
-    with self.assertRaises(ValueError):
+    with self.assertRaises(Wp1FatalSelectionError):
       simple_test_builder.build('invalid_content_type', **self.params)
 
   def test_build_incorrect_params(self):
     simple_test_builder = SimpleBuilder()
     params = {'items': ['Eiffel_Tower', 'Statue#of_Liberty', 'Libertas']}
-    with self.assertRaises(ValueError):
+    with self.assertRaises(Wp1FatalSelectionError):
       simple_test_builder.build('text/tab-separated-values', **params)
 
   def test_build_ignores_unwanted_params(self):

--- a/wp1/selection/models/sparql.py
+++ b/wp1/selection/models/sparql.py
@@ -1,4 +1,5 @@
 import json
+
 from pyparsing.exceptions import ParseException
 import requests
 from rdflib.term import Literal, URIRef, Variable
@@ -115,7 +116,7 @@ class Builder(AbstractBuilder):
     try:
       r.raise_for_status()
     except requests.exceptions.HTTPError as e:
-      raise Wp1FataSelectionError(
+      raise Wp1FatalSelectionError(
           f'Wikidata sent back a non-200 status code: {r.status_code}') from e
 
     try:

--- a/wp1/selection/models/sparql.py
+++ b/wp1/selection/models/sparql.py
@@ -7,6 +7,7 @@ from rdflib.plugins.sparql import parser
 from rdflib.plugins.sparql.parserutils import CompValue
 
 from wp1.constants import WIKIDATA_PREFIXES, WP1_USER_AGENT
+from wp1.exceptions import Wp1RetryableSelectionError, Wp1FatalSelectionError
 from wp1.selection.abstract_builder import AbstractBuilder
 
 DEFAULT_QUERY_VARIABLE = 'article'
@@ -80,15 +81,17 @@ class Builder(AbstractBuilder):
 
   def build(self, content_type, **params):
     if content_type != 'text/tab-separated-values':
-      raise ValueError('Unrecognized content type')
+      raise Wp1FatalSelectionError('Unrecognized content type')
 
     project = params.get('project')
     if not project:
-      raise ValueError('Expected project, got: %r' % project)
+      raise Wp1FatalSelectionError('Expected param "project", got: %r' %
+                                   project)
 
     params_query = params.get('query')
     if not params_query:
-      raise ValueError('Expected param "query", got: %r' % params_query)
+      raise Wp1FatalSelectionError('Expected param "query", got: %r' %
+                                   params_query)
 
     query_variable = params.get('queryVariable')
     parse_results = parser.parseQuery(params_query)
@@ -96,21 +99,34 @@ class Builder(AbstractBuilder):
     self.instrument_query(query.algebra, project, query_variable=query_variable)
     modified_query = algebra.translateAlgebra(query)
 
-    r = requests.post('https://query.wikidata.org/sparql',
-                      headers={'User-Agent': WP1_USER_AGENT},
-                      data={
-                          'query': modified_query,
-                          'format': 'json',
-                      })
-    r.raise_for_status()
+    try:
+      r = requests.post('https://query.wikidata.org/sparql',
+                        headers={'User-Agent': WP1_USER_AGENT},
+                        data={
+                            'query': modified_query,
+                            'format': 'json',
+                        })
+    except requests.exceptions.Timeout as e:
+      raise Wp1RetryableSelectionError(
+          'The request to Wikidata timed out') from e
+    except requests.exceptions.RequestException as e:
+      raise Wp1RetryableSelectionError('Could not connect to Wikidata') from e
 
-    if len(r.content) > 1024 * 1024 * 10:
-      raise ValueError('Response was larger than 10 MB')
+    try:
+      r.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+      raise Wp1FataSelectionError(
+          f'Wikidata sent back a non-200 status code: {r.status_code}') from e
 
     try:
       data = r.json()
     except json.decoder.JSONDecodeError:
-      raise ValueError('Response was not valid JSON')
+      raise Wp1FatalSelectionError(
+          'Wikidata response was not valid JSON. This is usually caused '
+          'by a timeout because the result set is too large.') from None
+
+    if len(r.content) > 1024 * 1024 * 10:
+      raise Wp1FatalSelectionError('Wikidata response was larger than 10 MB')
 
     urls = [
         d['_wp1_0']['value']
@@ -139,6 +155,6 @@ class Builder(AbstractBuilder):
     except Exception as e:
       # In testing, this was most common when the query contained
       # an undefined prefix.
-      return ('', params['query'], [e.args[0]])
+      return ('', params['query'], [str(e)])
 
     return ('', '', [])

--- a/wp1/selection/models/sparql_test.py
+++ b/wp1/selection/models/sparql_test.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import patch, MagicMock
 
 from wp1.base_db_test import BaseWpOneDbTest, get_first_selection
+from wp1.exceptions import Wp1FatalSelectionError
 from wp1.models.wp10.builder import Builder
 from wp1.selection.models.sparql import Builder as SparqlBuilder
 
@@ -139,7 +140,7 @@ class SparqlBuilderTest(BaseWpOneDbTest):
     response.json.side_effect = json.decoder.JSONDecodeError('foo', 'bar', 0)
     mock_requests.post.return_value = response
 
-    with self.assertRaises(ValueError):
+    with self.assertRaises(Wp1FatalSelectionError):
       actual = self.builder.build('text/tab-separated-values',
                                   query=self.cats_uk_us_after_1950,
                                   queryVariable='cat')
@@ -150,7 +151,7 @@ class SparqlBuilderTest(BaseWpOneDbTest):
     response.content = 'a' * (1024 * 1024 * 20)
     mock_requests.post.return_value = response
 
-    with self.assertRaises(ValueError):
+    with self.assertRaises(Wp1FatalSelectionError):
       actual = self.builder.build('text/tab-separated-values',
                                   query=self.cats_uk_us_after_1950,
                                   queryVariable='cat')

--- a/wp1/selection/models/sparql_test.py
+++ b/wp1/selection/models/sparql_test.py
@@ -2,8 +2,10 @@ import json
 import unittest
 from unittest.mock import patch, MagicMock
 
+import requests
+
 from wp1.base_db_test import BaseWpOneDbTest, get_first_selection
-from wp1.exceptions import Wp1FatalSelectionError
+from wp1.exceptions import Wp1FatalSelectionError, Wp1RetryableSelectionError
 from wp1.models.wp10.builder import Builder
 from wp1.selection.models.sparql import Builder as SparqlBuilder
 
@@ -123,41 +125,79 @@ class SparqlBuilderTest(BaseWpOneDbTest):
     response.json.assert_called_once()
     self.assertEqual(b'Foo', actual)
 
-  @patch('wp1.selection.models.sparql.requests')
-  def test_build_server_error(self, mock_requests):
-    response = MagicMock()
-    mock_requests.post.return_value = response
-    response.raise_for_status.side_effect = Exception()
-
-    with self.assertRaises(Exception):
-      actual = self.builder.build('text/tab-separated-values',
+  def test_build_wrong_content_type(self):
+    with self.assertRaises(Wp1FatalSelectionError):
+      actual = self.builder.build(None,
                                   query=self.cats_uk_us_after_1950,
                                   queryVariable='cat')
 
-  @patch('wp1.selection.models.sparql.requests')
-  def test_build_not_valid_json(self, mock_requests):
+  def test_build_missing_query(self):
+    with self.assertRaises(Wp1FatalSelectionError):
+      actual = self.builder.build('text/tab-separated-values',
+                                  project='en.wikipedia.org',
+                                  queryVariable='cat')
+
+  @patch('wp1.selection.models.sparql.requests.post')
+  def test_build_server_error(self, mock_request_post):
+    response = MagicMock()
+    mock_request_post.return_value = response
+    response.raise_for_status.side_effect = requests.exceptions.HTTPError
+
+    with self.assertRaises(Wp1FatalSelectionError):
+      actual = self.builder.build('text/tab-separated-values',
+                                  project='en.wikipedia.org',
+                                  query=self.cats_uk_us_after_1950,
+                                  queryVariable='cat')
+
+  @patch('wp1.selection.models.sparql.requests.post')
+  def test_build_server_timeout(self, mock_request_post):
+    response = MagicMock()
+    mock_request_post.side_effect = requests.exceptions.Timeout
+
+    with self.assertRaises(Wp1RetryableSelectionError):
+      actual = self.builder.build('text/tab-separated-values',
+                                  project='en.wikipedia.org',
+                                  query=self.cats_uk_us_after_1950,
+                                  queryVariable='cat')
+
+  @patch('wp1.selection.models.sparql.requests.post')
+  def test_build_server_request_exception(self, mock_request_post):
+    response = MagicMock()
+    mock_request_post.side_effect = requests.exceptions.RequestException
+
+    with self.assertRaises(Wp1RetryableSelectionError):
+      actual = self.builder.build('text/tab-separated-values',
+                                  project='en.wikipedia.org',
+                                  query=self.cats_uk_us_after_1950,
+                                  queryVariable='cat')
+
+  @patch('wp1.selection.models.sparql.requests.post')
+  def test_build_not_valid_json(self, mock_request_post):
     response = MagicMock()
     response.json.side_effect = json.decoder.JSONDecodeError('foo', 'bar', 0)
-    mock_requests.post.return_value = response
+    mock_request_post.return_value = response
 
     with self.assertRaises(Wp1FatalSelectionError):
       actual = self.builder.build('text/tab-separated-values',
+                                  project='en.wikipedia.org',
                                   query=self.cats_uk_us_after_1950,
                                   queryVariable='cat')
 
-  @patch('wp1.selection.models.sparql.requests')
-  def test_build_not_resp_too_large(self, mock_requests):
+  @patch('wp1.selection.models.sparql.requests.post')
+  def test_build_not_resp_too_large(self, mock_request_post):
     response = MagicMock()
     response.content = 'a' * (1024 * 1024 * 20)
-    mock_requests.post.return_value = response
+    mock_request_post.return_value = response
 
     with self.assertRaises(Wp1FatalSelectionError):
       actual = self.builder.build('text/tab-separated-values',
+                                  project='en.wikipedia.org',
                                   query=self.cats_uk_us_after_1950,
                                   queryVariable='cat')
 
   def test_validate(self):
     actual = self.builder.validate(query=self.cats_uk_us_after_1950,
+                                   project='en.wikipedia.org',
                                    queryVariable='cat')
 
     self.assertEqual(('', '', []), actual)
@@ -182,12 +222,15 @@ class SparqlBuilderTest(BaseWpOneDbTest):
 
   def test_validate_missing_prefix(self):
     query = 'SELECT ?foo WHERE { ?foo blah:x ?bar }'
-    actual = self.builder.validate(query=query, queryVariable='foo')
+    actual = self.builder.validate(project='en.wikipedia.org',
+                                   query=query,
+                                   queryVariable='foo')
 
     self.assertEqual(('', query, ['Unknown namespace prefix : blah']), actual)
 
   def test_validate_missing_query_variable(self):
-    actual = self.builder.validate(query=self.cats_uk_us_after_1950)
+    actual = self.builder.validate(project='en.wikipedia.org',
+                                   query=self.cats_uk_us_after_1950)
     self.assertEqual(
         ('', self.cats_uk_us_after_1950,
          ['The query variable "article" did not appear in the query']), actual)

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -91,7 +91,11 @@ def get_builder(builder_id):
   if builder.b_user_id != user['identity']['sub']:
     flask.abort(404)
 
-  return flask.jsonify(builder.to_web_dict())
+  selection_errors = logic_builder.latest_selections_with_errors(
+      wp10db, builder_id)
+  res = builder.to_web_dict()
+  res.update(selection_errors=selection_errors)
+  return flask.jsonify(res)
 
 
 @builders.route('/<builder_id>/delete', methods=['POST'])

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -64,16 +64,16 @@ class BuildersTest(BaseWebTestcase):
   def _insert_selections(self, builder_id):
     with self.wp10db.cursor() as cursor:
       cursor.execute(
-          'INSERT INTO selections VALUES (1, %s, "text/tab-separated-values", "20201225105544", 1, "object_key1")',
+          'INSERT INTO selections VALUES (1, %s, "text/tab-separated-values", "20201225105544", 1, "object_key1", NULL, NULL)',
           builder_id)
       cursor.execute(
-          'INSERT INTO selections VALUES (2, %s, "application/vnd.ms-excel", "20201225105544", 1, "object_key2")',
+          'INSERT INTO selections VALUES (2, %s, "application/vnd.ms-excel", "20201225105544", 1, "object_key2", NULL, NULL)',
           builder_id)
       cursor.execute(
-          'INSERT INTO selections VALUES (3, %s, "text/tab-separated-values", "20201225105544", 2, "latest_object_key_tsv")',
+          'INSERT INTO selections VALUES (3, %s, "text/tab-separated-values", "20201225105544", 2, "latest_object_key_tsv", NULL, NULL)',
           builder_id)
       cursor.execute(
-          'INSERT INTO selections VALUES (4, %s, "application/vnd.ms-excel", "20201225105544", 2, "latest_object_key_xls")',
+          'INSERT INTO selections VALUES (4, %s, "application/vnd.ms-excel", "20201225105544", 2, "latest_object_key_xls", NULL, NULL)',
           builder_id)
     self.wp10db.commit()
 

--- a/wp1/web/selection_test.py
+++ b/wp1/web/selection_test.py
@@ -35,7 +35,9 @@ class SelectionTest(BaseWebTestcase):
           's_extension':
               'tsv',
           's_url':
-              'http://test.server.fake/v1/builders/1a-2b-3c-4d/selection/latest.tsv'
+              'http://test.server.fake/v1/builders/1a-2b-3c-4d/selection/latest.tsv',
+          's_status':
+              None,
       }],
   }
 
@@ -63,31 +65,23 @@ class SelectionTest(BaseWebTestcase):
               's_extension':
                   'xls',
               's_url':
-                  'http://test.server.fake/v1/builders/1a-2b-3c-4d/selection/latest.xls'
+                  'http://test.server.fake/v1/builders/1a-2b-3c-4d/selection/latest.xls',
+              's_status':
+                  None,
           },
           {
-              'id':
-                  '1a-2b-3c-4d',
-              'name':
-                  'name',
-              'project':
-                  'project_name',
-              'created_at':
-                  1608893744,
-              'updated_at':
-                  1608893744,
-              'model':
-                  'model',
-              's_id':
-                  '1',
-              's_updated_at':
-                  1608893744,
-              's_content_type':
-                  'text/tab-separated-values',
-              's_extension':
-                  'tsv',
-              's_url':
-                  'http://test.server.fake/v1/builders/1a-2b-3c-4d/selection/latest.tsv'
+              'id': '1a-2b-3c-4d',
+              'name': 'name',
+              'project': 'project_name',
+              'created_at': 1608893744,
+              'updated_at': 1608893744,
+              'model': 'model',
+              's_id': '1',
+              's_updated_at': 1608893744,
+              's_content_type': 'text/tab-separated-values',
+              's_extension': 'tsv',
+              's_url': None,
+              's_status': 'CAN_RETRY',
           },
       ]
   }
@@ -105,6 +99,7 @@ class SelectionTest(BaseWebTestcase):
           's_content_type': None,
           's_extension': None,
           's_url': None,
+          's_status': None,
       }]
   }
 
@@ -117,7 +112,7 @@ class SelectionTest(BaseWebTestcase):
         VALUES ('1a-2b-3c-4d', 'name', '1234', 'project_name', 'model', '20201225105544', '20201225105544', 1)
       ''')
         cursor.execute(
-            'INSERT INTO selections VALUES (1, \'1a-2b-3c-4d\', "text/tab-separated-values", "20201225105544", 1, "object_key")'
+            'INSERT INTO selections VALUES (1, \'1a-2b-3c-4d\', "text/tab-separated-values", "20201225105544", 1, "object_key", NULL, NULL)'
         )
       self.wp10db.commit()
       with client.session_transaction() as sess:
@@ -134,10 +129,10 @@ class SelectionTest(BaseWebTestcase):
         VALUES ('1a-2b-3c-4d', 'name', '1234', 'project_name', 'model', '20201225105544', '20201225105544', 1)
       ''')
         cursor.execute(
-            'INSERT INTO selections VALUES (1, \'1a-2b-3c-4d\', "text/tab-separated-values", "20201225105544", 1, "object_key_1")'
+            'INSERT INTO selections VALUES (1, \'1a-2b-3c-4d\', "text/tab-separated-values", "20201225105544", 1, "object_key_1", "CAN_RETRY", \'{"errors"["error1"]}\')'
         )
         cursor.execute(
-            'INSERT INTO selections VALUES (2, \'1a-2b-3c-4d\', "application/vnd.ms-excel", "20201225105544", 1, "object_key_2")'
+            'INSERT INTO selections VALUES (2, \'1a-2b-3c-4d\', "application/vnd.ms-excel", "20201225105544", 1, "object_key_2", NULL, NULL)'
         )
       self.wp10db.commit()
       with client.session_transaction() as sess:
@@ -168,7 +163,7 @@ class SelectionTest(BaseWebTestcase):
     with self.override_db(self.app), self.app.test_client() as client:
       with self.wp10db.cursor() as cursor:
         cursor.execute(
-            '''INSERT INTO selections VALUES (2, \'1a-2b-3c-4d\', "application/vnd.ms-excel", '20201225105544', 1, "object_key")'''
+            '''INSERT INTO selections VALUES (2, \'1a-2b-3c-4d\', "application/vnd.ms-excel", '20201225105544', 1, "object_key", NULL, NULL)'''
         )
       self.wp10db.commit()
       with client.session_transaction() as sess:

--- a/wp10_test.up.sql
+++ b/wp10_test.up.sql
@@ -110,7 +110,9 @@ CREATE TABLE `selections` (
   s_content_type VARBINARY(255) NOT NULL,
   s_updated_at BINARY(14) NOT NULL,
   s_version int(11) NOT NULL,
-  s_object_key VARBINARY(255) NOT NULL
+  s_object_key VARBINARY(255),
+  s_status VARBINARY(255) DEFAULT 'OK',
+  s_error_messages BLOB
 );
 
 CREATE TABLE custom (


### PR DESCRIPTION
Fixes #526.

Previous to this PR, when selection materialization failed, there was no feedback to the user. Now, we show an error message in the overall list view, with more information and possibly a retry button on the edit view for the selection that failed.

Screenshots:

![error_list](https://user-images.githubusercontent.com/57832/206873837-2e72070a-8adb-4f19-8c93-733bf6fd598e.png)

![error_retryable](https://user-images.githubusercontent.com/57832/206873839-37aba0b3-90c6-4211-8aa5-c1fbbecb9b0d.png)

![error_fatal](https://user-images.githubusercontent.com/57832/206873840-c3eb5e9f-6bd9-4cbd-8807-dfa0979e14ad.png)

Note that each list of error messages contains a message that we wrote, such as "Could not connect to Wikidata" and the raw message that was returned by the Requests API or other API that failed, such as "HTTPSConnectionPool(host="query.wikidata.org' ...". The latter is not particularly user friendly but will help with debugging errors when they occur.

The "Retry" button on the edit page simply submits the current Builder as an update action, which will always cause materialization to be retried even if nothing has changed. Note that even though we classify most errors as non-retryable (since, unless the Builder params change they will simply fail again), the user could always click "Update" without making changes and invoke this same behavior.

Also includes Cypress tests for the new table entries in the list view and for the edit page.