### PR TITLE
Raise error if SPARQL query results are non-error but empty

### DIFF
--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -174,6 +174,8 @@ def latest_selection_url(wp10db, builder_id, ext):
     return None
 
   if data['object_key'] is None:
+    logger.warning('Object key for selection was None, builder id=%s',
+                   builder_id)
     return None
 
   return logic_selection.url_for(data['object_key'].decode('utf-8'))

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -191,11 +191,6 @@ def latest_selections_with_errors(wp10db, builder_id):
            WHERE b.b_id = %s AND s.s_status IS NOT NULL AND s.s_status != 'OK'
         ''', (builder_id,))
     data = cursor.fetchall()
-  if data is None:
-    logger.warning(
-        'Could not find latest selections with errors for builder id=%s',
-        builder_id)
-    return None
 
   res = []
   for db_selection in data:

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -456,6 +456,14 @@ class BuilderTest(BaseWpOneDbTest):
 
     self.assertIsNone(actual)
 
+  def test_latest_selection_url_no_object_key(self):
+    builder_id = self._insert_builder()
+    self._insert_selection(1, 'text/tab-separated-values', object_key=None)
+
+    actual = logic_builder.latest_selection_url(self.wp10db, builder_id, 'tsv')
+
+    self.assertIsNone(actual)
+
   def test_latest_selection_url_unrelated_selections(self):
     builder_id = self._insert_builder()
     self._insert_selection(1, 'text/tab-separated-values', builder_id=-1)
@@ -572,3 +580,19 @@ class BuilderTest(BaseWpOneDbTest):
         'ext': 'xls',
         'error_messages': ['There was an error']
     }], actual)
+
+  def test_latest_selection_with_errors_no_errors(self):
+    builder_id = self._insert_builder()
+    self._insert_selection(1,
+                           'text/tab-separated-values',
+                           builder_id=builder_id,
+                           has_errors=False)
+    self._insert_selection(2,
+                           'application/vnd.ms-excel',
+                           builder_id=builder_id,
+                           has_errors=False)
+
+    actual = logic_builder.latest_selections_with_errors(
+        self.wp10db, builder_id)
+
+    self.assertEqual(0, len(actual))


### PR DESCRIPTION
Fixes #555.

As explained in #555, that specific query was causing confusing results because the query variable was wrong. In general though, we need to be resilient against the possibility of there being no results in response from Wikidata. For this purpose, an empty results set is now considered a "fatal" error, since it couldn't be fixed by simply retrying and the query itself (or in this case the query variable) needs to be edited.