### PR TITLE
Less specific URL splitting for SPARQL URL input

### DIFF
--- a/wp1-frontend/src/components/SparqlBuilder.vue
+++ b/wp1-frontend/src/components/SparqlBuilder.vue
@@ -168,7 +168,7 @@ export default {
         this.queryUpdateError = true;
         return;
       }
-      const parts = url.split('wikidata.org/#');
+      const parts = url.split('#');
       if (parts.length < 2) {
         this.queryUpdateError = true;
         return;


### PR DESCRIPTION
Fixes #554

Just split on the anchor tag in order to allow URLs where the path is not exactly `/` or `/index.html`.