### PR TITLE
Fix status selection for builders, default is OK

### DIFF
--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -186,7 +186,7 @@ def latest_selections_with_errors(wp10db, builder_id):
            FROM selections AS s JOIN builders as b
              ON s.s_builder_id = b.b_id
              AND s.s_version = b.b_current_version
-           WHERE b.b_id = %s AND s.s_status IS NOT NULL
+           WHERE b.b_id = %s AND s.s_status IS NOT NULL AND s.s_status != 'OK'
         ''', (builder_id,))
     data = cursor.fetchall()
   if data is None:
@@ -233,6 +233,7 @@ def get_builders_with_selections(wp10db, user_id):
   for b in data:
     has_selection = b['s_id'] is not None
     has_status = b['s_status'] is not None
+    is_ok_status = b['s_status'] == b'OK'
     content_type = b['s_content_type'].decode(
         'utf-8') if has_selection else None
     selection_id = b['s_id'].decode('utf-8') if has_selection else None
@@ -261,7 +262,7 @@ def get_builders_with_selections(wp10db, user_id):
             if has_selection else None,
         's_url':
             latest_url_for(b['b_id'].decode('utf-8'), content_type)
-            if has_selection and not has_status else None,
+            if has_selection and (is_ok_status or not has_status) else None,
         's_status':
             b['s_status'].decode('utf-8')
             if has_selection and has_status else None

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -46,7 +46,7 @@ class BuilderTest(BaseWpOneDbTest):
       's_url':
           'http://test.server.fake/v1/builders/1a-2b-3c-4d/selection/latest.tsv',
       's_status':
-          None,
+          'OK',
   }]
 
   expected_lists_with_multiple_selections = [
@@ -74,7 +74,7 @@ class BuilderTest(BaseWpOneDbTest):
           's_url':
               'http://test.server.fake/v1/builders/1a-2b-3c-4d/selection/latest.xls',
           's_status':
-              None,
+              'OK',
       },
       {
           'id':
@@ -100,7 +100,7 @@ class BuilderTest(BaseWpOneDbTest):
           's_url':
               'http://test.server.fake/v1/builders/1a-2b-3c-4d/selection/latest.tsv',
           's_status':
-              None,
+              'OK',
       },
   ]
 
@@ -131,7 +131,7 @@ class BuilderTest(BaseWpOneDbTest):
       's_content_type': 'foo/bar-baz',
       's_extension': '???',
       's_url': None,
-      's_status': None,
+      's_status': 'OK',
   }]
 
   def _insert_builder(self, current_version=None):
@@ -163,7 +163,7 @@ class BuilderTest(BaseWpOneDbTest):
       status = 'CAN_RETRY'
       error_messages = '{"error_messages":["There was an error"]}'
     else:
-      status = None
+      status = 'OK'
       error_messages = None
 
     with self.wp10db.cursor() as cursor:


### PR DESCRIPTION
The database schema for selections makes 'OK' the default value. However some of the builder code was written assuming NULL was the default for selections with no errors. This PR fixes that.