### PR TITLE
UI for requesting ZIM file for WP1 Selection

### DIFF
--- a/db/migrations/20230326_01_hOgak-add-zim-file-updated-at-to-selections.py
+++ b/db/migrations/20230326_01_hOgak-add-zim-file-updated-at-to-selections.py
@@ -1,0 +1,12 @@
+"""
+Add zim_file_updated_at to selections
+"""
+
+from yoyo import step
+
+__depends__ = {'20230316_01_eMzhU-create-zimfarm-fields-on-selections'}
+
+steps = [
+    step('ALTER TABLE selections ADD COLUMN s_zim_file_updated_at BINARY(14)',
+         'ALTER TABLE selections DROP s_zim_file_updated_at')
+]

--- a/db/migrations/20230326_02_bTYKT-remove-default-for-s-zimfarm-status.py
+++ b/db/migrations/20230326_02_bTYKT-remove-default-for-s-zimfarm-status.py
@@ -1,0 +1,14 @@
+"""
+Remove DEFAULT for s_zimfarm_status
+"""
+
+from yoyo import step
+
+__depends__ = {'20230326_01_hOgak-add-zim-file-updated-at-to-selections'}
+
+steps = [
+    step(
+        'ALTER TABLE selections CHANGE COLUMN s_zimfarm_status s_zimfarm_status VARBINARY(255) DEFAULT "NOT_REQUESTED"',
+        'ALTER TABLE selections CHANGE COLUMN s_zimfarm_status s_zimfarm_status VARBINARY(255) DEFAULT "REQUESTED"',
+    )
+]

--- a/wp1-frontend/cypress/e2e/myLists.cy.js
+++ b/wp1-frontend/cypress/e2e/myLists.cy.js
@@ -11,7 +11,7 @@ describe('the user selection list page', () => {
     it('successfully loads', () => {});
 
     it('displays the datatables view', () => {
-      cy.get('.dataTables_info').contains('Showing 1 to 6 of 6 entries');
+      cy.get('.dataTables_info').contains('Showing 1 to 9 of 9 entries');
     });
 
     it('displays list and its contents', () => {
@@ -77,6 +77,78 @@ describe('the user selection list page', () => {
         .contains('.btn-primary', 'Edit')
         .click();
       cy.url().should('eq', 'http://localhost:5173/#/selections/sparql/2');
+    });
+
+    describe('when the selection has not been materialized', () => {
+      it('does not display the Create Zim button', () => {
+        cy.contains('td', 'in retry')
+          .parent('tr')
+          .within(() => {
+            cy.get('td').eq(7).should('contain', '-');
+          });
+      });
+
+      it('does not display the ZIM updated date', () => {
+        cy.contains('td', 'in retry')
+          .parent('tr')
+          .within(() => {
+            cy.get('td').eq(6).should('contain', '-');
+          });
+      });
+    });
+
+    describe('when the selection is materialized', () => {
+      it('displays the Create Zim button', () => {
+        cy.contains('td', 'selection ready, no zim')
+          .parent('tr')
+          .within(() => {
+            cy.get('td').eq(7).should('contain', 'Create ZIM');
+          });
+      });
+
+      it('does not display the ZIM updated date', () => {
+        cy.contains('td', 'selection ready, no zim')
+          .parent('tr')
+          .within(() => {
+            cy.get('td').eq(6).should('contain', '-');
+          });
+      });
+    });
+
+    describe('when the ZIM file has been requested but is not yet ready', () => {
+      it('displays a spinner', () => {
+        cy.contains('td', 'zim requested')
+          .parent('tr')
+          .within(() => {
+            cy.get('td').eq(7).get('div').should('have.class', 'loader');
+          });
+      });
+
+      it('does not display the ZIM updated date', () => {
+        cy.contains('td', 'zim requested')
+          .parent('tr')
+          .within(() => {
+            cy.get('td').eq(6).should('contain', '-');
+          });
+      });
+    });
+
+    describe('when the ZIM file is ready', () => {
+      it('displays the download ZIM link', () => {
+        cy.contains('td', 'zim ready')
+          .parent('tr')
+          .within(() => {
+            cy.get('td').eq(7).get('a').should('contain', 'Download ZIM');
+          });
+      });
+
+      it('displays the ZIM updated date', () => {
+        cy.contains('td', 'zim ready')
+          .parent('tr')
+          .within(() => {
+            cy.get('td').eq(6).should('contain', '12/17/22');
+          });
+      });
     });
   });
 

--- a/wp1-frontend/cypress/e2e/myLists.cy.js
+++ b/wp1-frontend/cypress/e2e/myLists.cy.js
@@ -17,7 +17,7 @@ describe('the user selection list page', () => {
     it('displays list and its contents', () => {
       const listTd = cy.contains('td', 'simple list');
       listTd.siblings().contains('td', 'en.wikipedia.org');
-      listTd.siblings().contains('td', '9/5/2021');
+      listTd.siblings().contains('td', '9/5/21');
       listTd.siblings().contains('.btn-primary', 'Edit');
     });
 

--- a/wp1-frontend/cypress/e2e/zimFile.cy.js
+++ b/wp1-frontend/cypress/e2e/zimFile.cy.js
@@ -31,7 +31,7 @@ describe('the zim file creation page', () => {
           cy.get('#longdesc').should('be.visible');
         });
 
-        it('Displays the Request ZIM file button', () => {
+        it('displays the Request ZIM file button', () => {
           cy.get('#request').should('be.visible');
           cy.get('#request').should('not.have.attr', 'disabled');
         });
@@ -98,7 +98,7 @@ describe('the zim file creation page', () => {
         });
 
         it('does not show the spinner', () => {
-          cy.get('#loader').should('not.exist');
+          cy.get('#loader').should('not.be.visible');
         });
       });
     });

--- a/wp1-frontend/cypress/e2e/zimFile.cy.js
+++ b/wp1-frontend/cypress/e2e/zimFile.cy.js
@@ -1,0 +1,120 @@
+/// <reference types="Cypress" />
+
+describe('the zim file creation page', () => {
+  describe('when the user is logged in', () => {
+    beforeEach(() => {
+      cy.intercept('v1/oauth/identify', { fixture: 'identity.json' }).as(
+        'identity'
+      );
+    });
+
+    describe('and the builder is found', () => {
+      beforeEach(() => {
+        cy.intercept('GET', 'v1/builders/1', {
+          fixture: 'simple_builder.json',
+        }).as('builder');
+      });
+
+      describe('when the zim file has not been requested yet', () => {
+        beforeEach(() => {
+          cy.intercept('v1/builders/1/zim/status', {
+            fixture: 'zim_status_not_requested.json',
+          }).as('status');
+          cy.visit('/#/selections/1/zim');
+          cy.wait('@identity');
+          cy.wait('@builder');
+          cy.wait('@status');
+        });
+
+        it('displays the form for entering descriptions', () => {
+          cy.get('#desc').should('be.visible');
+          cy.get('#longdesc').should('be.visible');
+        });
+
+        it('Displays the Request ZIM file button', () => {
+          cy.get('#request').should('be.visible');
+          cy.get('#request').should('not.have.attr', 'disabled');
+        });
+
+        describe('when the Request ZIM file button is clicked', () => {
+          beforeEach(() => {
+            cy.intercept('POST', 'v1/builders/1/zim', {
+              statusCode: 204,
+            }).as('request');
+            cy.get('#request').click();
+          });
+
+          it('makes the ZIM file request', () => {
+            cy.wait('@request');
+          });
+        });
+      });
+
+      describe('when the zim file has been requested but is not ready', () => {
+        beforeEach(() => {
+          cy.intercept('v1/builders/1/zim/status', {
+            fixture: 'zim_status_not_ready.json',
+          }).as('status');
+          cy.visit('/#/selections/1/zim');
+          cy.wait('@identity');
+          cy.wait('@builder');
+          cy.wait('@status');
+        });
+
+        it('does not display the form for descriptions', () => {
+          cy.get('#desc').should('not.exist');
+          cy.get('#longdesc').should('not.exist');
+        });
+
+        it('shows the Download ZIM button disabled', () => {
+          cy.get('#download').should('be.visible');
+          cy.get('#download').should('have.attr', 'disabled');
+        });
+
+        it('shows the spinner', () => {
+          cy.get('#loader').should('be.visible');
+        });
+      });
+
+      describe('when the zim file is ready', () => {
+        beforeEach(() => {
+          cy.intercept('v1/builders/1/zim/status', {
+            fixture: 'zim_status_ready.json',
+          }).as('status');
+          cy.visit('/#/selections/1/zim');
+          cy.wait('@identity');
+          cy.wait('@builder');
+          cy.wait('@status');
+        });
+
+        it('does not display the form for descriptions', () => {
+          cy.get('#desc').should('not.exist');
+          cy.get('#longdesc').should('not.exist');
+        });
+
+        it('shows the Download ZIM button enabled', () => {
+          cy.get('#download').should('be.visible');
+          cy.get('#download').should('not.have.attr', 'disabled');
+        });
+
+        it('does not show the spinner', () => {
+          cy.get('#loader').should('not.exist');
+        });
+      });
+    });
+
+    describe('and the builder is not found', () => {
+      beforeEach(() => {
+        cy.intercept('GET', 'v1/builders/1', {
+          statusCode: 404,
+          body: '404 NOT FOUND',
+        });
+        cy.visit('/#/selections/1/zim');
+      });
+
+      it('displays the 404 text', () => {
+        cy.get('#404').should('be.visible');
+      });
+    });
+  });
+});

--- a/wp1-frontend/cypress/e2e/zimFile.cy.js
+++ b/wp1-frontend/cypress/e2e/zimFile.cy.js
@@ -31,9 +31,34 @@ describe('the zim file creation page', () => {
           cy.get('#longdesc').should('be.visible');
         });
 
+        it('validates the description input on losing focus', () => {
+          cy.get('#desc').click();
+          cy.get('#longdesc').click();
+          cy.get('#desc-group > .invalid-feedback').should('be.visible');
+        });
+
         it('displays the Request ZIM file button', () => {
           cy.get('#request').should('be.visible');
           cy.get('#request').should('not.have.attr', 'disabled');
+        });
+
+        describe('when the description is missing and the submit button is clicked', () => {
+          beforeEach(() => {
+            cy.intercept('POST', 'v1/builders/1/zim', (req) => {
+              throw new Error(
+                'POST to create ZIM should not have been requested'
+              );
+            }).as('request');
+          });
+
+          it('does not submit the form', () => {
+            cy.get('#request').click();
+          });
+
+          it('shows the error message', () => {
+            cy.get('#request').click();
+            cy.get('#desc-group > .invalid-feedback').should('be.visible');
+          });
         });
 
         describe('when the Request ZIM file button is clicked', () => {
@@ -41,6 +66,8 @@ describe('the zim file creation page', () => {
             cy.intercept('POST', 'v1/builders/1/zim', {
               statusCode: 204,
             }).as('request');
+
+            cy.get('#desc').click().type('Description from user');
             cy.get('#request').click();
           });
 

--- a/wp1-frontend/cypress/e2e/zimFile.cy.js
+++ b/wp1-frontend/cypress/e2e/zimFile.cy.js
@@ -44,7 +44,7 @@ describe('the zim file creation page', () => {
 
         describe('when the description is missing and the submit button is clicked', () => {
           beforeEach(() => {
-            cy.intercept('POST', 'v1/builders/1/zim', (req) => {
+            cy.intercept('POST', 'v1/builders/1/zim', () => {
               throw new Error(
                 'POST to create ZIM should not have been requested'
               );

--- a/wp1-frontend/cypress/fixtures/list_data.json
+++ b/wp1-frontend/cypress/fixtures/list_data.json
@@ -12,7 +12,10 @@
       "s_updated_at": 1630880303,
       "s_content_type": "text/tab-separated-values",
       "s_extension": "tsv",
-      "s_url": "https://www.example.fake/abcd-efgh"
+      "s_url": "https://www.example.fake/abcd-efgh",
+      "s_zim_file_updated_at": null,
+      "s_zim_file_url": null,
+      "s_zimfarm_status": "NOT_REQUESTED"
     },
     {
       "id": 2,
@@ -26,7 +29,10 @@
       "s_updated_at": null,
       "s_content_type": null,
       "s_extension": null,
-      "s_url": null
+      "s_url": null,
+      "s_zim_file_updated_at": null,
+      "s_zim_file_url": null,
+      "s_zimfarm_status": "NOT_REQUESTED"
     },
     {
       "created_at": 1670251154,
@@ -40,7 +46,10 @@
       "s_status": null,
       "s_updated_at": 1670251157,
       "s_url": null,
-      "updated_at": 1670261154
+      "updated_at": 1670261154,
+      "s_zim_file_updated_at": null,
+      "s_zim_file_url": null,
+      "s_zimfarm_status": "NOT_REQUESTED"
     },
     {
       "created_at": 1669778531,
@@ -54,7 +63,10 @@
       "s_status": "FAILED",
       "s_updated_at": 1670253950,
       "s_url": null,
-      "updated_at": 1670247215
+      "updated_at": 1670247215,
+      "s_zim_file_updated_at": null,
+      "s_zim_file_url": null,
+      "s_zimfarm_status": "NOT_REQUESTED"
     },
     {
       "created_at": 1669778531,
@@ -64,11 +76,14 @@
       "project": "en.wikipedia.org",
       "s_content_type": "text/tab-separated-values",
       "s_extension": "tsv",
-      "s_id": "1234-abcd",
+      "s_id": "1234-efgh",
       "s_status": "CAN_RETRY",
       "s_updated_at": 1670253950,
       "s_url": null,
-      "updated_at": 1670247215
+      "updated_at": 1670247215,
+      "s_zim_file_updated_at": null,
+      "s_zim_file_url": null,
+      "s_zimfarm_status": "NOT_REQUESTED"
     },
     {
       "created_at": 1669778531,
@@ -82,7 +97,61 @@
       "s_status": "CAN_RETRY",
       "s_updated_at": 1670253950,
       "s_url": null,
-      "updated_at": 1670267215
+      "updated_at": 1670267215,
+      "s_zim_file_updated_at": null,
+      "s_zim_file_url": null,
+      "s_zimfarm_status": "NOT_REQUESTED"
+    },
+    {
+      "created_at": 1669678531,
+      "id": "7368f534-27f5-4350-bfe3-23b90363df7b",
+      "model": "wp1.selection.models.sparql",
+      "name": "selection ready, no zim",
+      "project": "en.wikipedia.org",
+      "s_content_type": "text/tab-separated-values",
+      "s_extension": "tsv",
+      "s_id": "1234-hijk",
+      "s_status": "OK",
+      "s_updated_at": 1671253950,
+      "s_url": "https://www.example.fake/1234-hijk",
+      "updated_at": 1670267215,
+      "s_zim_file_updated_at": null,
+      "s_zim_file_url": null,
+      "s_zimfarm_status": "NOT_REQUESTED"
+    },
+    {
+      "created_at": 1669679000,
+      "id": "7368f534-27f5-4350-bfe3-23b90363df7b",
+      "model": "wp1.selection.models.sparql",
+      "name": "zim requested",
+      "project": "en.wikipedia.org",
+      "s_content_type": "text/tab-separated-values",
+      "s_extension": "tsv",
+      "s_id": "1234-hijk",
+      "s_status": "OK",
+      "s_updated_at": 1671263950,
+      "s_url": "https://www.example.fake/1234-hijk",
+      "updated_at": 1670287215,
+      "s_zim_file_updated_at": null,
+      "s_zim_file_url": null,
+      "s_zimfarm_status": "REQUESTED"
+    },
+    {
+      "created_at": 1669679000,
+      "id": "7368f534-27f5-4350-bfe3-23b90363df7b",
+      "model": "wp1.selection.models.sparql",
+      "name": "zim ready",
+      "project": "en.wikipedia.org",
+      "s_content_type": "text/tab-separated-values",
+      "s_extension": "tsv",
+      "s_id": "1234-hijk",
+      "s_status": "OK",
+      "s_updated_at": 1671263950,
+      "s_url": "https://www.example.fake/1234-hijk",
+      "updated_at": 1670287215,
+      "s_zim_file_updated_at": 1671287215,
+      "s_zim_file_url": "https://localhost/zim/latest",
+      "s_zimfarm_status": "FILE_READY"
     }
   ]
 }

--- a/wp1-frontend/cypress/fixtures/zim_status_not_ready.json
+++ b/wp1-frontend/cypress/fixtures/zim_status_not_ready.json
@@ -1,0 +1,3 @@
+{
+  "status": "REQUESTED"
+}

--- a/wp1-frontend/cypress/fixtures/zim_status_not_requested.json
+++ b/wp1-frontend/cypress/fixtures/zim_status_not_requested.json
@@ -1,0 +1,3 @@
+{
+  "status": "NOT_REQUESTED"
+}

--- a/wp1-frontend/cypress/fixtures/zim_status_ready.json
+++ b/wp1-frontend/cypress/fixtures/zim_status_ready.json
@@ -1,0 +1,3 @@
+{
+  "status": "FILE_READY"
+}

--- a/wp1-frontend/src/components/BaseBuilder.vue
+++ b/wp1-frontend/src/components/BaseBuilder.vue
@@ -31,14 +31,14 @@
             <h4 class="materialize-header">
               There was an error creating your selection
             </h4>
-            <div>
-              The following errors occurred when creating the .{{ item.ext }}
-              version:
-            </div>
             <div
               v-for="item in builder.selection_errors"
               v-bind:key="item.error_messages[0]"
             >
+              <div>
+                The following errors occurred when creating the .{{ item.ext }}
+                version:
+              </div>
               <ul class="materialize-error-list">
                 <li v-for="msg in item.error_messages" v-bind:key="msg">
                   {{ msg }}

--- a/wp1-frontend/src/components/BaseBuilder.vue
+++ b/wp1-frontend/src/components/BaseBuilder.vue
@@ -31,14 +31,14 @@
             <h4 class="materialize-header">
               There was an error creating your selection
             </h4>
+            <div>
+              The following errors occurred when creating the .{{ item.ext }}
+              version:
+            </div>
             <div
               v-for="item in builder.selection_errors"
               v-bind:key="item.error_messages[0]"
             >
-              <div>
-                The following errors occurred when creating the .{{ item.ext }}
-                version:
-              </div>
               <ul class="materialize-error-list">
                 <li v-for="msg in item.error_messages" v-bind:key="msg">
                   {{ msg }}

--- a/wp1-frontend/src/components/CreateZimFile.vue
+++ b/wp1-frontend/src/components/CreateZimFile.vue
@@ -1,0 +1,63 @@
+<template>
+  <div v-if="isLoggedIn">
+    <div>
+      <SecondaryNav></SecondaryNav>
+    </div>
+  </div>
+  <div v-else>
+    <LoginRequired></LoginRequired>
+  </div>
+</template>
+
+<script>
+import PulseLoader from 'vue-spinner/src/PulseLoader.vue';
+
+import SecondaryNav from './SecondaryNav.vue';
+import LoginRequired from './LoginRequired.vue';
+
+export default {
+  name: 'CreateZimFile',
+  components: { SecondaryNav, LoginRequired, PulseLoader },
+  data: function () {
+    return {};
+  },
+  created: function () {
+    this.getBuilder();
+  },
+  methods: {
+    getBuilder: async function () {
+      const response = await fetch(
+        `${import.meta.env.VITE_API_URL}/builders/${this.builderId}`,
+        {
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+        }
+      );
+      if (response.status == 404) {
+        this.notFound = true;
+      } else if (!response.ok) {
+        this.serverError = true;
+      } else {
+        this.notFound = false;
+        this.builder = await response.json();
+        this.$emit('onBuilderLoaded', this.builder);
+      }
+    },
+  },
+  computed: {
+    isLoggedIn: function () {
+      return this.$root.$data.isLoggedIn;
+    },
+    builderId: function () {
+      return this.$route.params.builder_id;
+    },
+  },
+  watch: {
+    builderId: function () {
+      this.getBuilder();
+    },
+  },
+};
+</script>
+
+<style scoped></style>

--- a/wp1-frontend/src/components/MyLists.vue
+++ b/wp1-frontend/src/components/MyLists.vue
@@ -65,20 +65,21 @@
                   ></span>
                 </div>
               </td>
-              <td v-if="item.s_zim_file_url">
+              <td v-if="item.s_zim_file_url && !isPending(item)">
                 {{ localDate(item.s_zim_file_updated_at) }}
               </td>
               <td v-else>-</td>
-              <td v-if="item.s_zim_file_url">
+              <td v-if="item.s_zim_file_url && !isPending(item)">
                 <a :href="item.s_zim_file_url">Download ZIM</a>
               </td>
-              <td v-else>
+              <td v-else-if="!isPending(item) && !hasSelectionError(item)">
                 <router-link :to="zimPathFor(item)"
                   ><button type="button" class="btn btn-primary">
                     Create ZIM
                   </button></router-link
                 >
               </td>
+              <td v-else>-</td>
               <td>
                 <router-link :to="editPathFor(item)"
                   ><button type="button" class="btn btn-primary">

--- a/wp1-frontend/src/components/MyLists.vue
+++ b/wp1-frontend/src/components/MyLists.vue
@@ -16,6 +16,8 @@
               <th>Project</th>
               <th>Download Updated</th>
               <th>Download</th>
+              <th>ZIM updated</th>
+              <th>Download ZIM</th>
               <th></th>
             </tr>
           </thead>
@@ -23,26 +25,14 @@
             <tr v-for="item in list" :key="item.s_id">
               <td>{{ item.name }}</td>
               <td :data-order="item.created_at">
-                {{
-                  new Date(item.created_at * 1000).toLocaleDateString() +
-                  ' ' +
-                  new Date(item.created_at * 1000).toLocaleTimeString()
-                }}
+                {{ localDate(item.created_at) }}
               </td>
               <td :data-order="item.updated_at">
-                {{
-                  new Date(item.updated_at * 1000).toLocaleDateString() +
-                  ' ' +
-                  new Date(item.updated_at * 1000).toLocaleTimeString()
-                }}
+                {{ localDate(item.updated_at) }}
               </td>
               <td>{{ item.project }}</td>
               <td v-if="item.s_updated_at" :data-order="item.s_updated_at">
-                {{
-                  new Date(item.s_updated_at * 1000).toLocaleDateString() +
-                  ' ' +
-                  new Date(item.s_updated_at * 1000).toLocaleTimeString()
-                }}
+                {{ localDate(item.s_updated_at) }}
               </td>
               <td v-else data-order="0">-</td>
               <td v-if="!isPending(item) && !hasSelectionError(item)">
@@ -74,6 +64,20 @@
                     ><i class="bi bi-info-circle"></i
                   ></span>
                 </div>
+              </td>
+              <td v-if="item.s_zim_file_url">
+                {{ localDate(item.s_zim_file_updated_at) }}
+              </td>
+              <td v-else>-</td>
+              <td v-if="item.s_zim_file_url">
+                <a :href="item.s_zim_file_url">Download ZIM</a>
+              </td>
+              <td v-else>
+                <router-link :to="zimPathFor(item)"
+                  ><button type="button" class="btn btn-primary">
+                    Create ZIM
+                  </button></router-link
+                >
               </td>
               <td>
                 <router-link :to="editPathFor(item)"
@@ -127,6 +131,13 @@ export default {
     hasSelectionError: function (item) {
       return item.s_status !== null && item.s_status !== 'OK';
     },
+    localDate: function (secs) {
+      const fmt = new Intl.DateTimeFormat('en-US', {
+        dateStyle: 'short',
+        timeStyle: 'short',
+      });
+      return fmt.format(new Date(secs * 1000));
+    },
     getLists: async function () {
       let createDataTable = false;
       if (this.list.length === 0) {
@@ -145,7 +156,7 @@ export default {
       if (createDataTable) {
         this.$nextTick(function () {
           $('#list-table').DataTable({
-            columnDefs: [{ orderable: false, targets: [5, 6] }],
+            columnDefs: [{ orderable: false, targets: [5, 7, 8] }],
             order: [[2, 'desc']],
           });
         });
@@ -169,6 +180,9 @@ export default {
       const fragments = item.model.split('.');
       const modelFragment = fragments[fragments.length - 1];
       return { path: `/selections/${modelFragment}/${item.id}` };
+    },
+    zimPathFor: (item) => {
+      return { path: `/selections/${item.id}/zim` };
     },
     startProgressPolling: function () {
       if (this.pollId) {

--- a/wp1-frontend/src/components/MyLists.vue
+++ b/wp1-frontend/src/components/MyLists.vue
@@ -72,6 +72,13 @@
               <td v-if="item.s_zim_file_url && !isPending(item)">
                 <a :href="item.s_zim_file_url">Download ZIM</a>
               </td>
+              <td v-else-if="hasPendingZim(item)">
+                <pulse-loader
+                  class="loader"
+                  :color="loaderColor"
+                  :size="loaderSize"
+                ></pulse-loader>
+              </td>
               <td v-else-if="!isPending(item) && !hasSelectionError(item)">
                 <router-link :to="zimPathFor(item)"
                   ><button type="button" class="btn btn-primary">
@@ -127,6 +134,13 @@ export default {
     isPending: function (item) {
       return (
         (!item.s_url && !item.s_status) || item.updated_at > item.s_updated_at
+      );
+    },
+    hasPendingZim: function (item) {
+      return (
+        item.s_status === 'OK' &&
+        item.s_zimfarm_status !== 'NOT_REQUESTED' &&
+        item.s_zimfarm_status !== 'FILE_READY'
       );
     },
     hasSelectionError: function (item) {

--- a/wp1-frontend/src/components/SparqlBuilder.vue
+++ b/wp1-frontend/src/components/SparqlBuilder.vue
@@ -104,7 +104,7 @@
           v-model="params.query"
           :placeholder="
             '#Rock bands that start with &quot;M&quot;\n' +
-            'SELECT ?band ?bandLabel\n' +
+            'SELECT ?band ?bandLabel ?article\n' +
             'WHERE\n' +
             '{\n' +
             '  ?band wdt:P31 wd:Q5741069 .\n' +

--- a/wp1-frontend/src/components/ZimFile.vue
+++ b/wp1-frontend/src/components/ZimFile.vue
@@ -45,6 +45,7 @@
           <div id="desc" class="form-group">
             <label for="desc">Description</label>
             <input
+              id="desc"
               ref="desc"
               v-model="description"
               class="form-control"
@@ -54,6 +55,7 @@
           <div id="longdesc" class="form-group">
             <label for="longdesc">Long Description</label>
             <textarea
+              id="longdesc"
               ref="longdesc"
               v-model="longDescription"
               rows="6"
@@ -71,6 +73,7 @@
           </div>
           <div>
             <button
+              id="request"
               v-on:click.prevent="onSubmit"
               class="btn btn-primary"
               type="button"
@@ -85,6 +88,7 @@
         <div class="col-lg-6 col-md-9 mx-4">
           <a :href="zimPathFor()"
             ><button
+              id="download"
               type="button"
               class="btn btn-primary"
               :disabled="status !== 'FILE_READY'"
@@ -93,6 +97,7 @@
             </button></a
           >
           <pulse-loader
+            id="loader"
             class="loader"
             :loading="processing || showLoader"
             :color="loaderColor"

--- a/wp1-frontend/src/components/ZimFile.vue
+++ b/wp1-frontend/src/components/ZimFile.vue
@@ -49,6 +49,7 @@
               ref="desc"
               v-model="description"
               class="form-control"
+              maxlength="10"
               placeholder="ZIM file created from a WP1 Selection"
             />
           </div>
@@ -60,6 +61,7 @@
               v-model="longDescription"
               rows="6"
               class="form-control"
+              maxlength="4000"
               placeholder="ZIM file created from a WP1 Selection"
             ></textarea>
           </div>

--- a/wp1-frontend/src/components/ZimFile.vue
+++ b/wp1-frontend/src/components/ZimFile.vue
@@ -3,6 +3,17 @@
     <div>
       <SecondaryNav></SecondaryNav>
     </div>
+    <div v-if="notFound">
+      <div id="404" class="col-lg-6 m-4">
+        <h2>404 Not Found</h2>
+        Sorry, the list with that ID either doesn't exist or isn't owned by you.
+      </div>
+    </div>
+    <div v-else-if="serverError">
+      <h2>500 Server error</h2>
+      Something went wrong and we couldn't retrieve the list with that ID. You
+      might try again later.
+    </div>
   </div>
   <div v-else>
     <LoginRequired></LoginRequired>
@@ -16,10 +27,10 @@ import SecondaryNav from './SecondaryNav.vue';
 import LoginRequired from './LoginRequired.vue';
 
 export default {
-  name: 'CreateZimFile',
+  name: 'ZimFile',
   components: { SecondaryNav, LoginRequired, PulseLoader },
   data: function () {
-    return {};
+    return { notFound: false, serverError: false };
   },
   created: function () {
     this.getBuilder();

--- a/wp1-frontend/src/components/ZimFile.vue
+++ b/wp1-frontend/src/components/ZimFile.vue
@@ -92,6 +92,12 @@
               Download ZIM
             </button></a
           >
+          <pulse-loader
+            class="loader"
+            :loading="processing || showLoader"
+            :color="loaderColor"
+            :size="loaderSize"
+          ></pulse-loader>
         </div>
       </div>
     </div>
@@ -113,6 +119,8 @@ export default {
   data: function () {
     return {
       description: '',
+      loaderColor: '#007bff',
+      loaderSize: '1rem',
       longDescription: '',
       notFound: false,
       pollId: null,
@@ -215,6 +223,13 @@ export default {
     builderId: function () {
       return this.$route.params.builder_id;
     },
+    showLoader: function () {
+      return (
+        this.processing ||
+        this.status === 'REQUESTED' ||
+        this.status === 'ENDED'
+      );
+    },
   },
   watch: {
     builderId: function () {
@@ -228,8 +243,14 @@ export default {
 .errors {
   color: #dc3545;
 }
-
 .error-list {
   background-color: pink;
+}
+.loader {
+  position: relative;
+  top: 5px;
+  display: inline-block;
+  margin: 0 20px;
+  text-align: center;
 }
 </style>

--- a/wp1-frontend/src/components/ZimFile.vue
+++ b/wp1-frontend/src/components/ZimFile.vue
@@ -14,6 +14,87 @@
       Something went wrong and we couldn't retrieve the list with that ID. You
       might try again later.
     </div>
+    <div v-else-if="ready">
+      <div class="row">
+        <div class="col-lg-6 col-md-9 mx-4">
+          <h2>Create ZIM file</h2>
+          <p v-if="status === 'NOT_REQUESTED'">
+            Use this form to create a ZIM file from your selection, so that you
+            can browse the articles it contains offline. The
+            &quot;Description&quot; and &quot;Long Description&quot; fields are
+            required, but generic defaults will be used if they're not provided.
+          </p>
+          <p>
+            Once you request a ZIM file, it will be queued for creation. This
+            page and the My Selections page will automatically update with a URL
+            to download your ZIM file once it is ready.
+          </p>
+          <p v-if="status === 'REQUESTED'">
+            Your ZIM file has been requested and is being processed. This page
+            will update with the URL to download it once it is ready. It will
+            also keep you updated on any errors that may occur.
+          </p>
+          <p v-else-if="status === 'FILE_READY'">
+            Your ZIM file is ready! Click the button below to download it. You
+            can also always download it from the My Selections page.
+          </p>
+        </div>
+      </div>
+      <div v-if="status === 'NOT_REQUESTED'" class="row">
+        <div class="col-lg-6 col-md-9 mx-4">
+          <div id="desc" class="form-group">
+            <label for="desc">Description</label>
+            <input
+              ref="desc"
+              v-model="description"
+              class="form-control"
+              placeholder="ZIM file created from a WP1 Selection"
+            />
+          </div>
+          <div id="longdesc" class="form-group">
+            <label for="longdesc">Long Description</label>
+            <textarea
+              ref="longdesc"
+              v-model="longDescription"
+              rows="6"
+              class="form-control"
+              placeholder="ZIM file created from a WP1 Selection"
+            ></textarea>
+          </div>
+          <div v-if="!success" class="error-list error">
+            <p>The following errors occurred:</p>
+            <ul>
+              <li v-for="msg in errorMessages" v-bind:key="msg">
+                {{ msg }}
+              </li>
+            </ul>
+          </div>
+          <div>
+            <button
+              v-on:click.prevent="onSubmit"
+              class="btn btn-primary"
+              type="button"
+              :disabled="processing"
+            >
+              Request ZIM file
+            </button>
+          </div>
+        </div>
+      </div>
+      <div v-else class="row">
+        <div class="col-lg-6 col-md-9 mx-4">
+          <a :href="zimPathFor()"
+            ><button
+              type="button"
+              class="btn btn-primary"
+              :disabled="status !== 'FILE_READY'"
+            >
+              Download ZIM
+            </button></a
+          >
+        </div>
+      </div>
+    </div>
   </div>
   <div v-else>
     <LoginRequired></LoginRequired>
@@ -30,10 +111,23 @@ export default {
   name: 'ZimFile',
   components: { SecondaryNav, LoginRequired, PulseLoader },
   data: function () {
-    return { notFound: false, serverError: false };
+    return {
+      description: '',
+      longDescription: '',
+      notFound: false,
+      pollId: null,
+      processing: false,
+      ready: false,
+      serverError: false,
+      errorMessages: [],
+      status: null,
+      success: true,
+    };
   },
-  created: function () {
-    this.getBuilder();
+  created: async function () {
+    await this.getBuilder();
+    await this.getStatus();
+    this.ready = true;
   },
   methods: {
     getBuilder: async function () {
@@ -54,6 +148,65 @@ export default {
         this.$emit('onBuilderLoaded', this.builder);
       }
     },
+    getStatus: async function () {
+      const url = `${import.meta.env.VITE_API_URL}/builders/${
+        this.builderId
+      }/zim/status`;
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        this.success = false;
+        this.errors = 'An unknown server error has occurred.';
+      }
+
+      const data = await response.json();
+      this.status = data.status;
+      if (this.status === 'FILE_READY') {
+        this.stopProgressPolling();
+      } else if (this.status !== 'NOT_REQUESTED') {
+        this.startProgressPolling();
+      }
+    },
+    onSubmit: async function () {
+      const postUrl = `${import.meta.env.VITE_API_URL}/builders/${
+        this.builderId
+      }/zim`;
+
+      this.processing = true;
+      const response = await fetch(postUrl, {
+        headers: { 'Content-Type': 'application/json' },
+        method: 'post',
+        credentials: 'include',
+        body: JSON.stringify({
+          description: this.description,
+          long_description: this.longDescription,
+        }),
+      });
+      this.processing = false;
+
+      if (!response.ok) {
+        this.success = false;
+        const data = await response.json();
+        this.errors = data.error_messages;
+        return;
+      }
+
+      await this.getStatus();
+    },
+    zimPathFor: function () {
+      return `${import.meta.env.VITE_API_URL}/builders/${
+        this.builderId
+      }/zim/latest`;
+    },
+    startProgressPolling: function () {
+      if (this.pollId) {
+        return;
+      }
+      this.pollId = setInterval(() => this.getStatus(), 30000);
+    },
+    stopProgressPolling: function () {
+      clearInterval(this.pollId);
+    },
   },
   computed: {
     isLoggedIn: function () {
@@ -71,4 +224,12 @@ export default {
 };
 </script>
 
-<style scoped></style>
+<style scoped>
+.errors {
+  color: #dc3545;
+}
+
+.error-list {
+  background-color: pink;
+}
+</style>

--- a/wp1-frontend/src/components/ZimFile.vue
+++ b/wp1-frontend/src/components/ZimFile.vue
@@ -42,48 +42,65 @@
       </div>
       <div v-if="status === 'NOT_REQUESTED'" class="row">
         <div class="col-lg-6 col-md-9 mx-4">
-          <div id="desc" class="form-group">
-            <label for="desc">Description</label>
-            <input
-              id="desc"
-              ref="desc"
-              v-model="description"
-              class="form-control"
-              maxlength="10"
-              placeholder="ZIM file created from a WP1 Selection"
-            />
-          </div>
-          <div id="longdesc" class="form-group">
-            <label for="longdesc">Long Description</label>
-            <textarea
-              id="longdesc"
-              ref="longdesc"
-              v-model="longDescription"
-              rows="6"
-              class="form-control"
-              maxlength="4000"
-              placeholder="ZIM file created from a WP1 Selection"
-            ></textarea>
-          </div>
-          <div v-if="!success" class="error-list error">
-            <p>The following errors occurred:</p>
-            <ul>
-              <li v-for="msg in errorMessages" v-bind:key="msg">
-                {{ msg }}
-              </li>
-            </ul>
-          </div>
-          <div>
-            <button
-              id="request"
-              v-on:click.prevent="onSubmit"
-              class="btn btn-primary"
-              type="button"
-              :disabled="processing"
-            >
-              Request ZIM file
-            </button>
-          </div>
+          <form
+            ref="form"
+            v-on:submit.prevent="onSubmit"
+            class="needs-validation"
+            novalidate
+          >
+            <div id="desc-group" ref="form_group" class="form-group">
+              <label for="desc">Description</label>
+              <input
+                id="desc"
+                ref="desc"
+                v-on:blur="validationOnBlur"
+                v-model="description"
+                class="form-control"
+                maxlength="80"
+                placeholder="ZIM file created from a WP1 Selection"
+                required
+              />
+              <div class="invalid-feedback">Please provide a description</div>
+            </div>
+            <div class="form-group">
+              <label for="longdesc">Long Description</label>
+              <textarea
+                id="longdesc"
+                ref="longdesc"
+                v-model="longDescription"
+                rows="6"
+                class="form-control"
+                maxlength="4000"
+                placeholder="ZIM file created from a WP1 Selection"
+              ></textarea>
+            </div>
+            <div v-if="!success" class="error-list error">
+              <p>The following errors occurred:</p>
+              <ul>
+                <li v-for="msg in errorMessages" v-bind:key="msg">
+                  {{ msg }}
+                </li>
+              </ul>
+            </div>
+            <div>
+              <button
+                id="request"
+                v-on:click.prevent="onSubmit"
+                class="btn btn-primary"
+                type="button"
+                :disabled="processing"
+              >
+                Request ZIM file
+              </button>
+              <pulse-loader
+                id="loader"
+                class="loader"
+                :loading="processing || showLoader"
+                :color="loaderColor"
+                :size="loaderSize"
+              ></pulse-loader>
+            </div>
+          </form>
         </div>
       </div>
       <div v-else class="row">
@@ -183,6 +200,12 @@ export default {
       }
     },
     onSubmit: async function () {
+      const form = this.$refs.form;
+      if (!form.checkValidity()) {
+        this.$refs.form_group.classList.add('was-validated');
+        return;
+      }
+
       const postUrl = `${import.meta.env.VITE_API_URL}/builders/${
         this.builderId
       }/zim`;
@@ -221,6 +244,13 @@ export default {
     },
     stopProgressPolling: function () {
       clearInterval(this.pollId);
+    },
+    validationOnBlur: function (event) {
+      if (event.target.value) {
+        event.target.classList.remove('is-invalid');
+      } else {
+        event.target.classList.add('is-invalid');
+      }
     },
   },
   computed: {

--- a/wp1-frontend/src/main.js
+++ b/wp1-frontend/src/main.js
@@ -14,11 +14,11 @@ import ArticlePage from './components/ArticlePage.vue';
 import SimpleBuilder from './components/SimpleBuilder.vue';
 import SparqlBuilder from './components/SparqlBuilder.vue';
 import ComparePage from './components/ComparePage.vue';
-import CreateZimFile from './components/CreateZimFile.vue';
 import IndexPage from './components/IndexPage.vue';
 import MyLists from './components/MyLists.vue';
 import ProjectPage from './components/ProjectPage.vue';
 import UpdatePage from './components/UpdatePage.vue';
+import ZimFile from './components/ZimFile.vue';
 
 Vue.config.productionTip = false;
 
@@ -126,9 +126,9 @@ const routes = [
   },
   {
     path: '/selections/:builder_id/zim',
-    component: CreateZimFile,
+    component: ZimFile,
     meta: {
-      title: () => BASE_TITLE + ' - Create ZIM file',
+      title: () => BASE_TITLE + ' - ZIM file',
     },
   },
 ];

--- a/wp1-frontend/src/main.js
+++ b/wp1-frontend/src/main.js
@@ -14,6 +14,7 @@ import ArticlePage from './components/ArticlePage.vue';
 import SimpleBuilder from './components/SimpleBuilder.vue';
 import SparqlBuilder from './components/SparqlBuilder.vue';
 import ComparePage from './components/ComparePage.vue';
+import CreateZimFile from './components/CreateZimFile.vue';
 import IndexPage from './components/IndexPage.vue';
 import MyLists from './components/MyLists.vue';
 import ProjectPage from './components/ProjectPage.vue';
@@ -121,6 +122,13 @@ const routes = [
     component: SparqlBuilder,
     meta: {
       title: () => BASE_TITLE + ' - Edit SPARQL Selection',
+    },
+  },
+  {
+    path: '/selections/:builder_id/zim',
+    component: CreateZimFile,
+    meta: {
+      title: () => BASE_TITLE + ' - Create ZIM file',
     },
   },
 ];

--- a/wp1/credentials.py.dev.example
+++ b/wp1/credentials.py.dev.example
@@ -84,6 +84,7 @@ CREDENTIALS = {
         # ZIM files from materialized selections.
         'ZIMFARM': {
             'url': 'https://api.farm.youzim.it/v1',
+            's3_url': 'https://fake.wasabisys.com/org-kiwix-zimit',
             'user': 'wp1',
             'password': '', # EDIT this line
             'hook_token': '' # EDIT this line,

--- a/wp1/credentials.py.e2e
+++ b/wp1/credentials.py.e2e
@@ -63,6 +63,7 @@ CREDENTIALS = {
         },
         'ZIMFARM': {
             'url': 'https://fake.farm/v1',
+            's3_url': 'https://fake.wasabisys.com/org-kiwix-zimit',
             'user': 'farmuser',
             'password': 'farmpass',
             'hook_token': 'hook-token-abc',

--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -115,6 +115,7 @@ CREDENTIALS = {
         # ZIM files from materialized selections.
         'ZIMFARM': {
             'url': 'https://api.farm.youzim.it/v1',
+            's3_url': 'https://s3.us-west-1.wasabisys.com/org-kiwix-zimit',
             'user': '', # EDIT this line
             'password': '', # EDIT this line
             # A simple token secret exchanged between the WP1 server and the zimfarm
@@ -167,6 +168,7 @@ CREDENTIALS = {
         # Fake Zim Farm server values for test.
         'ZIMFARM': {
             'url': 'https://fake.farm/v1',
+            's3_url': 'https://fake.wasabisys.com/org-kiwix-zimit',
             'user': 'farmuser',
             'password': 'farmpass',
             'hook_token': 'hook-token-abc',
@@ -244,6 +246,7 @@ CREDENTIALS = {
     #   # ZIM files from materializes selections.
     #   'ZIMFARM': {
     #      'url': 'https://api.farm.youzim.it/v1',
+    #      's3_url': 'https://fake.wasabisys.com/org-kiwix-zimit',
     #      'user': '', # EDIT this line
     #      'password': '', # EDIT this line
     #       # A simple token secret exchanged between the WP1 server and the zimfarm

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -264,7 +264,12 @@ def latest_selections_with_errors(wp10db, builder_id):
   return res
 
 
-def schedule_zim_file(redis, wp10db, user_id, builder_id):
+def schedule_zim_file(redis,
+                      wp10db,
+                      user_id,
+                      builder_id,
+                      description='',
+                      long_description=''):
   if isinstance(builder_id, str):
     builder_id = builder_id.encode('utf-8')
   builder = get_builder(wp10db, builder_id)
@@ -277,7 +282,11 @@ def schedule_zim_file(redis, wp10db, user_id, builder_id):
         'Could not use builder id = %s for user id = %s' %
         (builder_id, user_id))
 
-  task_id = zimfarm.schedule_zim_file(redis, wp10db, builder)
+  task_id = zimfarm.schedule_zim_file(redis,
+                                      wp10db,
+                                      builder,
+                                      description=description,
+                                      long_description=long_description)
   selection = latest_selection_for(wp10db, builder_id,
                                    'text/tab-separated-values')
 
@@ -289,6 +298,14 @@ def schedule_zim_file(redis, wp10db, user_id, builder_id):
            WHERE s_id = %s
         ''', (task_id, selection.s_id))
   wp10db.commit()
+
+  return task_id
+
+
+def latest_zimfarm_status(wp10db, builder_id):
+  selection = latest_selection_for(wp10db, builder_id,
+                                   'text/tab-separated-values')
+  return selection.s_zimfarm_status.decode('utf-8')
 
 
 def on_zim_file_status_poll(task_id):

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -259,12 +259,10 @@ def on_zim_file_status_poll(task_id):
   redis = redis_connect()
 
   if zimfarm.is_zim_file_ready(redis, task_id):
-    with wp10db.cursor() as cursor:
-      cursor.execute(
-          'UPDATE selections '
-          'SET s_zimfarm_status = "FILE_READY" '
-          'WHERE s_zimfarm_task_id = %s', (task_id,))
-    wp10db.commit()
+    logic_selection.update_zimfarm_task(wp10db,
+                                        task_id,
+                                        'FILE_READY',
+                                        set_updated_now=True)
   else:
     queues.poll_for_zim_file_status(redis, task_id)
 

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -324,6 +324,7 @@ def get_builders_with_selections(wp10db, user_id):
     has_selection = b['s_id'] is not None
     has_status = b['s_status'] is not None
     is_ok_status = b['s_status'] == b'OK'
+    is_zim_ready = b['s_zimfarm_status'] == b'FILE_READY'
     content_type = b['s_content_type'].decode(
         'utf-8') if has_selection else None
     selection_id = b['s_id'].decode('utf-8') if has_selection else None
@@ -363,6 +364,7 @@ def get_builders_with_selections(wp10db, user_id):
             has_selection and b['s_zim_file_updated_at'] is not None else None,
         's_zim_file_url':
             latest_zim_for(b['b_id'].decode('utf-8'))
-            if content_type == 'text/tab-separated-values' else None,
+            if content_type == 'text/tab-separated-values' and is_zim_ready else
+            None,
     })
   return result

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -323,18 +323,18 @@ def on_zim_file_status_poll(task_id):
   wp10db.close()
 
 
-def _get_builder_data(b):
+def _get_builder_data(builder):
   return {
-      'id': b['b_id'].decode('utf-8'),
-      'name': b['b_name'].decode('utf-8'),
-      'project': b['b_project'].decode('utf-8'),
-      'model': b['b_model'].decode('utf-8'),
-      'created_at': logic_util.wp10_timestamp_to_unix(b['b_created_at']),
-      'updated_at': logic_util.wp10_timestamp_to_unix(b['b_updated_at']),
+      'id': builder['b_id'].decode('utf-8'),
+      'name': builder['b_name'].decode('utf-8'),
+      'project': builder['b_project'].decode('utf-8'),
+      'model': builder['b_model'].decode('utf-8'),
+      'created_at': logic_util.wp10_timestamp_to_unix(builder['b_created_at']),
+      'updated_at': logic_util.wp10_timestamp_to_unix(builder['b_updated_at']),
   }
 
 
-def _get_selection_data(b):
+def _get_selection_data(builder):
   data = {
       's_id': None,
       's_updated_at': None,
@@ -347,30 +347,32 @@ def _get_selection_data(b):
       's_zim_file_url': None,
   }
 
-  has_selection = b['s_id'] is not None
-  has_status = b['s_status'] is not None
-  is_ok_status = b['s_status'] == b'OK'
-  is_zim_ready = b['s_zimfarm_status'] == b'FILE_READY'
+  has_selection = builder['s_id'] is not None
+  has_status = builder['s_status'] is not None
+  is_ok_status = builder['s_status'] == b'OK'
+  is_zim_ready = builder['s_zimfarm_status'] == b'FILE_READY'
 
   if has_selection:
-    content_type = b['s_content_type'].decode('utf-8')
-    data['s_id'] = b['s_id'].decode('utf-8')
-    data['s_updated_at'] = logic_util.wp10_timestamp_to_unix(b['s_updated_at'])
+    content_type = builder['s_content_type'].decode('utf-8')
+    data['s_id'] = builder['s_id'].decode('utf-8')
+    data['s_updated_at'] = logic_util.wp10_timestamp_to_unix(
+        builder['s_updated_at'])
     data['s_content_type'] = content_type
     data['s_extension'] = CONTENT_TYPE_TO_EXT.get(content_type, '???')
-    data['s_zimfarm_status'] = b['s_zimfarm_status'].decode('utf-8')
+    data['s_zimfarm_status'] = builder['s_zimfarm_status'].decode('utf-8')
     if has_status:
-      data['s_status'] = b['s_status'].decode('utf-8')
+      data['s_status'] = builder['s_status'].decode('utf-8')
 
     if is_ok_status or not has_status:
-      data['s_url'] = latest_url_for(b['b_id'].decode('utf-8'), content_type)
+      data['s_url'] = latest_url_for(builder['b_id'].decode('utf-8'),
+                                     content_type)
 
-    if b['s_zim_file_updated_at'] is not None:
+    if builder['s_zim_file_updated_at'] is not None:
       data['s_zim_file_updated_at'] = logic_util.wp10_timestamp_to_unix(
-          b['s_zim_file_updated_at'])
+          builder['s_zim_file_updated_at'])
 
     if content_type == 'text/tab-separated-values' and is_zim_ready:
-      data['s_zim_file_url'] = latest_zim_for(b['b_id'].decode('utf-8'))
+      data['s_zim_file_url'] = latest_zim_for(builder['b_id'].decode('utf-8'))
 
   return data
 
@@ -389,10 +391,10 @@ def get_builders_with_selections(wp10db, user_id):
 
   builders = {}
   result = []
-  for b in data:
+  for db_builder in data:
     builder = {}
-    builder.update(_get_builder_data(b))
-    builder.update(_get_selection_data(b))
+    builder.update(_get_builder_data(db_builder))
+    builder.update(_get_selection_data(db_builder))
     result.append(builder)
 
   return result

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -10,6 +10,7 @@ from wp1.models.wp10.selection import Selection
 from wp1.storage import connect_storage
 from wp1.logic import util
 from wp1.timestamp import utcnow
+from wp1 import zimfarm
 
 try:
   from wp1.credentials import ENV, CREDENTIALS
@@ -62,6 +63,16 @@ def url_for(object_key):
   path = urllib.parse.quote(
       object_key if isinstance(object_key, str) else object_key.decode('utf-8'))
   return '%s/%s' % (S3_PUBLIC_URL, path)
+
+
+def zim_file_url_for_selection(selection):
+  if not selection:
+    raise ValueError('Cannot get zim file url for empty selection')
+  return zim_file_url_for(selection.s_zimfarm_task_id)
+
+
+def zim_file_url_for(task_id):
+  return zimfarm.zim_file_url_for_task_id(task_id)
 
 
 def object_key_for(selection_id,

--- a/wp1/logic/selection_test.py
+++ b/wp1/logic/selection_test.py
@@ -25,7 +25,7 @@ class SelectionTest(BaseWpOneDbTest):
         s_version=1,
         s_updated_at=b'20190830112844',
         s_object_key=b'selections/foo.bar.model/deadbeef/name.tsv',
-        s_zimfarm_status=b'REQUESTED')
+        s_zimfarm_status=b'NOT_REQUESTED')
 
   def _insert_selections(self, selections=None):
     if selections is None:

--- a/wp1/models/wp10/selection.py
+++ b/wp1/models/wp10/selection.py
@@ -29,6 +29,10 @@ class Selection:
   s_zimfarm_task_id = attr.ib(default=None)
   s_zimfarm_status = attr.ib(default=None)
   s_zimfarm_error_messages = attr.ib(default=None)
+  s_zim_file_updated_at = attr.ib(default=None)
+
+  def set_id(self):
+    self.s_id = str(uuid.uuid4()).encode('utf-8')
 
   @property
   def updated_at_dt(self):
@@ -47,5 +51,20 @@ class Selection:
     """Sets the updated_at field to a timestamp that is equal to now"""
     self.set_updated_at_dt(utcnow())
 
-  def set_id(self):
-    self.s_id = str(uuid.uuid4()).encode('utf-8')
+  @property
+  def zim_file_updated_at_dt(self):
+    """The timestamp parsed into a datetime.datetime object."""
+    return datetime.datetime.strptime(
+        self.s_zim_file_updated_at.decode('utf-8'), TS_FORMAT_WP10)
+
+  def set_zim_file_updated_at_dt(self, dt):
+    """Sets the zim_file_updated_at field using a datetime.datetime object"""
+    if dt is None:
+      logger.warning(
+          'Attempt to set selection zim_file_updated_at to None ignored')
+      return
+    self.s_zim_file_updated_at = dt.strftime(TS_FORMAT_WP10).encode('utf-8')
+
+  def set_zim_file_updated_at_now(self):
+    """Sets the zim_file_updated_at field to a timestamp that is equal to now"""
+    self.set_zim_file_updated_at_dt(utcnow())

--- a/wp1/models/wp10/selection_test.py
+++ b/wp1/models/wp10/selection_test.py
@@ -13,7 +13,8 @@ class ModelsSelectionTest(BaseWpOneDbTest):
                                s_builder_id=100,
                                s_content_type='text/tab-separated-values',
                                s_version=1,
-                               s_updated_at=b'20190830112844')
+                               s_updated_at=b'20190830112844',
+                               s_zim_file_updated_at=b'20200830112844')
 
   def test_updated_at_dt(self):
     dt = self.selection.updated_at_dt
@@ -36,3 +37,25 @@ class ModelsSelectionTest(BaseWpOneDbTest):
     self.selection.set_updated_at_now()
 
     self.assertEqual(b'20191225044444', self.selection.s_updated_at)
+
+  def test_zim_file_updated_at_dt(self):
+    dt = self.selection.zim_file_updated_at_dt
+    self.assertEqual(2020, dt.year)
+    self.assertEqual(8, dt.month)
+    self.assertEqual(30, dt.day)
+    self.assertEqual(11, dt.hour)
+    self.assertEqual(28, dt.minute)
+    self.assertEqual(44, dt.second)
+
+  def test_set_zim_file_updated_at_dt(self):
+    dt = datetime.datetime(2020, 12, 15, 9, 30, 55)
+    self.selection.set_zim_file_updated_at_dt(dt)
+
+    self.assertEqual(b'20201215093055', self.selection.s_zim_file_updated_at)
+
+  @patch('wp1.models.wp10.selection.utcnow',
+         return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
+  def test_set_zim_file_updated_at_now(self, patched_now):
+    self.selection.set_zim_file_updated_at_now()
+
+    self.assertEqual(b'20191225044444', self.selection.s_zim_file_updated_at)

--- a/wp1/selection/models/sparql.py
+++ b/wp1/selection/models/sparql.py
@@ -50,6 +50,9 @@ class Builder(AbstractBuilder):
     urls = []
     # Check every variable that appears in the query graph.
     for variable in [str(v) for v in q.algebra._vars]:
+      has_struct = len(data.get('results', {}).get('bindings', [])) > 0
+      if not has_struct:
+        continue
       if not data['results']['bindings'][0].get(variable):
         # There is no binding for this variable. Maybe it's some kind of
         # special variable. Just skip it.

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -173,7 +173,10 @@ def zimfarm_status():
   files = data.get('files', {})
   for key, value in files.items():
     if value['status'] == 'uploaded':
-      logic_selection.update_zimfarm_task(wp10db, task_id, 'FILE_READY')
+      logic_selection.update_zimfarm_task(wp10db,
+                                          task_id,
+                                          'FILE_READY',
+                                          set_updated_now=True)
       return '', 204
 
   found = logic_selection.update_zimfarm_task(wp10db, task_id, 'ENDED')

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -219,6 +219,4 @@ def latest_zim_file_for_builder(builder_id):
   if not url:
     flask.abort(404)
 
-  print(url)
-
   return flask.redirect(url, code=302)

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -184,3 +184,16 @@ def zimfarm_status():
     redis = get_redis()
     queues.poll_for_zim_file_status(redis, task_id)
   return '', 204
+
+
+@builders.route('/<builder_id>/zim/latest')
+def latest_zim_file_for_builder(builder_id):
+  wp10db = get_db('wp10db')
+
+  url = logic_builder.latest_zim_file_url_for(wp10db, builder_id)
+  if not url:
+    flask.abort(404)
+
+  print(url)
+
+  return flask.redirect(url, code=302)

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -419,7 +419,7 @@ class BuildersTest(BaseWebTestcase):
     with self.override_db(self.app), self.app.test_client() as client:
       with client.session_transaction() as sess:
         sess['user'] = self.USER
-      rv = client.post('/v1/builders/%s/zim' % builder_id)
+      rv = client.post('/v1/builders/%s/zim' % builder_id, json={})
       self.assertEqual('204 NO CONTENT', rv.status)
 
     patched_schedule_zim_file.assert_called_once()
@@ -444,7 +444,7 @@ class BuildersTest(BaseWebTestcase):
     with self.override_db(self.app), self.app.test_client() as client:
       with client.session_transaction() as sess:
         sess['user'] = self.USER
-      rv = client.post('/v1/builders/1234-not-found/zim')
+      rv = client.post('/v1/builders/1234-not-found/zim', json={})
       self.assertEqual('404 NOT FOUND', rv.status)
 
   @patch('wp1.zimfarm.schedule_zim_file')
@@ -457,7 +457,7 @@ class BuildersTest(BaseWebTestcase):
     with self.override_db(self.app), self.app.test_client() as client:
       with client.session_transaction() as sess:
         sess['user'] = self.UNAUTHORIZED_USER
-      rv = client.post('/v1/builders/%s/zim' % builder_id)
+      rv = client.post('/v1/builders/%s/zim' % builder_id, json={})
       self.assertEqual('403 FORBIDDEN', rv.status)
 
   @patch('wp1.zimfarm.schedule_zim_file')
@@ -471,7 +471,7 @@ class BuildersTest(BaseWebTestcase):
     with self.override_db(self.app), self.app.test_client() as client:
       with client.session_transaction() as sess:
         sess['user'] = self.USER
-      rv = client.post('/v1/builders/%s/zim' % builder_id)
+      rv = client.post('/v1/builders/%s/zim' % builder_id, json={})
       self.assertEqual('500 INTERNAL SERVER ERROR', rv.status)
 
   @patch('wp1.web.builders.queues.poll_for_zim_file_status')

--- a/wp1/web/selection_test.py
+++ b/wp1/web/selection_test.py
@@ -38,6 +38,12 @@ class SelectionTest(BaseWebTestcase):
               'http://test.server.fake/v1/builders/1a-2b-3c-4d/selection/latest.tsv',
           's_status':
               'OK',
+          's_zim_file_updated_at':
+              None,
+          's_zim_file_url':
+              None,
+          's_zimfarm_status':
+              'NOT_REQUESTED',
       }],
   }
 
@@ -68,6 +74,12 @@ class SelectionTest(BaseWebTestcase):
                   'http://test.server.fake/v1/builders/1a-2b-3c-4d/selection/latest.xls',
               's_status':
                   None,
+              's_zim_file_updated_at':
+                  None,
+              's_zim_file_url':
+                  None,
+              's_zimfarm_status':
+                  'NOT_REQUESTED',
           },
           {
               'id': '1a-2b-3c-4d',
@@ -82,6 +94,9 @@ class SelectionTest(BaseWebTestcase):
               's_extension': 'tsv',
               's_url': None,
               's_status': 'CAN_RETRY',
+              's_zim_file_updated_at': None,
+              's_zim_file_url': None,
+              's_zimfarm_status': 'NOT_REQUESTED',
           },
       ]
   }
@@ -100,6 +115,9 @@ class SelectionTest(BaseWebTestcase):
           's_extension': None,
           's_url': None,
           's_status': None,
+          's_zim_file_updated_at': None,
+          's_zim_file_url': None,
+          's_zimfarm_status': None,
       }]
   }
 
@@ -147,7 +165,7 @@ class SelectionTest(BaseWebTestcase):
                s_status, s_error_messages, s_zimfarm_status)
             VALUES
               (2, \'1a-2b-3c-4d\', "application/vnd.ms-excel", "20201225105544", 1,
-               "object_key_2", NULL, NULL, NULL)
+               "object_key_2", NULL, NULL, 'NOT_REQUESTED')
         ''')
       self.wp10db.commit()
       with client.session_transaction() as sess:

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -125,7 +125,7 @@ def get_webhook_url():
                                                  urllib.parse.quote(token))
 
 
-def _get_params(wp10db, builder):
+def _get_params(wp10db, builder, description='', long_description=''):
   if builder is None:
     raise ObjectNotFoundError('Given builder was None: %r' % builder)
 
@@ -148,13 +148,21 @@ def _get_params(wp10db, builder):
       'platform': 'wikimedia',
       'monitor': False,
       'flags': {
-          'mwUrl': 'https://%s/' % project,
-          'adminEmail': 'contact+wp1@kiwix.org',
-          'articleList': logic_selection.url_for_selection(selection),
-          'customZimTitle': util.safe_name(builder.b_name.decode('utf-8')),
+          'mwUrl':
+              'https://%s/' % project,
+          'adminEmail':
+              'contact+wp1@kiwix.org',
+          'articleList':
+              logic_selection.url_for_selection(selection),
+          'customZimTitle':
+              util.safe_name(builder.b_name.decode('utf-8')),
           # TODO(#584): Replace these placeholders with input from the user.
-          'customZimDescription': 'ZIM file created from a WP1 Selection',
-          'customZimLongDescription': 'ZIM file created from a WP1 Selection',
+          'customZimDescription':
+              description
+              if description else 'ZIM file created from a WP1 Selection',
+          'customZimLongDescription':
+              long_description
+              if long_description else 'ZIM file created from a WP1 Selection',
       }
   }
 
@@ -185,12 +193,19 @@ def _get_zimfarm_headers(token):
   return {"Authorization": "Token %s" % token, 'User-Agent': WP1_USER_AGENT}
 
 
-def schedule_zim_file(redis, wp10db, builder):
+def schedule_zim_file(redis,
+                      wp10db,
+                      builder,
+                      description='',
+                      long_description=''):
   token = get_zimfarm_token(redis)
   if token is None:
     raise ZimfarmError('Error retrieving auth token for request')
 
-  params = _get_params(wp10db, builder)
+  params = _get_params(wp10db,
+                       builder,
+                       description=description,
+                       long_description=long_description)
   base_url = get_zimfarm_url()
   headers = _get_zimfarm_headers(token)
 

--- a/wp10_test.up.sql
+++ b/wp10_test.up.sql
@@ -115,7 +115,8 @@ CREATE TABLE `selections` (
   s_error_messages BLOB,
   s_zimfarm_task_id VARBINARY(255),
   s_zimfarm_error_messages BLOB,
-  s_zimfarm_status VARBINARY(255) DEFAULT "REQUESTED"
+  s_zimfarm_status VARBINARY(255) DEFAULT "REQUESTED",
+  s_zim_file_updated_at BINARY(14)
 );
 
 CREATE TABLE custom (

--- a/wp10_test.up.sql
+++ b/wp10_test.up.sql
@@ -115,7 +115,7 @@ CREATE TABLE `selections` (
   s_error_messages BLOB,
   s_zimfarm_task_id VARBINARY(255),
   s_zimfarm_error_messages BLOB,
-  s_zimfarm_status VARBINARY(255) DEFAULT "REQUESTED",
+  s_zimfarm_status VARBINARY(255) DEFAULT "NOT_REQUESTED",
   s_zim_file_updated_at BINARY(14)
 );
 


### PR DESCRIPTION
This PR provides the frontend UI, written in Vue, to allow a user to create a ZIM file from their WP1 Selections. It provides a new page where the user can enter the `Description` and `LongDescription` of the ZIM file, request its creation, monitor its progress, and download the ZIM file when it is ready. The ZIM file also has an updated time which is displayed in the 'My Selections' table view, where the ZIM file can also be downloaded.

Fixes #484. Fixes #483. Fixes #482. Fixes #481.