### PR TITLE
Additional status bug on frontend

### DIFF
--- a/wp1-frontend/src/components/MyLists.vue
+++ b/wp1-frontend/src/components/MyLists.vue
@@ -125,7 +125,7 @@ export default {
       );
     },
     hasSelectionError: function (item) {
-      return item.s_status !== null;
+      return item.s_status !== null && item.s_status !== 'OK';
     },
     getLists: async function () {
       let createDataTable = false;


### PR DESCRIPTION
The frontend additionally had a bug where it was only checking for non-NULL status as indication of error. Whereas in production, the status could be 'OK' to indicate success. See #550 