### PR TITLE
Use borg-backup image from ghcr.io

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,7 @@ services:
     restart: always
 
   backup:
-    image: kiwix/borg-backup:latest
+    image: ghcr.io/kiwix/borg-backup:latest
     env_file:
       - /data/wp1bot/db/.wp1db_backup.env
     restart: always


### PR DESCRIPTION
docker.io hosted image has been removed already and any new pull would fail. This image is now available on ghcr.io