### PR TITLE
Attempt to fix routing issues. Doesn't quite work.

### DIFF
--- a/wp1-frontend/src/components/BaseBuilder.vue
+++ b/wp1-frontend/src/components/BaseBuilder.vue
@@ -189,6 +189,7 @@ export default {
   components: { SecondaryNav, LoginRequired, PulseLoader },
   name: 'BaseBuilder',
   props: {
+    builderId: String,
     invalidItems: String,
     listName: String,
     model: String,
@@ -219,9 +220,6 @@ export default {
     },
     isEditing: function () {
       return !!this.builderId;
-    },
-    builderId: function () {
-      return this.$route.params.builder_id;
     },
     computedInvalidItems: function () {
       return this.invalidItems;

--- a/wp1-frontend/src/components/SimpleBuilder.vue
+++ b/wp1-frontend/src/components/SimpleBuilder.vue
@@ -1,8 +1,10 @@
 <template>
   <BaseBuilder
+    :key="$route.path"
     :listName="'Simple Selection'"
     :model="'wp1.selection.models.simple'"
     :params="params"
+    :builderId="$route.params.builder_id"
     :invalidItems="invalidItems"
     @onBuilderLoaded="onBuilderLoaded"
     @onBeforeSubmit="onBeforeSubmit"
@@ -25,8 +27,7 @@
             'Eiffel_Tower\nStatue_of_Liberty\nFreedom_Monument_(Baghdad)\n' +
             'George-Étienne_Cartier_Monument\n\n# Whitespace and comments ' +
             'starting with # are ignored' +
-            '\n' +
-            success
+            '\n'
           "
           class="form-control my-list"
           :class="{ 'is-invalid': !success }"

--- a/wp1-frontend/src/components/SparqlBuilder.vue
+++ b/wp1-frontend/src/components/SparqlBuilder.vue
@@ -1,8 +1,10 @@
 <template>
   <BaseBuilder
+    :key="$route.path"
     :listName="'SPARQL Selection'"
     :model="'wp1.selection.models.sparql'"
     :params="params"
+    :builderId="$route.params.builder_id"
     @onBeforeSubmit="onBeforeSubmit"
     @onValidationError="onValidationError"
     @onBuilderLoaded="onBuilderLoaded"
@@ -100,8 +102,7 @@
             '  ?article wdt:P31 wd:Q5741069 .\n' +
             '  ?article rdfs:label ?bandLabel .\n' +
             '  FILTER(LANG(?bandLabel) = &quot;en&quot;) .\n' +
-            '  FILTER(STRSTARTS(?bandLabel, \'M\')) .\n}' +
-            success
+            '  FILTER(STRSTARTS(?bandLabel, \'M\')) .\n}'
           "
           class="form-control my-list"
           :class="{ 'is-invalid': !success }"


### PR DESCRIPTION
As a workaround to component reuse, this PR adds a `:key="$route.path"` to affected components. This is intended to cause them to be discarded by the Vue renderer when the route changes. While this fixes the 404 error seen in #570, it doesn't fully resolve the issue because the contents of the form fields are preserved after the route change.