### PR TITLE
Create API endpoint for scheduling ZIM file creation

### DIFF
--- a/db/migrations/20230316_01_eMzhU-create-zimfarm-fields-on-selections.py
+++ b/db/migrations/20230316_01_eMzhU-create-zimfarm-fields-on-selections.py
@@ -1,0 +1,17 @@
+"""
+Create zimfarm fields on selections
+"""
+
+from yoyo import step
+
+__depends__ = {'20221113_03_xzm65-allow-selections-null-object-key'}
+
+steps = [
+    step(
+        'ALTER TABLE selections ADD COLUMN ('
+        '  s_zimfarm_task_id VARBINARY(255),'
+        '  s_zimfarm_error_messages BLOB, '
+        '  s_zimfarm_status VARBINARY(255) DEFAULT "REQUESTED")',
+        'ALTER TABLE selections DROP s_zimfarm_task_id, DROP s_zimfarm_error_messages, DROP s_zimfarm_status'
+    )
+]

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -5,6 +5,8 @@ services:
     container_name: wp1bot-redis-dev
     ports:
       - '9736:6379'
+    networks:
+      - wp1bot-dev
     restart: always
 
   dev-database:
@@ -12,6 +14,8 @@ services:
     container_name: wp1bot-db-dev
     ports:
       - '6300:3306'
+    networks:
+      - wp1bot-dev
     restart: always
 
   dev-workers:
@@ -23,14 +27,12 @@ services:
       - ./wp1:/usr/src/app/wp1/
       - ./wp1/credentials.py.dev:/usr/src/app/wp1/credentials.py
       - ./log/:/var/log/wp1bot/
-    links:
-      - redis
-      - dev-database
+    networks:
+      - wp1bot-dev
     restart: always
     depends_on:
       - redis
       - dev-database
 
 networks:
-  default:
-    name: dev.openzim.org
+  wp1bot-dev:

--- a/docker/dev-workers/Dockerfile
+++ b/docker/dev-workers/Dockerfile
@@ -5,8 +5,10 @@ LABEL maintainer="kiwix"
 
 # Python app
 WORKDIR /usr/src
-COPY . app
+RUN mkdir app
+COPY requirements.txt app/requirements.txt
 RUN pip3 install --no-cache-dir -r app/requirements.txt
+COPY . app
 
 # Start
 CMD supervisord -c /usr/src/app/supervisord-dev.conf -n

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ chardet==3.0.4
 Click==7.0
 coverage==5.5
 croniter==0.3.30
+crontab==1.0.0
 Deprecated==1.2.13
 distlib==0.3.6
 fakeredis==2.4.0
@@ -22,6 +23,7 @@ Flask==1.1.1
 Flask-Cors==3.0.9
 Flask-gzip==0.2
 Flask-Session==0.3.2
+freezegun==1.2.2
 ghp-import==2.1.0
 gunicorn==19.9.0
 identify==1.4.6
@@ -58,8 +60,9 @@ rdflib==6.2.0
 redis==4.4.0
 requests==2.25.1
 requests-oauthlib==1.0.0
-rq==1.11.0
+rq==1.13.0
 rq-dashboard==0.5.2
+rq-scheduler==0.13.0
 s3transfer==0.4.2
 six==1.16.0
 sortedcontainers==2.4.0

--- a/supervisord-dev.conf
+++ b/supervisord-dev.conf
@@ -26,7 +26,53 @@ command=/usr/local/bin/rq worker -u redis://redis --queue-class rate_limit_queue
 ; process_num is required if you specify >1 numprocs
 process_name=materializer-%(process_num)s
 
-; If you want to run more than one materializer instance, increase this.
+; If you want to run more than one materializer worker, increase this.
+numprocs=1
+
+; This is the directory from which RQ is run. Be sure to point this to the
+; directory where your source code is importable from
+directory=/usr/src/app
+
+redirect_stderr=true
+stdout_logfile=/var/log/wp1bot/%(program_name)s-%(process_num)s.log
+stdout_logfile_maxbytes=100MB
+stdout_logfile_backups=5
+
+; RQ requires the TERM signal to perform a warm shutdown. If RQ does not die
+; within 10 seconds, supervisor will forcefully kill it
+stopsignal=TERM
+autostart=true
+autorestart=true
+
+[program:wp1-zimfile-polling]
+; In the docker-compose world, the redis host is just 'redis'
+command=/usr/local/bin/rq worker -u redis://redis zimfile-polling
+; process_num is required if you specify >1 numprocs
+process_name=zimfile-polling-%(process_num)s
+
+; If you want to run more than one zimfile-polling worker, increase this
+numprocs=1
+
+; This is the directory from which RQ is run. Be sure to point this to the
+; directory where your source code is importable from
+directory=/usr/src/app
+
+redirect_stderr=true
+stdout_logfile=/var/log/wp1bot/%(program_name)s-%(process_num)s.log
+stdout_logfile_maxbytes=100MB
+stdout_logfile_backups=5
+
+; RQ requires the TERM signal to perform a warm shutdown. If RQ does not die
+; within 10 seconds, supervisor will forcefully kill it
+stopsignal=TERM
+autostart=true
+autorestart=true
+
+[program:scheduler]
+; In the docker-compose world, the redis host is just 'redis'
+command=/usr/local/bin/rqscheduler --host redis -i 20
+; process_num is required if you specify >1 numprocs
+process_name=scheduler-%(process_num)s
 numprocs=1
 
 ; This is the directory from which RQ is run. Be sure to point this to the

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -180,7 +180,53 @@ command=/usr/local/bin/rq worker -u redis://redis --queue-class rate_limit_queue
 ; process_num is required if you specify >1 numprocs
 process_name=materializer-%(process_num)s
 
-; If you want to run more than one materializer instance, increase this
+; If you want to run more than one materializer worker, increase this
+numprocs=1
+
+; This is the directory from which RQ is run. Be sure to point this to the
+; directory where your source code is importable from
+directory=/usr/src/app
+
+redirect_stderr=true
+stdout_logfile=/var/log/wp1bot/%(program_name)s-%(process_num)s.log
+stdout_logfile_maxbytes=100MB
+stdout_logfile_backups=5
+
+; RQ requires the TERM signal to perform a warm shutdown. If RQ does not die
+; within 10 seconds, supervisor will forcefully kill it
+stopsignal=TERM
+autostart=true
+autorestart=true
+
+[program:wp1-zimfile-polling]
+; In the docker-compose world, the redis host is just 'redis'
+command=/usr/local/bin/rq worker -u redis://redis zimfile-polling
+; process_num is required if you specify >1 numprocs
+process_name=zimfile-polling-%(process_num)s
+
+; If you want to run more than one zimfile-polling worker, increase this
+numprocs=1
+
+; This is the directory from which RQ is run. Be sure to point this to the
+; directory where your source code is importable from
+directory=/usr/src/app
+
+redirect_stderr=true
+stdout_logfile=/var/log/wp1bot/%(program_name)s-%(process_num)s.log
+stdout_logfile_maxbytes=100MB
+stdout_logfile_backups=5
+
+; RQ requires the TERM signal to perform a warm shutdown. If RQ does not die
+; within 10 seconds, supervisor will forcefully kill it
+stopsignal=TERM
+autostart=true
+autorestart=true
+
+[program:scheduler]
+; In the docker-compose world, the redis host is just 'redis'
+command=/usr/local/bin/rqscheduler --host redis -i 20
+; process_num is required if you specify >1 numprocs
+process_name=scheduler-%(process_num)s
 numprocs=1
 
 ; This is the directory from which RQ is run. Be sure to point this to the

--- a/wp1/credentials.py.dev.example
+++ b/wp1/credentials.py.dev.example
@@ -79,6 +79,15 @@ CREDENTIALS = {
             'secret': '', # EDIT this line
             'bucket': 'org-kiwix-dev-wp1',
         },
+
+        # Server URL and credentials for the Zim Farm that will be used to create
+        # ZIM files from materialized selections.
+        'ZIMFARM': {
+            'url': 'https://api.farm.youzim.it/v1',
+            'user': 'wp1',
+            'password': '', # EDIT this line
+            'hook_token': '' # EDIT this line,
+        },
     },
 
     # EDIT: Remove the next line after you've provided actual credentials.

--- a/wp1/credentials.py.e2e
+++ b/wp1/credentials.py.e2e
@@ -65,6 +65,7 @@ CREDENTIALS = {
             'url': 'https://fake.farm/v1',
             'user': 'farmuser',
             'password': 'farmpass',
+            'hook_token': 'hook-token-abc',
         }
     },
     Environment.PRODUCTION: {},

--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -112,7 +112,7 @@ CREDENTIALS = {
         },
 
         # Server URL and credentials for the Zim Farm that will be used to create
-        # ZIM files from materializes selections.
+        # ZIM files from materialized selections.
         'ZIMFARM': {
             'url': 'https://api.farm.youzim.it/v1',
             'user': '', # EDIT this line

--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -117,6 +117,9 @@ CREDENTIALS = {
             'url': 'https://api.farm.youzim.it/v1',
             'user': '', # EDIT this line
             'password': '', # EDIT this line
+            # A simple token secret exchanged between the WP1 server and the zimfarm
+            # server, to ensure requests to the webhook endpoint are valid.
+            'hook_token': '', # EDIT this line
         },
     },
 
@@ -166,6 +169,7 @@ CREDENTIALS = {
             'url': 'https://fake.farm/v1',
             'user': 'farmuser',
             'password': 'farmpass',
+            'hook_token': 'hook-token-abc',
         }
     },
 
@@ -242,5 +246,8 @@ CREDENTIALS = {
     #      'url': 'https://api.farm.youzim.it/v1',
     #      'user': '', # EDIT this line
     #      'password': '', # EDIT this line
+    #       # A simple token secret exchanged between the WP1 server and the zimfarm
+    #       # server, to ensure requests to the webhook endpoint are valid.
+    #       'hook_token': '', # EDIT this line
     #   },
 }

--- a/wp1/custom_tables/us_roads_test.py
+++ b/wp1/custom_tables/us_roads_test.py
@@ -88,5 +88,4 @@ class UsRoadsCustomTableTest(BaseWpOneDbTest):
     table_data = custom.generate(self.wp10db)
     actual = custom.create_wikicode(table_data)
 
-    self.maxDiff = None
     self.assertEqual(self.expected_wikicode, actual)

--- a/wp1/exceptions.py
+++ b/wp1/exceptions.py
@@ -1,4 +1,8 @@
-class Wp1SelectionError(Exception):
+class Wp1Error(Exception):
+  pass
+
+
+class Wp1SelectionError(Wp1Error):
   pass
 
 
@@ -10,5 +14,13 @@ class Wp1FatalSelectionError(Wp1SelectionError):
   pass
 
 
-class ZimFarmError(Exception):
+class ZimFarmError(Wp1Error):
+  pass
+
+
+class ObjectNotFoundError(Wp1Error):
+  pass
+
+
+class UserNotAuthorizedError(Wp1Error):
   pass

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -5,12 +5,14 @@ import attr
 
 from wp1.constants import CONTENT_TYPE_TO_EXT, EXT_TO_CONTENT_TYPE
 from wp1.credentials import CREDENTIALS, ENV
+from wp1.exceptions import ObjectNotFoundError, UserNotAuthorizedError
 import wp1.logic.selection as logic_selection
 import wp1.logic.util as logic_util
 from wp1.models.wp10.builder import Builder
 from wp1.models.wp10.selection import Selection
 from wp1.storage import connect_storage
 from wp1.wp10_db import connect as wp10_connect
+from wp1 import zimfarm
 
 logger = logging.getLogger(__name__)
 
@@ -221,6 +223,33 @@ def latest_selections_with_errors(wp10db, builder_id):
     res.append(status)
 
   return res
+
+
+def schedule_zim_file(redis, wp10db, user_id, builder_id):
+  if isinstance(builder_id, str):
+    builder_id = builder_id.encode('utf-8')
+  builder = get_builder(wp10db, builder_id)
+  if builder is None:
+    raise ObjectNotFoundError('Could not find builder with id = %s' %
+                              builder_id)
+
+  if builder.b_user_id != user_id:
+    raise UserNotAuthorizedError(
+        'Could not use builder id = %s for user id = %s' %
+        (builder_id, user_id))
+
+  task_id = zimfarm.schedule_zim_file(redis, wp10db, builder)
+  selection = latest_selection_for(wp10db, builder_id,
+                                   'text/tab-separated-values')
+
+  with wp10db.cursor() as cursor:
+    cursor.execute(
+        '''UPDATE selections SET
+             s_zimfarm_status = 'REQUESTED', s_zimfarm_task_id = %s,
+             s_zimfarm_error_messages = NULL
+           WHERE s_id = %s
+        ''', (task_id, selection.s_id))
+  wp10db.commit()
 
 
 def get_builders_with_selections(wp10db, user_id):

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -10,6 +10,8 @@ import wp1.logic.selection as logic_selection
 import wp1.logic.util as logic_util
 from wp1.models.wp10.builder import Builder
 from wp1.models.wp10.selection import Selection
+from wp1 import queues
+from wp1.redis_db import connect as redis_connect
 from wp1.storage import connect_storage
 from wp1.wp10_db import connect as wp10_connect
 from wp1 import zimfarm
@@ -250,6 +252,24 @@ def schedule_zim_file(redis, wp10db, user_id, builder_id):
            WHERE s_id = %s
         ''', (task_id, selection.s_id))
   wp10db.commit()
+
+
+def on_zim_file_status_poll(task_id):
+  wp10db = wp10_connect()
+  redis = redis_connect()
+
+  ready = zimfarm.is_zim_file_ready(redis, task_id)
+  if ready:
+    with wp10db.cursor() as cursor:
+      cursor.execute(
+          'UPDATE selections '
+          'SET s_zimfarm_status = "FILE_READY" '
+          'WHERE s_zimfarm_task_id = %s', (task_id,))
+    wp10db.commit()
+  else:
+    queues.poll_for_zim_file_status(redis, task_id)
+
+  wp10db.close()
 
 
 def get_builders_with_selections(wp10db, user_id):

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -258,8 +258,7 @@ def on_zim_file_status_poll(task_id):
   wp10db = wp10_connect()
   redis = redis_connect()
 
-  ready = zimfarm.is_zim_file_ready(redis, task_id)
-  if ready:
+  if zimfarm.is_zim_file_ready(redis, task_id):
     with wp10db.cursor() as cursor:
       cursor.execute(
           'UPDATE selections '

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -671,7 +671,8 @@ class BuilderTest(BaseWpOneDbTest):
 
   @patch('wp1.logic.builder.zimfarm.is_zim_file_ready')
   @patch('wp1.logic.builder.wp10_connect')
-  def test_on_zim_file_status_poll_true(self, patched_connect,
+  @patch('wp1.logic.builder.redis_connect')
+  def test_on_zim_file_status_poll_true(self, patched_redis, patched_connect,
                                         patched_is_ready):
     patched_is_ready.return_value = True
     builder_id = self._insert_builder()
@@ -698,7 +699,8 @@ class BuilderTest(BaseWpOneDbTest):
   @patch('wp1.logic.builder.zimfarm.is_zim_file_ready')
   @patch('wp1.logic.builder.queues.poll_for_zim_file_status')
   @patch('wp1.logic.builder.wp10_connect')
-  def test_on_zim_file_status_poll_false(self, patched_connect,
+  @patch('wp1.logic.builder.redis_connect')
+  def test_on_zim_file_status_poll_false(self, patched_redis, patched_connect,
                                          patched_poll_for_status,
                                          patched_is_ready):
     patched_is_ready.return_value = False

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -4,6 +4,7 @@ from unittest.mock import patch, MagicMock, ANY
 import attr
 
 from wp1.base_db_test import BaseWpOneDbTest
+from wp1.exceptions import ObjectNotFoundError, UserNotAuthorizedError
 from wp1.logic import builder as logic_builder
 from wp1.models.wp10.builder import Builder
 
@@ -168,9 +169,13 @@ class BuilderTest(BaseWpOneDbTest):
 
     with self.wp10db.cursor() as cursor:
       cursor.execute(
-          'INSERT INTO selections VALUES (%s, %s, %s, "20191225044444", %s, %s, %s, %s)',
-          (id_, builder_id, content_type, version, object_key, status,
-           error_messages))
+          '''INSERT INTO selections
+               (s_id, s_builder_id, s_content_type, s_updated_at, s_version,
+                s_object_key, s_status, s_error_messages)
+             VALUES
+               (%s, %s, %s, "20191225044444", %s, %s, %s, %s)
+          ''', (id_, builder_id, content_type, version, object_key, status,
+                error_messages))
     self.wp10db.commit()
 
   def _get_builder_by_user_id(self):
@@ -616,3 +621,50 @@ class BuilderTest(BaseWpOneDbTest):
         self.wp10db, builder_id)
 
     self.assertEqual(0, len(actual))
+
+  @patch('wp1.logic.builder.zimfarm.schedule_zim_file')
+  def test_schedule_zim_file(self, patched_schedule_zim_file):
+    redis = MagicMock()
+    patched_schedule_zim_file.return_value = '1234-a'
+
+    builder_id = self._insert_builder()
+    self._insert_selection(1,
+                           'text/tab-separated-values',
+                           builder_id=builder_id,
+                           has_errors=False)
+
+    logic_builder.schedule_zim_file(redis, self.wp10db, 1234, builder_id)
+
+    patched_schedule_zim_file.assert_called_once_with(redis, self.wp10db,
+                                                      self.builder)
+    with self.wp10db.cursor() as cursor:
+      cursor.execute('SELECT s_zimfarm_task_id, s_zimfarm_status, '
+                     ' s_zimfarm_error_messages FROM selections '
+                     ' WHERE s_id = 1')
+      data = cursor.fetchone()
+
+    self.assertEqual(b'1234-a', data['s_zimfarm_task_id'])
+    self.assertEqual(b'REQUESTED', data['s_zimfarm_status'])
+    self.assertIsNone(data['s_zimfarm_error_messages'])
+
+  @patch('wp1.logic.builder.zimfarm.schedule_zim_file')
+  def test_schedule_zim_file(self, patched_schedule_zim_file):
+    redis = MagicMock()
+    patched_schedule_zim_file.return_value = '1234-a'
+
+    with self.assertRaises(ObjectNotFoundError):
+      logic_builder.schedule_zim_file(redis, self.wp10db, 1234, '404builder')
+
+  @patch('wp1.logic.builder.zimfarm.schedule_zim_file')
+  def test_schedule_zim_file(self, patched_schedule_zim_file):
+    redis = MagicMock()
+    patched_schedule_zim_file.return_value = '1234-a'
+
+    builder_id = self._insert_builder()
+    self._insert_selection(1,
+                           'text/tab-separated-values',
+                           builder_id=builder_id,
+                           has_errors=False)
+
+    with self.assertRaises(UserNotAuthorizedError):
+      logic_builder.schedule_zim_file(redis, self.wp10db, 5678, builder_id)

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -171,9 +171,9 @@ class BuilderTest(BaseWpOneDbTest):
       cursor.execute(
           '''INSERT INTO selections
                (s_id, s_builder_id, s_content_type, s_updated_at, s_version,
-                s_object_key, s_status, s_error_messages)
+                s_object_key, s_status, s_error_messages, s_zimfarm_task_id)
              VALUES
-               (%s, %s, %s, "20191225044444", %s, %s, %s, %s)
+               (%s, %s, %s, "20191225044444", %s, %s, %s, %s, "5678")
           ''', (id_, builder_id, content_type, version, object_key, status,
                 error_messages))
     self.wp10db.commit()
@@ -668,3 +668,52 @@ class BuilderTest(BaseWpOneDbTest):
 
     with self.assertRaises(UserNotAuthorizedError):
       logic_builder.schedule_zim_file(redis, self.wp10db, 5678, builder_id)
+
+  @patch('wp1.logic.builder.zimfarm.is_zim_file_ready')
+  @patch('wp1.logic.builder.wp10_connect')
+  def test_on_zim_file_status_poll_true(self, patched_connect,
+                                        patched_is_ready):
+    patched_is_ready.return_value = True
+    builder_id = self._insert_builder()
+    self._insert_selection(1,
+                           'text/tab-separated-values',
+                           builder_id=builder_id,
+                           has_errors=False)
+
+    orig_close = self.wp10db.close
+    try:
+      self.wp10db.close = lambda: True
+      patched_connect.return_value = self.wp10db
+      logic_builder.on_zim_file_status_poll('5678')
+    finally:
+      self.wp10db.close = orig_close
+
+    with self.wp10db.cursor() as cursor:
+      cursor.execute('SELECT s_zimfarm_status FROM selections WHERE s_id = 1')
+      data = cursor.fetchone()
+
+    self.assertIsNotNone(data)
+    self.assertEqual(b'FILE_READY', data['s_zimfarm_status'])
+
+  @patch('wp1.logic.builder.zimfarm.is_zim_file_ready')
+  @patch('wp1.logic.builder.queues.poll_for_zim_file_status')
+  @patch('wp1.logic.builder.wp10_connect')
+  def test_on_zim_file_status_poll_false(self, patched_connect,
+                                         patched_poll_for_status,
+                                         patched_is_ready):
+    patched_is_ready.return_value = False
+    builder_id = self._insert_builder()
+    self._insert_selection(1,
+                           'text/tab-separated-values',
+                           builder_id=builder_id,
+                           has_errors=False)
+
+    orig_close = self.wp10db.close
+    try:
+      self.wp10db.close = lambda: True
+      patched_connect.return_value = self.wp10db
+      logic_builder.on_zim_file_status_poll('5678')
+    finally:
+      self.wp10db.close = orig_close
+
+    patched_poll_for_status.assert_called_once()

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -138,3 +138,11 @@ def set_error_messages(selection, e):
   if e.__cause__:
     messages.append(str(e.__cause__))
   selection.s_error_messages = json.dumps({'error_messages': messages})
+
+
+def update_zimfarm_task(wp10db, task_id, status):
+  with wp10db.cursor() as cursor:
+    cursor.execute(
+        'UPDATE selections SET s_zimfarm_status = %s WHERE s_zimfarm_task_id = %s',
+        (status, task_id))
+  wp10db.commit()

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -145,4 +145,6 @@ def update_zimfarm_task(wp10db, task_id, status):
     cursor.execute(
         'UPDATE selections SET s_zimfarm_status = %s WHERE s_zimfarm_task_id = %s',
         (status, task_id))
+    found = bool(cursor.rowcount)
   wp10db.commit()
+  return found

--- a/wp1/logic/selection_test.py
+++ b/wp1/logic/selection_test.py
@@ -24,7 +24,8 @@ class SelectionTest(BaseWpOneDbTest):
         s_content_type=b'text/tab-separated-values',
         s_version=1,
         s_updated_at=b'20190830112844',
-        s_object_key=b'selections/foo.bar.model/deadbeef/name.tsv')
+        s_object_key=b'selections/foo.bar.model/deadbeef/name.tsv',
+        s_zimfarm_status=b'REQUESTED')
 
   def _insert_selections(self, selections=None):
     if selections is None:
@@ -34,16 +35,17 @@ class SelectionTest(BaseWpOneDbTest):
     with self.wp10db.cursor() as cursor:
       cursor.executemany(
           '''INSERT INTO selections
-      (s_id, s_builder_id, s_version, s_content_type, s_updated_at, s_object_key, s_status, s_error_messages)
-      VALUES (%(s_id)s, %(s_builder_id)s, %(s_version)s, %(s_content_type)s,
-              %(s_updated_at)s, %(s_object_key)s, NULL, NULL)
-    ''', selections)
+              (s_id, s_builder_id, s_version, s_content_type, s_updated_at, s_object_key, s_zimfarm_status)
+             VALUES
+              (%(s_id)s, %(s_builder_id)s, %(s_version)s, %(s_content_type)s,
+               %(s_updated_at)s, %(s_object_key)s, "REQUESTED")
+          ''', selections)
     self.wp10db.commit()
 
   def test_insert_selection(self):
-    self.maxDiff = None
     logic_selection.insert_selection(self.wp10db, self.selection)
     actual = _get_selection(self.wp10db)
+    self.maxDiff = None
     self.assertEqual(self.selection, actual)
 
   def test_get_next_version_empty_table(self):

--- a/wp1/models/wp10/selection.py
+++ b/wp1/models/wp10/selection.py
@@ -26,6 +26,9 @@ class Selection:
   data = attr.ib(default=None)
   s_status = attr.ib(default=None)
   s_error_messages = attr.ib(default=None)
+  s_zimfarm_task_id = attr.ib(default=None)
+  s_zimfarm_status = attr.ib(default=None)
+  s_zimfarm_error_messages = attr.ib(default=None)
 
   @property
   def updated_at_dt(self):

--- a/wp1/queues_test.py
+++ b/wp1/queues_test.py
@@ -180,3 +180,15 @@ class QueuesTest(BaseWpOneDbTest):
         'text/tab-separated-values',
         job_timeout=constants.JOB_TIMEOUT,
         failure_ttl=constants.JOB_FAILURE_TTL)
+
+  @patch('wp1.queues.Queue')
+  @patch('wp1.queues.Scheduler')
+  def test_poll_for_zim_file_status(self, patched_scheduler, patched_queue):
+    poll_q_mock = MagicMock()
+    patched_queue.return_value = poll_q_mock
+    scheduler_mock = MagicMock()
+    patched_scheduler.return_value = scheduler_mock
+
+    queues.poll_for_zim_file_status(self.redis, '1234')
+
+    scheduler_mock.enqueue_in.assert_called_once()

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -169,6 +169,14 @@ def zimfarm_status():
     flask.abort(400)
 
   wp10db = get_db('wp10db')
-  logic_selection.update_zimfarm_task(wp10db, task_id, 'ENDED')
 
+  files = data.get('files', {})
+  for key, value in files.items():
+    if value['status'] == 'uploaded':
+      logic_selection.update_zimfarm_task(wp10db, task_id, 'FILE_READY')
+      return '', 204
+
+  redis = get_redis()
+  queues.poll_for_zimfile_status(redis, task_id)
+  logic_selection.update_zimfarm_task(wp10db, task_id, 'ENDED')
   return '', 204

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -176,7 +176,8 @@ def zimfarm_status():
       logic_selection.update_zimfarm_task(wp10db, task_id, 'FILE_READY')
       return '', 204
 
-  redis = get_redis()
-  queues.poll_for_zimfile_status(redis, task_id)
-  logic_selection.update_zimfarm_task(wp10db, task_id, 'ENDED')
+  found = logic_selection.update_zimfarm_task(wp10db, task_id, 'ENDED')
+  if found:
+    redis = get_redis()
+    queues.poll_for_zim_file_status(redis, task_id)
   return '', 204

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -473,7 +473,8 @@ class BuildersTest(BaseWebTestcase):
       rv = client.post('/v1/builders/%s/zim' % builder_id)
       self.assertEqual('500 INTERNAL SERVER ERROR', rv.status)
 
-  def test_zimfarm_status(self):
+  @patch('wp1.web.builders.queues.poll_for_zim_file_status')
+  def test_zimfarm_status(self, patched_poll):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -487,6 +488,7 @@ class BuildersTest(BaseWebTestcase):
                            'foo': 'bar'
                        })
       self.assertEqual('204 NO CONTENT', rv.status)
+      patched_poll.assert_called_once()
 
     with self.wp10db.cursor() as cursor:
       cursor.execute(
@@ -527,7 +529,8 @@ class BuildersTest(BaseWebTestcase):
                        })
       self.assertEqual('400 BAD REQUEST', rv.status)
 
-  def test_zimfarm_status_not_found_task_id(self):
+  @patch('wp1.web.builders.queues.poll_for_zim_file_status')
+  def test_zimfarm_status_not_found_task_id(self, patched_poll):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -541,3 +544,5 @@ class BuildersTest(BaseWebTestcase):
                            'foo': 'bar'
                        })
       self.assertEqual('204 NO CONTENT', rv.status)
+
+    patched_poll.assert_not_called()

--- a/wp1/web/selection_test.py
+++ b/wp1/web/selection_test.py
@@ -37,7 +37,7 @@ class SelectionTest(BaseWebTestcase):
           's_url':
               'http://test.server.fake/v1/builders/1a-2b-3c-4d/selection/latest.tsv',
           's_status':
-              None,
+              'OK',
       }],
   }
 
@@ -107,13 +107,18 @@ class SelectionTest(BaseWebTestcase):
     self.app = create_app()
     with self.override_db(self.app), self.app.test_client() as client:
       with self.wp10db.cursor() as cursor:
-        cursor.execute('''INSERT INTO builders
-        (b_id, b_name, b_user_id, b_project, b_model, b_created_at, b_updated_at, b_current_version)
-        VALUES ('1a-2b-3c-4d', 'name', '1234', 'project_name', 'model', '20201225105544', '20201225105544', 1)
-      ''')
-        cursor.execute(
-            'INSERT INTO selections VALUES (1, \'1a-2b-3c-4d\', "text/tab-separated-values", "20201225105544", 1, "object_key", NULL, NULL)'
-        )
+        cursor.execute('''
+          INSERT INTO builders
+            (b_id, b_name, b_user_id, b_project, b_model, b_created_at, b_updated_at, b_current_version)
+          VALUES
+            ('1a-2b-3c-4d', 'name', '1234', 'project_name', 'model', '20201225105544', '20201225105544', 1)
+        ''')
+        cursor.execute('''
+            INSERT INTO selections
+              (s_id, s_builder_id, s_content_type, s_updated_at, s_version, s_object_key)
+            VALUES
+              (1, \'1a-2b-3c-4d\', "text/tab-separated-values", "20201225105544", 1, "object_key")
+        ''')
       self.wp10db.commit()
       with client.session_transaction() as sess:
         sess['user'] = self.USER
@@ -128,12 +133,22 @@ class SelectionTest(BaseWebTestcase):
         (b_id, b_name, b_user_id, b_project, b_model, b_created_at, b_updated_at, b_current_version)
         VALUES ('1a-2b-3c-4d', 'name', '1234', 'project_name', 'model', '20201225105544', '20201225105544', 1)
       ''')
-        cursor.execute(
-            'INSERT INTO selections VALUES (1, \'1a-2b-3c-4d\', "text/tab-separated-values", "20201225105544", 1, "object_key_1", "CAN_RETRY", \'{"errors"["error1"]}\')'
-        )
-        cursor.execute(
-            'INSERT INTO selections VALUES (2, \'1a-2b-3c-4d\', "application/vnd.ms-excel", "20201225105544", 1, "object_key_2", NULL, NULL)'
-        )
+        cursor.execute('''
+            INSERT INTO selections
+              (s_id, s_builder_id, s_content_type, s_updated_at, s_version, s_object_key,
+               s_status, s_error_messages)
+            VALUES
+              (1, \'1a-2b-3c-4d\', "text/tab-separated-values", "20201225105544", 1,
+               "object_key_1", "CAN_RETRY", \'{"errors"["error1"]}\')
+        ''')
+        cursor.execute('''
+            INSERT INTO selections
+              (s_id, s_builder_id, s_content_type, s_updated_at, s_version, s_object_key,
+               s_status, s_error_messages, s_zimfarm_status)
+            VALUES
+              (2, \'1a-2b-3c-4d\', "application/vnd.ms-excel", "20201225105544", 1,
+               "object_key_2", NULL, NULL, NULL)
+        ''')
       self.wp10db.commit()
       with client.session_transaction() as sess:
         sess['user'] = self.USER
@@ -162,9 +177,12 @@ class SelectionTest(BaseWebTestcase):
     self.app = create_app()
     with self.override_db(self.app), self.app.test_client() as client:
       with self.wp10db.cursor() as cursor:
-        cursor.execute(
-            '''INSERT INTO selections VALUES (2, \'1a-2b-3c-4d\', "application/vnd.ms-excel", '20201225105544', 1, "object_key", NULL, NULL)'''
-        )
+        cursor.execute('''
+          INSERT INTO selections
+            (s_id, s_builder_id, s_content_type, s_updated_at, s_version, s_object_key)
+          VALUES
+            (2, \'1a-2b-3c-4d\', "application/vnd.ms-excel", '20201225105544', 1, "object_key")
+        ''')
       self.wp10db.commit()
       with client.session_transaction() as sess:
         sess['user'] = self.USER

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -7,7 +7,7 @@ import requests
 
 from wp1.constants import WP1_USER_AGENT
 from wp1.credentials import CREDENTIALS, ENV
-from wp1.exceptions import ZimFarmError
+from wp1.exceptions import ZimFarmError, ObjectNotFoundError
 from wp1.logic import util
 import wp1.logic.builder as logic_builder
 import wp1.logic.selection as logic_selection
@@ -33,8 +33,8 @@ def request_zimfarm_token(redis):
   password = CREDENTIALS[ENV].get('ZIMFARM', {}).get('password')
 
   if user is None or password is None:
-    raise ZimFarmError(
-        'Could not log into zimfarm, user/password not found in credentials.py')
+    raise ZimFarmError('Could not log into zimfarm, user/password not found in '
+                       'site credentials')
 
   logger.debug('Requesting auth token from %s with username/password',
                get_zimfarm_url())
@@ -44,7 +44,11 @@ def request_zimfarm_token(redis):
                         'username': user,
                         'password': password
                     })
-  r.raise_for_status()
+  try:
+    r.raise_for_status()
+  except requests.exceptions.HTTPError as e:
+    logger.exception(r.text)
+    raise ZimFarmError('Error getting authentication token for Zimfarm') from e
 
   data = r.json()
   store_zimfarm_token(redis, data)
@@ -66,7 +70,11 @@ def refresh_zimfarm_token(redis, refresh_token):
           'refresh-token': refresh_token
       },
   )
-  r.raise_for_status()
+  try:
+    r.raise_for_status()
+  except requests.exceptions.HTTPError as e:
+    logger.exception(r.text)
+    raise ZimFarmError('Error getting authentication token for Zimfarm') from e
 
   data = r.json()
   access_token = data.get('access_token')
@@ -103,16 +111,12 @@ def get_zimfarm_url():
   return url
 
 
-def _get_params(wp10db, builder_id):
-  if isinstance(builder_id, str):
-    builder_id = builder_id.encode('utf-8')
-
-  builder = logic_builder.get_builder(wp10db, builder_id)
+def _get_params(wp10db, builder):
   if builder is None:
-    raise ZimFarmError('Could not find builder with id: %s', builder_id)
+    raise ObjectNotFoundError('Given builder was None: %r' % builder)
 
   project = builder.b_project.decode('utf-8')
-  selection = logic_builder.latest_selection_for(wp10db, builder_id,
+  selection = logic_builder.latest_selection_for(wp10db, builder.b_id,
                                                  'text/tab-separated-values')
 
   config = {
@@ -161,12 +165,12 @@ def _get_zimfarm_headers(token):
   return {"Authorization": "Token %s" % token, 'User-Agent': WP1_USER_AGENT}
 
 
-def schedule_zim_file(redis, wp10db, builder_id):
+def schedule_zim_file(redis, wp10db, builder):
   token = get_zimfarm_token(redis)
   if token is None:
-    raise ZimfarmError('Could not retrieve auth token for request')
+    raise ZimfarmError('Error retrieving auth token for request')
 
-  params = _get_params(wp10db, builder_id)
+  params = _get_params(wp10db, builder)
   base_url = get_zimfarm_url()
   headers = _get_zimfarm_headers(token)
 
@@ -174,9 +178,9 @@ def schedule_zim_file(redis, wp10db, builder_id):
 
   try:
     r.raise_for_status()
-  except Exception:
+  except requests.exceptions.HTTPError as e:
     logger.exception(r.text)
-    raise
+    raise ZimFarmError('Error creating schedule for ZIM file creation') from e
 
   r = requests.post('%s/requested-tasks/' % base_url,
                     headers=headers,
@@ -191,9 +195,9 @@ def schedule_zim_file(redis, wp10db, builder_id):
 
     if task_id is None:
       raise ZimFarmError('Did not get scheduled task id')
-  except Exception:
+  except requests.exceptions.HTTPError as e:
     logger.exception(r.text)
-    raise
+    raise ZimFarmError('Error requesting task for ZIM file creation') from e
   finally:
     requests.delete('%s/schedules/%s' % (base_url, params['name']),
                     headers=headers)

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -223,3 +223,23 @@ def schedule_zim_file(redis, wp10db, builder):
                     headers=headers)
 
   return task_id
+
+
+def is_zim_file_ready(redis, task_id):
+  token = get_zimfarm_token(redis)
+  if token is None:
+    raise ZimfarmError('Error retrieving auth token for request')
+
+  base_url = get_zimfarm_url()
+  headers = _get_zimfarm_headers(token)
+
+  r = requests.get('%s/tasks/%s' % (base_url, task_id))
+  r.raise_for_status()
+
+  data = r.json()
+  files = data.get('files', {})
+
+  for key, value in files.items():
+    if value.get('status') == 'uploaded':
+      return True
+  return False

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -72,6 +72,7 @@ class ZimFarmTest(BaseWpOneDbTest):
 
     actual = zimfarm._get_params(self.wp10db, self.builder)
 
+    self.maxDiff = None
     self.assertEqual(
         {
             'name': 'wp1_selection_def',
@@ -84,6 +85,13 @@ class ZimFarmTest(BaseWpOneDbTest):
             'periodicity': 'manually',
             'tags': [],
             'enabled': True,
+            'notification': {
+                'ended': {
+                    'webhook': [
+                        'http://test.server.fake/v1/builders/zim/status?token=hook-token-abc'
+                    ],
+                },
+            },
             'config': {
                 'task_name': 'mwoffliner',
                 'warehouse_path': '/wikipedia',

--- a/wp10_test.up.sql
+++ b/wp10_test.up.sql
@@ -112,7 +112,10 @@ CREATE TABLE `selections` (
   s_version int(11) NOT NULL,
   s_object_key VARBINARY(255),
   s_status VARBINARY(255) DEFAULT 'OK',
-  s_error_messages BLOB
+  s_error_messages BLOB,
+  s_zimfarm_task_id VARBINARY(255),
+  s_zimfarm_error_messages BLOB,
+  s_zimfarm_status VARBINARY(255) DEFAULT "REQUESTED"
 );
 
 CREATE TABLE custom (


### PR DESCRIPTION
This PR adds an API endpoint for scheduling ZIM file creation. The endpoint currently takes no arguments, though once there is a UI it will take a description and long_description. The API immediately calls `zimfarm.schedule_zim_file`, and if that method raises any exceptions, the appropriate status code is sent back to the client. Specifically, if a generic `ZimFarmError` occurs, which indicates that there was some kind of problem (400 or 500) communicating with the Zimfarm, a detailed error message is returned alongside the user-friendly one, to better help with debugging.

This PR also adds a webhook so that the Zimfarm can notify the WP1 instance when the task is 'ended'. The webhook is trivially secured with a token in `credentials.py` that the Zimfarm server sends back to the WP1 instance (and that is never revealed to the user).

Finally, this PR adds in a polling mechanism for the ZIM file to actually be 'uploaded'/ready. When the ended webhook is received, if the file status is not 'uploaded', a task is scheduled in 2 minutes to poll the Zimfarm. If the polling reveals that the file still isn't ready, the task is rescheduled another 2 minutes in the future. We use [RQ Scheduler](https://github.com/rq/rq-scheduler) for this.