### PR TITLE
Create zimfarm.py module for getting Zimfarm access tokens and requesting ZIM file creation tasks

### DIFF
--- a/wp1/credentials.py.e2e
+++ b/wp1/credentials.py.e2e
@@ -61,6 +61,11 @@ CREDENTIALS = {
         'CLIENT_URL': {
             'api': 'http://test.server.fake'
         },
+        'ZIMFARM': {
+            'url': 'https://fake.farm/v1',
+            'user': 'farmuser',
+            'password': 'farmpass',
+        }
     },
     Environment.PRODUCTION: {},
 }

--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -110,6 +110,14 @@ CREDENTIALS = {
             'secret': '', # EDIT this line
             'bucket': 'org-kiwix-dev-wp1',
         },
+
+        # Server URL and credentials for the Zim Farm that will be used to create
+        # ZIM files from materializes selections.
+        'ZIMFARM': {
+            'url': 'https://api.farm.youzim.it/v1',
+            'user': '', # EDIT this line
+            'password': '', # EDIT this line
+        },
     },
 
     # Environment for python nosetests. In this environment, only the MySQL database
@@ -152,6 +160,13 @@ CREDENTIALS = {
             'secret': 'test_secret',
             'bucket': 'org-kiwix-dev-wp1',
         },
+
+        # Fake Zim Farm server values for test.
+        'ZIMFARM': {
+            'url': 'https://fake.farm/v1',
+            'user': 'farmuser',
+            'password': 'farmpass',
+        }
     },
 
     # EDIT: Remove the next line after you've provided actual production credentials.
@@ -192,8 +207,8 @@ CREDENTIALS = {
     #   # Credentials for authentication through mwoauth.
     #   # To register the app go to 'https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration/propose'
     #   'MWOAUTH': {
-    #       'consumer_key': '', # EDIT this line for production.
-    #       'consumer_secret': '', # EDIT this line for production.
+    #      'consumer_key': '', # EDIT this line for production.
+    #      'consumer_secret': '', # EDIT this line for production.
     #   },
 
     #   # Secret key for session. If this ever changes, all existing logged in users will be
@@ -203,21 +218,29 @@ CREDENTIALS = {
     #   # import os
     #   # os.urandom(24).hex()
     #   'SESSION': {
-    #       'secret_key': '' # EDIT this line for production.
+    #      'secret_key': '' # EDIT this line for production.
     #   },
 
     #   # Client side url used for redirection in login process.
     #   'CLIENT_URL': {
-    #       'domains': ['http://wp1.openzim.org', 'https://wp1.openzim.org'],
-    #       'homepage': 'https://wp1.openzim.org/#/',
-    #       's3': 'https://org-kiwix-wp1.s3.us-west-1.wasabisys.com',
-    #       'api': 'https://api.wp1.openzim.org',
+    #      'domains': ['http://wp1.openzim.org', 'https://wp1.openzim.org'],
+    #      'homepage': 'https://wp1.openzim.org/#/',
+    #      's3': 'https://org-kiwix-wp1.s3.us-west-1.wasabisys.com',
+    #      'api': 'https://api.wp1.openzim.org',
     #   },
 
-    # Configuration for the storage backend for storing selection lists.
+    #   # Configuration for the storage backend for storing selection lists.
     #   'STORAGE': {
-    #       'key': '', # EDIT this line for production.
-    #       'secret': '', # EDIT this line for production.
-    #       'bucket': 'org-kiwix-wp1',
+    #      'key': '', # EDIT this line for production.
+    #      'secret': '', # EDIT this line for production.
+    #      'bucket': 'org-kiwix-wp1',
+    #   },
+
+    #   # Server URL and credentials for the Zim Farm that will be used to create
+    #   # ZIM files from materializes selections.
+    #   'ZIMFARM': {
+    #      'url': 'https://api.farm.youzim.it/v1',
+    #      'user': '', # EDIT this line
+    #      'password': '', # EDIT this line
     #   },
 }

--- a/wp1/exceptions.py
+++ b/wp1/exceptions.py
@@ -8,3 +8,7 @@ class Wp1RetryableSelectionError(Wp1SelectionError):
 
 class Wp1FatalSelectionError(Wp1SelectionError):
   pass
+
+
+class ZimFarmError(Exception):
+  pass

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -8,6 +8,7 @@ import attr
 from wp1.constants import CONTENT_TYPE_TO_EXT
 from wp1.models.wp10.selection import Selection
 from wp1.storage import connect_storage
+from wp1.logic import util
 
 try:
   from wp1.credentials import ENV, CREDENTIALS
@@ -85,7 +86,7 @@ def object_key_for(selection_id,
       'model': model,
       'id': selection_id,
       'ext': ext,
-      'name': name,
+      'name': util.safe_name(name),
   }
 
 

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -6,6 +6,7 @@ import urllib.parse
 import attr
 
 from wp1.constants import CONTENT_TYPE_TO_EXT
+from wp1.models.wp10.selection import Selection
 from wp1.storage import connect_storage
 
 try:
@@ -24,10 +25,11 @@ def insert_selection(wp10db, selection):
   with wp10db.cursor() as cursor:
     cursor.execute(
         '''INSERT INTO selections
-      (s_id, s_builder_id, s_version, s_content_type, s_updated_at,
-       s_object_key, s_status, s_error_messages)
-      VALUES (%(s_id)s, %(s_builder_id)s, %(s_version)s, %(s_content_type)s,
-      %(s_updated_at)s, %(s_object_key)s, %(s_status)s, %(s_error_messages)s)
+             (s_id, s_builder_id, s_version, s_content_type, s_updated_at,
+              s_object_key, s_status, s_error_messages)
+             VALUES
+             (%(s_id)s, %(s_builder_id)s, %(s_version)s, %(s_content_type)s,
+              %(s_updated_at)s, %(s_object_key)s, %(s_status)s, %(s_error_messages)s)
     ''', attr.asdict(selection))
   wp10db.commit()
 

--- a/wp1/logic/util.py
+++ b/wp1/logic/util.py
@@ -1,4 +1,5 @@
 import datetime
+import re
 import time
 
 from wp1.conf import get_conf
@@ -96,3 +97,7 @@ def int_to_ns(wp10db):
   if _INT_TO_NS is None:
     _INT_TO_NS = {v: k for k, v in ns_to_int(wp10db).items()}
   return _INT_TO_NS
+
+
+def safe_name(name):
+  return ''.join(c for c in name if re.match(r'\w|\.|-|_', c)).strip()

--- a/wp1/logic/util_test.py
+++ b/wp1/logic/util_test.py
@@ -14,5 +14,4 @@ class TestUtil(unittest.TestCase):
   def test_safe_name(self):
     for test, expected in self.safe_name_tests:
       actual = util.safe_name(test)
-      print(test, expected, actual)
       self.assertEqual(expected, actual)

--- a/wp1/logic/util_test.py
+++ b/wp1/logic/util_test.py
@@ -1,0 +1,18 @@
+import unittest
+
+from wp1.logic import util
+
+
+class TestUtil(unittest.TestCase):
+  safe_name_tests = [
+      ('Foo Bar', 'FooBar'),
+      ('Français', 'Français'),
+      ('âme île & **hôtel-sûr_être', 'âmeîlehôtel-sûr_être'),
+      ('爱', '爱'),
+  ]
+
+  def test_safe_name(self):
+    for test, expected in self.safe_name_tests:
+      actual = util.safe_name(test)
+      print(test, expected, actual)
+      self.assertEqual(expected, actual)

--- a/wp1/selection/abstract_builder_test.py
+++ b/wp1/selection/abstract_builder_test.py
@@ -88,7 +88,7 @@ class AbstractBuilderTest(BaseWpOneDbTest):
 
     self.assertEqual(
         actual.s_object_key, b'selections/wp1.selection.models.fake/'
-        b'abcd-1234/My Builder.tsv')
+        b'abcd-1234/MyBuilder.tsv')
 
   @patch('wp1.models.wp10.selection.utcnow',
          return_value=datetime(2020, 12, 25, 10, 55, 44))
@@ -109,7 +109,7 @@ class AbstractBuilderTest(BaseWpOneDbTest):
     object_key = self.s3.upload_fileobj.call_args[1]['key']
     self.assertEqual(b'a\nb\nc', data.read())
     self.assertEqual(
-        'selections/wp1.selection.models.fake/abcd-1234/My Builder.tsv',
+        'selections/wp1.selection.models.fake/abcd-1234/MyBuilder.tsv',
         object_key)
 
   def test_materialize_retryable_error(self):

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -123,7 +123,7 @@ def _get_params(wp10db, builder_id):
           'memory': TASK_MEMORY,
           'disk': TASK_DISK,
       },
-      'platform': None,
+      'platform': 'wikimedia',
       'monitor': False,
       'flags': {
           'mwUrl': 'https://%s/' % project,

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -1,0 +1,55 @@
+from wp1.credentials import CREDENTIALS, ENV
+from wp1.logic import util
+import wp1.logic.builder as logic_builder
+import wp1.logic.selection as logic_selection
+
+TASK_CPU = 2
+TASK_MEMORY = 1024
+TASK_DISK = 2048
+MWOFFLINER_IMAGE = 'ghcr.io/openzim/mwoffliner:1.12.1'
+
+
+def _get_params(wp10db, builder_id):
+  if isinstance(builder_id, str):
+    builder_id = builder_id.encode('utf-8')
+
+  builder = logic_builder.get_builder(wp10db, builder_id)
+  project = builder.b_project.decode('utf-8')
+  selection = logic_builder.latest_selection_for(wp10db, builder_id,
+                                                 'text/tab-separated-values')
+
+  config = {
+      'task_name': 'zimit',
+      'warehouse_path': '/wp1',
+      'image': {
+          'name': MWOFFLINER_IMAGE.split(':')[0],
+          'tag': MWOFFLINER_IMAGE.split(':')[1],
+      },
+      'resources': {
+          'cpu': TASK_CPU,
+          'memory': TASK_MEMORY,
+          'disk': TASK_DISK,
+      },
+      'platform': None,
+      'monitor': False,
+      'flags': {
+          'mwUrl': 'https://%s/' % project,
+          'adminEmail': 'admin@wp1.openzim.org',
+          'articleList': logic_selection.url_for_selection(selection),
+          'customZimTitle': util.safe_name(builder.b_name.decode('utf-8')),
+      }
+  }
+
+  return {
+      'name': 'wp1_selection_%s' % selection.s_id.decode('utf-8'),
+      'language': {
+          'code': 'eng',
+          'name_en': 'English',
+          'name_native': 'English'
+      },
+      'category': 'other',
+      'periodicity': 'manually',
+      'tags': [],
+      'enabled': True,
+      'config': config,
+  }

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -14,7 +14,8 @@ import wp1.logic.selection as logic_selection
 from wp1.timestamp import utcnow
 from wp1.time import get_current_datetime
 
-TASK_CPU = 2
+# TODO(#582): Determine resource profile from Selection list size.
+TASK_CPU = 3
 TASK_MEMORY = 1024 * 1024 * 1024
 TASK_DISK = 2048 * 1024 * 100
 MWOFFLINER_IMAGE = 'ghcr.io/openzim/mwoffliner:latest'
@@ -107,6 +108,9 @@ def _get_params(wp10db, builder_id):
     builder_id = builder_id.encode('utf-8')
 
   builder = logic_builder.get_builder(wp10db, builder_id)
+  if builder is None:
+    raise ZimFarmError('Could not find builder with id: %s', builder_id)
+
   project = builder.b_project.decode('utf-8')
   selection = logic_builder.latest_selection_for(wp10db, builder_id,
                                                  'text/tab-separated-values')
@@ -130,6 +134,9 @@ def _get_params(wp10db, builder_id):
           'adminEmail': 'contact+wp1@kiwix.org',
           'articleList': logic_selection.url_for_selection(selection),
           'customZimTitle': util.safe_name(builder.b_name.decode('utf-8')),
+          # TODO(#584): Replace these placeholders with input from the user.
+          'customZimDescription': 'ZIM file created from a WP1 Selection',
+          'customZimLongDescription': 'ZIM file created from a WP1 Selection',
       }
   }
 

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -1,7 +1,15 @@
+from datetime import timedelta
+from functools import wraps
+import time
+
+import requests
+
+from wp1.constants import WP1_USER_AGENT
 from wp1.credentials import CREDENTIALS, ENV
 from wp1.logic import util
 import wp1.logic.builder as logic_builder
 import wp1.logic.selection as logic_selection
+from wp1.timestamp import utcnow
 
 TASK_CPU = 2
 TASK_MEMORY = 1024
@@ -34,7 +42,7 @@ def _get_params(wp10db, builder_id):
       'monitor': False,
       'flags': {
           'mwUrl': 'https://%s/' % project,
-          'adminEmail': 'admin@wp1.openzim.org',
+          'adminEmail': 'contact+wp1@kiwix.org',
           'articleList': logic_selection.url_for_selection(selection),
           'customZimTitle': util.safe_name(builder.b_name.decode('utf-8')),
       }
@@ -53,3 +61,98 @@ def _get_params(wp10db, builder_id):
       'enabled': True,
       'config': config,
   }
+
+
+def store_zimfarm_token(wp10db, data):
+  data['expires_at'] = utcnow() + timedelta(seconds=data['expires_in'])
+
+  with wp10db.cursor() as cursor:
+    cursor.execute(
+        'INSERT INTO zimfarm_auth (access_token, expires_at, refresh_token) '
+        'VALUES (%(access_token)s, %(expires_at)s, %(refresh_token)s)', data)
+
+
+def request_zimfarm_token(wp10db):
+  user = CREDENTIALS[ENV].get('ZIMFARM', {}).get('user')
+  password = CREDENTIALS[ENV].get('ZIMFARM', {}).get('password')
+
+  if user is None or password is None:
+    raise ZimFarmError(
+        'Could not log into zimfarm, user/password not found in credentials.py')
+
+  r = requests.post('%s/auth/authorize' % get_zimfarm_url,
+                    headers={'User-Agent': WP1_USER_AGENT},
+                    data={
+                        'username': user,
+                        'password': password
+                    })
+  r.raise_for_status()
+
+  data = r.json()
+  print(data)
+
+  store_zimfarm_token(wp10db, data)
+
+  return data['access_token']
+
+
+def refresh_zimfarm_token(wp10db, refresh_token):
+  r = requests.post(
+      '%s/auth/token',
+      headers={
+          'User-Agent': WP1_USER_AGENT,
+          'refresh-token': refresh_token
+      },
+  )
+  r.raise_for_status()
+
+  data = r.json()
+  print(data)
+
+  store_zimfarm_token(wp10db, data)
+
+  return data['access_token']
+
+
+def get_zimfarm_token(wp10db):
+  with wp10db.cursor() as cursor:
+    cursor.execute(
+        'SELECT access_token, expires_at, refresh_token FROM zimfarm_auth LIMIT 1'
+    )
+    data = cursor.fetchone()
+    if data is None:
+      return request_zimfarm_token(wp10db)
+
+  if data['expires_at'] < time.mktime(utcnow().timetuple()):
+    # Token is expired, refresh
+    return refresh_zimfarm_token(wp10db, data['refresh_token'])
+
+  return data['access_token']
+
+
+def get_zimfarm_url():
+  return CREDENTIALS[ENV].get('ZIMFARM', {}).get('url', '')
+
+
+def schedule_zim_file(wp10db, builder_id):
+  token = get_zimfarm_token(wp10db)
+
+  params = _get_params(wp10db, builder_id)
+  base_url = get_zimfarm_url()
+
+  r = requests.post('%s/schedules/' % base_url,
+                    headers={'User-Agent': WP1_USER_AGENT},
+                    json=params)
+
+  r.raise_for_status()
+
+  r = requests.post('%s/requested_tasks/' % base_url,
+                    headers={'User-Agent': WP1_USER_AGENT},
+                    json={schedule_names: [params['name'],]})
+
+  r.raise_for_status()
+
+  task_id = r.json()['requested'][0]
+  print(task_id)
+
+  r = requets.delete('%s/schedules/%s' % (base_url, params['name']))

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -87,7 +87,7 @@ class ZimFarmTest(BaseWpOneDbTest):
                     'memory': 1073741824,
                     'disk': 209715200,
                 },
-                'platform': None,
+                'platform': 'wikimedia',
                 'monitor': False,
                 'flags': {
                     'mwUrl':

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -1,0 +1,97 @@
+import attr
+
+from wp1 import zimfarm
+from wp1.base_db_test import BaseWpOneDbTest
+from wp1.models.wp10.builder import Builder
+
+
+class ZimFarmTest(BaseWpOneDbTest):
+
+  def _insert_builder(self):
+    value_dict = attr.asdict(self.builder)
+    value_dict['b_current_version'] = 1
+    value_dict['b_id'] = b'1a-2b-3c-4d'
+    with self.wp10db.cursor() as cursor:
+      cursor.execute(
+          '''INSERT INTO builders
+               (b_id, b_name, b_user_id, b_project, b_params, b_model, b_created_at,
+                b_updated_at, b_current_version)
+             VALUES
+               (%(b_id)s, %(b_name)s, %(b_user_id)s, %(b_project)s, %(b_params)s,
+                %(b_model)s, %(b_created_at)s, %(b_updated_at)s, %(b_current_version)s)
+          ''', value_dict)
+    self.wp10db.commit()
+    return value_dict['b_id']
+
+  def _insert_selection(self, id_):
+    version = 1
+    object_key = 'selections/foo/1234/name.tsv'
+    content_type = 'text/tab-separated-values'
+    builder_id = self.builder.b_id
+    with self.wp10db.cursor() as cursor:
+      cursor.execute(
+          '''INSERT INTO selections
+                (s_id, s_builder_id, s_updated_at, s_content_type, s_version, s_object_key)
+              VALUES
+                (%s, %s, '20191225044444', %s, %s, %s)''',
+          (id_, builder_id, content_type, version, object_key))
+    self.wp10db.commit()
+
+  def setUp(self):
+    super().setUp()
+    self.builder = Builder(
+        b_id=b'1a-2b-3c-4d',
+        b_name=b'My Builder',
+        b_user_id=1234,
+        b_project=b'en.wikipedia.fake',
+        b_model=b'wp1.selection.models.simple',
+        b_params=b'{"list": ["a", "b", "c"]}',
+        b_created_at=b'20191225044444',
+        b_updated_at=b'20191225044444',
+        b_current_version=1,
+    )
+
+  def test_get_params(self):
+    self._insert_builder()
+    self._insert_selection(b'abc-12345-def')
+
+    actual = zimfarm._get_params(self.wp10db, self.builder.b_id)
+
+    self.assertEqual(
+        {
+            'name': 'wp1_selection_abc-12345-def',
+            'language': {
+                'code': 'eng',
+                'name_en': 'English',
+                'name_native': 'English'
+            },
+            'category': 'other',
+            'periodicity': 'manually',
+            'tags': [],
+            'enabled': True,
+            'config': {
+                'task_name': 'mwoffliner',
+                'warehouse_path': '/wp1',
+                'image': {
+                    'name': 'ghcr.io/openzim/mwoffliner',
+                    'tag': '1.12.1'
+                },
+                'resources': {
+                    'cpu': 2,
+                    'memory': 1024,
+                    'disk': 2048
+                },
+                'platform': None,
+                'monitor': False,
+                'flags': {
+                    'mwUrl':
+                        'https://en.wikipedia.fake/',
+                    'adminEmail':
+                        'admin@wp1.openzim.org',
+                    'articleList':
+                        'http://credentials.not.found.fake/selections/foo/1234/name.tsv',
+                    'customZimTitle':
+                        'MyBuilder'
+                }
+            }
+        }, actual)


### PR DESCRIPTION
This PR is part of #483. It provides the backend API for:

1. Connecting to a Zimfarm instance as configured in credentials.py, using user name and password and storing `access_token` and `refresh_token` in Redis
2. Requesting a ZIM file creation task from the Zimfarm based on a specific Builder, using it's latest selection that is in TSV format

Currently, this is "fire and forget". The library does not monitor the requested task or provide for any way, in WP1, to find out its status or download the resulting ZIM file.

It is also standalone and not called from anywhere in WP1.

Future work will first integrate this functionality with the web API at api.wp1.openzim.org, so that there is a way to request ZIM files based on WP1 Builders. As part of that, we will create a job tracking system so that we know the status of the ZIM file creation on the Zimfarm, with webhooks and some polling. We will also create a way for the user to download the "latest" ZIM file from the WP1 API. As part of this work, we will likely revisit the error handling for `schedule_zim_farm`, to possibly internally retry transient HTTP errors, as well as wrap fatal errors (400 BAD REQUEST) in a WP1 specific error class so it can be caught appropriately at the API layer.

The final step will be to build UI pages that expose this functionality.