### PR TITLE
Deal with ZIM file errors on the Zimfarm

### DIFF
--- a/wp1-frontend/cypress/e2e/myLists.cy.js
+++ b/wp1-frontend/cypress/e2e/myLists.cy.js
@@ -11,7 +11,7 @@ describe('the user selection list page', () => {
     it('successfully loads', () => {});
 
     it('displays the datatables view', () => {
-      cy.get('.dataTables_info').contains('Showing 1 to 9 of 9 entries');
+      cy.get('.dataTables_info').contains('Showing 1 to 10 of 10 entries');
     });
 
     it('displays list and its contents', () => {
@@ -77,6 +77,23 @@ describe('the user selection list page', () => {
         .contains('.btn-primary', 'Edit')
         .click();
       cy.url().should('eq', 'http://localhost:5173/#/selections/sparql/2');
+    });
+
+    it('displays a failed link for selection with failed ZIM', () => {
+      cy.contains('td', 'zim failed')
+        .parent('tr')
+        .within(() => {
+          cy.get('td').eq(7).get('span').should('contain', 'Failed');
+        });
+    });
+
+    it('goes to the zim page when the failed link is clicked', () => {
+      cy.contains('td', 'zim failed')
+        .parent('tr')
+        .within(() => {
+          cy.get('td').eq(7).get('span a').click();
+        });
+      cy.url().should('eq', 'http://localhost:5173/#/selections/3a3d4c8e/zim');
     });
 
     describe('when the selection has not been materialized', () => {

--- a/wp1-frontend/cypress/e2e/zimFile.cy.js
+++ b/wp1-frontend/cypress/e2e/zimFile.cy.js
@@ -128,6 +128,47 @@ describe('the zim file creation page', () => {
           cy.get('#loader').should('not.be.visible');
         });
       });
+
+      describe('when the zim file has failed', () => {
+        beforeEach(() => {
+          cy.intercept('v1/builders/1/zim/status', {
+            fixture: 'zim_status_failed.json',
+          }).as('status');
+          cy.visit('/#/selections/1/zim');
+          cy.wait('@identity');
+          cy.wait('@builder');
+          cy.wait('@status');
+        });
+
+        it('displays the form for entering descriptions', () => {
+          cy.get('#desc').should('be.visible');
+          cy.get('#longdesc').should('be.visible');
+        });
+
+        it('does not show the spinner', () => {
+          cy.get('#loader').should('not.be.visible');
+        });
+
+        it('displays the Request ZIM file button', () => {
+          cy.get('#request').should('be.visible');
+          cy.get('#request').should('not.have.attr', 'disabled');
+        });
+
+        describe('when the Request ZIM file button is clicked', () => {
+          beforeEach(() => {
+            cy.intercept('POST', 'v1/builders/1/zim', {
+              statusCode: 204,
+            }).as('request');
+
+            cy.get('#desc').click().type('Description from user');
+            cy.get('#request').click();
+          });
+
+          it('makes the ZIM file request', () => {
+            cy.wait('@request');
+          });
+        });
+      });
     });
 
     describe('and the builder is not found', () => {

--- a/wp1-frontend/cypress/fixtures/list_data.json
+++ b/wp1-frontend/cypress/fixtures/list_data.json
@@ -152,6 +152,23 @@
       "s_zim_file_updated_at": 1671287215,
       "s_zim_file_url": "https://localhost/zim/latest",
       "s_zimfarm_status": "FILE_READY"
+    },
+    {
+      "created_at": 1682181321,
+      "id": "3a3d4c8e",
+      "model": "wp1.selection.models.simple",
+      "name": "zim failed",
+      "project": "en.wikipedia.org",
+      "s_content_type": "text/tab-separated-values",
+      "s_extension": "tsv",
+      "s_id": "f2b74880-5c89-446b-80e1-460006d2199d",
+      "s_status": null,
+      "s_updated_at": 1682181322,
+      "s_url": "http://example.fake/latest.tsv",
+      "s_zim_file_updated_at": null,
+      "s_zim_file_url": null,
+      "s_zimfarm_status": "FAILED",
+      "updated_at": 1682181321
     }
   ]
 }

--- a/wp1-frontend/cypress/fixtures/zim_status_failed.json
+++ b/wp1-frontend/cypress/fixtures/zim_status_failed.json
@@ -1,0 +1,4 @@
+{
+  "status": "FAILED",
+  "error_url": "https://example.fake/failed"
+}

--- a/wp1-frontend/src/components/MyLists.vue
+++ b/wp1-frontend/src/components/MyLists.vue
@@ -79,6 +79,13 @@
                   :size="loaderSize"
                 ></pulse-loader>
               </td>
+              <td v-else-if="zimFailed(item)">
+                <span class="zim-failed"
+                  ><router-link :to="zimPathFor(item)"
+                    >Failed</router-link
+                  ></span
+                >
+              </td>
               <td v-else-if="!isPending(item) && !hasSelectionError(item)">
                 <router-link :to="zimPathFor(item)"
                   ><button type="button" class="btn btn-primary">
@@ -142,6 +149,9 @@ export default {
         item.s_zimfarm_status !== 'NOT_REQUESTED' &&
         item.s_zimfarm_status !== 'FILE_READY'
       );
+    },
+    zimFailed: function (item) {
+      return item.s_zimfarm_status === 'FAILED';
     },
     hasSelectionError: function (item) {
       return item.s_status !== null && item.s_status !== 'OK';
@@ -220,6 +230,10 @@ export default {
 
 <style scoped>
 @import '../cards.scss';
+
+.zim-failed a {
+  color: #dc3545 !important;
+}
 
 .failed {
   display: inline-block;

--- a/wp1-frontend/src/components/ZimFile.vue
+++ b/wp1-frontend/src/components/ZimFile.vue
@@ -38,9 +38,15 @@
             Your ZIM file is ready! Click the button below to download it. You
             can also always download it from the My Selections page.
           </p>
+          <p v-else-if="status === 'FAILED'" class="errors">
+            There was an error creating your ZIM file. More information may be
+            available <a :href="error_url">via the Zimfarm API</a>. If you feel
+            this was a transient or external error, you can try requesting your
+            ZIM file again below.
+          </p>
         </div>
       </div>
-      <div v-if="status === 'NOT_REQUESTED'" class="row">
+      <div v-if="status === 'NOT_REQUESTED' || status === 'FAILED'" class="row">
         <div class="col-lg-6 col-md-9 mx-4">
           <form
             ref="form"
@@ -74,7 +80,7 @@
                 placeholder="ZIM file created from a WP1 Selection"
               ></textarea>
             </div>
-            <div v-if="!success" class="error-list error">
+            <div v-if="!success" class="error-list errors">
               <p>The following errors occurred:</p>
               <ul>
                 <li v-for="msg in errorMessages" v-bind:key="msg">
@@ -82,25 +88,25 @@
                 </li>
               </ul>
             </div>
-            <div>
-              <button
-                id="request"
-                v-on:click.prevent="onSubmit"
-                class="btn btn-primary"
-                type="button"
-                :disabled="processing"
-              >
-                Request ZIM file
-              </button>
-              <pulse-loader
-                id="loader"
-                class="loader"
-                :loading="processing || showLoader"
-                :color="loaderColor"
-                :size="loaderSize"
-              ></pulse-loader>
-            </div>
           </form>
+          <div>
+            <button
+              id="request"
+              v-on:click.prevent="onSubmit"
+              class="btn btn-primary"
+              type="button"
+              :disabled="processing"
+            >
+              Request ZIM file
+            </button>
+            <pulse-loader
+              id="loader"
+              class="loader"
+              :loading="processing || showLoader"
+              :color="loaderColor"
+              :size="loaderSize"
+            ></pulse-loader>
+          </div>
         </div>
       </div>
       <div v-else class="row">
@@ -153,6 +159,7 @@ export default {
       serverError: false,
       errorMessages: [],
       status: null,
+      error_url: '',
       success: true,
     };
   },
@@ -195,6 +202,8 @@ export default {
       this.status = data.status;
       if (this.status === 'FILE_READY') {
         this.stopProgressPolling();
+      } else if (this.status === 'FAILED') {
+        this.error_url = data.error_url;
       } else if (this.status !== 'NOT_REQUESTED') {
         this.startProgressPolling();
       }

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -586,7 +586,11 @@ class BuildersTest(BaseWebTestcase):
     with self.app.test_client() as client:
       rv = client.get('/v1/builders/%s/zim/status' % builder_id)
     self.assertEqual('200 OK', rv.status)
-    self.assertEqual({'status': 'FILE_READY'}, rv.get_json())
+    self.assertEqual(
+        {
+            'error_url': 'https://fake.farm/v1/tasks/task-id-1234',
+            'status': 'FILE_READY'
+        }, rv.get_json())
 
   @patch('wp1.logic.builder.zimfarm.zim_file_url_for_task_id',
          return_value='http://fake-file-host.fake/1234/file.zim')


### PR DESCRIPTION
Fixes #604.

Check for `status: failed` in the JSON returned by the Zimfarm, both when the webhook is called and when polling for file ready status. If a failure state is detected in either case, mark the Selection Zim status as `FAILED`.

When this status is encountered in the frontend, display a failure message with an option to retry. Also display failed status in the My Lists table with an option to go to the Zim file page and retry.