### PR TITLE
Re-factor ZIM files to their own table

### DIFF
--- a/db/migrations/20230427_01_QJ8ZK-add-zim-file-table.py
+++ b/db/migrations/20230427_01_QJ8ZK-add-zim-file-table.py
@@ -11,8 +11,8 @@ steps = [
         'CREATE TABLE zim_files ('
         '  z_id INTEGER NOT NULL PRIMARY KEY AUTO_INCREMENT,'
         '  z_selection_id VARBINARY(255) NOT NULL,'
-        '  z_task_id VARBINARY(255) NOT NULL,'
         '  z_status VARBINARY(255) DEFAULT "NOT_REQUESTED",'
+        '  z_task_id VARBINARY(255),'
         '  z_requested_at BINARY(14),'
         '  z_updated_at BINARY(14)'
         ')', 'DROP TABLE zim_files'),

--- a/db/migrations/20230427_01_QJ8ZK-add-zim-file-table.py
+++ b/db/migrations/20230427_01_QJ8ZK-add-zim-file-table.py
@@ -1,0 +1,24 @@
+"""
+Add ZIM file table
+"""
+
+from yoyo import step
+
+__depends__ = {'20230423_01_9nFkK-add-s-zim-file-requested-at'}
+
+steps = [
+    step(
+        'CREATE TABLE zim_files ('
+        '  z_id INTEGER NOT NULL PRIMARY KEY AUTO_INCREMENT,'
+        '  z_selection_id VARBINARY(255) NOT NULL,'
+        '  z_task_id VARBINARY(255) NOT NULL,'
+        '  z_status VARBINARY(255) DEFAULT "NOT_REQUESTED",'
+        '  z_requested_at BINARY(14),'
+        '  z_updated_at BINARY(14)'
+        ')', 'DROP TABLE zim_files'),
+    step(
+        'INSERT INTO zim_files (z_selection_id, z_task_id, z_status, z_requested_at, z_updated_at) '
+        'SELECT s_id, s_zimfarm_task_id, s_zimfarm_status, s_zim_file_requested_at, s_zim_file_updated_at '
+        'FROM selections WHERE s_zimfarm_task_id IS NOT NULL',
+        'DELETE FROM zim_files')
+]

--- a/db/migrations/20230427_02_Sareg-drop-selections-zim-file-fields.py
+++ b/db/migrations/20230427_02_Sareg-drop-selections-zim-file-fields.py
@@ -1,0 +1,14 @@
+"""
+Drop selections zim file fields
+"""
+
+from yoyo import step
+
+__depends__ = {'20230427_01_QJ8ZK-add-zim-file-table'}
+
+steps = [
+    step(
+        'ALTER TABLE selections'
+        '  DROP s_zimfarm_status, DROP s_zimfarm_error_messages, DROP s_zimfarm_task_id,'
+        '  DROP s_zim_file_requested_at, DROP s_zim_file_updated_at'),
+]

--- a/db/migrations/20230429_01_e8yCB-add-zim-file-versions.py
+++ b/db/migrations/20230429_01_e8yCB-add-zim-file-versions.py
@@ -1,0 +1,16 @@
+"""
+Add zim file versions
+"""
+
+from yoyo import step
+
+__depends__ = {'20230427_02_Sareg-drop-selections-zim-file-fields'}
+
+steps = [
+    step('ALTER TABLE zim_files ADD COLUMN z_version INTEGER',
+         'ALTER TABLE zim_files DROP COLUMN z_version'),
+    step('ALTER TABLE selections ADD COLUMN s_zim_version INTEGER',
+         'ALTER TABLE selections DROP COLUMN s_zim_version'),
+    step('UPDATE selections SET s_zim_version = 1'),
+    step('UPDATE zim_files SET z_version = 1'),
+]

--- a/db/migrations/20230513_01_4PsR6-add-descriptions-to-zim-file-table.py
+++ b/db/migrations/20230513_01_4PsR6-add-descriptions-to-zim-file-table.py
@@ -1,0 +1,14 @@
+"""
+Add descriptions to zim file table
+"""
+
+from yoyo import step
+
+__depends__ = {'20230429_01_e8yCB-add-zim-file-versions'}
+
+steps = [
+    step("ALTER TABLE zim_files ADD COLUMN z_long_description BLOB",
+         "ALTER TABLE zim_files DROP COLUMN z_long_description"),
+    step("ALTER TABLE zim_files ADD COLUMN z_description TINYBLOB",
+         "ALTER TABLE zim_files DROP COLUMN z_description")
+]

--- a/wp1-frontend/cypress/fixtures/list_data.json
+++ b/wp1-frontend/cypress/fixtures/list_data.json
@@ -13,9 +13,9 @@
       "s_content_type": "text/tab-separated-values",
       "s_extension": "tsv",
       "s_url": "https://www.example.fake/abcd-efgh",
-      "s_zim_file_updated_at": null,
-      "s_zim_file_url": null,
-      "s_zimfarm_status": "NOT_REQUESTED"
+      "z_updated_at": null,
+      "z_url": null,
+      "z_status": "NOT_REQUESTED"
     },
     {
       "id": 2,
@@ -30,9 +30,9 @@
       "s_content_type": null,
       "s_extension": null,
       "s_url": null,
-      "s_zim_file_updated_at": null,
-      "s_zim_file_url": null,
-      "s_zimfarm_status": "NOT_REQUESTED"
+      "z_updated_at": null,
+      "z_url": null,
+      "z_status": "NOT_REQUESTED"
     },
     {
       "created_at": 1670251154,
@@ -47,9 +47,9 @@
       "s_updated_at": 1670251157,
       "s_url": null,
       "updated_at": 1670261154,
-      "s_zim_file_updated_at": null,
-      "s_zim_file_url": null,
-      "s_zimfarm_status": "NOT_REQUESTED"
+      "z_updated_at": null,
+      "z_url": null,
+      "z_status": "NOT_REQUESTED"
     },
     {
       "created_at": 1669778531,
@@ -64,9 +64,9 @@
       "s_updated_at": 1670253950,
       "s_url": null,
       "updated_at": 1670247215,
-      "s_zim_file_updated_at": null,
-      "s_zim_file_url": null,
-      "s_zimfarm_status": "NOT_REQUESTED"
+      "z_updated_at": null,
+      "z_url": null,
+      "z_status": "NOT_REQUESTED"
     },
     {
       "created_at": 1669778531,
@@ -81,9 +81,9 @@
       "s_updated_at": 1670253950,
       "s_url": null,
       "updated_at": 1670247215,
-      "s_zim_file_updated_at": null,
-      "s_zim_file_url": null,
-      "s_zimfarm_status": "NOT_REQUESTED"
+      "z_updated_at": null,
+      "z_url": null,
+      "z_status": "NOT_REQUESTED"
     },
     {
       "created_at": 1669778531,
@@ -98,9 +98,9 @@
       "s_updated_at": 1670253950,
       "s_url": null,
       "updated_at": 1670267215,
-      "s_zim_file_updated_at": null,
-      "s_zim_file_url": null,
-      "s_zimfarm_status": "NOT_REQUESTED"
+      "z_updated_at": null,
+      "z_url": null,
+      "z_status": "NOT_REQUESTED"
     },
     {
       "created_at": 1669678531,
@@ -115,9 +115,9 @@
       "s_updated_at": 1671253950,
       "s_url": "https://www.example.fake/1234-hijk",
       "updated_at": 1670267215,
-      "s_zim_file_updated_at": null,
-      "s_zim_file_url": null,
-      "s_zimfarm_status": "NOT_REQUESTED"
+      "z_updated_at": null,
+      "z_url": null,
+      "z_status": "NOT_REQUESTED"
     },
     {
       "created_at": 1669679000,
@@ -132,9 +132,9 @@
       "s_updated_at": 1671263950,
       "s_url": "https://www.example.fake/1234-hijk",
       "updated_at": 1670287215,
-      "s_zim_file_updated_at": null,
-      "s_zim_file_url": null,
-      "s_zimfarm_status": "REQUESTED"
+      "z_updated_at": null,
+      "z_url": null,
+      "z_status": "REQUESTED"
     },
     {
       "created_at": 1669679000,
@@ -149,9 +149,9 @@
       "s_updated_at": 1671263950,
       "s_url": "https://www.example.fake/1234-hijk",
       "updated_at": 1670287215,
-      "s_zim_file_updated_at": 1671287215,
-      "s_zim_file_url": "https://localhost/zim/latest",
-      "s_zimfarm_status": "FILE_READY"
+      "z_updated_at": 1671287215,
+      "z_url": "https://localhost/zim/latest",
+      "z_status": "FILE_READY"
     },
     {
       "created_at": 1682181321,
@@ -165,10 +165,10 @@
       "s_status": null,
       "s_updated_at": 1682181322,
       "s_url": "http://example.fake/latest.tsv",
-      "s_zim_file_updated_at": null,
-      "s_zim_file_url": null,
-      "s_zimfarm_status": "FAILED",
-      "updated_at": 1682181321
+      "updated_at": 1682181321,
+      "z_updated_at": null,
+      "z_url": null,
+      "z_status": "FAILED"
     }
   ]
 }

--- a/wp1-frontend/src/components/MyLists.vue
+++ b/wp1-frontend/src/components/MyLists.vue
@@ -65,12 +65,12 @@
                   ></span>
                 </div>
               </td>
-              <td v-if="item.s_zim_file_url && !isPending(item)">
-                {{ localDate(item.s_zim_file_updated_at) }}
+              <td v-if="item.z_url && !isPending(item)">
+                {{ localDate(item.z_updated_at) }}
               </td>
               <td v-else>-</td>
-              <td v-if="item.s_zim_file_url && !isPending(item)">
-                <a :href="item.s_zim_file_url">Download ZIM</a>
+              <td v-if="item.z_url && !isPending(item)">
+                <a :href="item.z_url">Download ZIM</a>
               </td>
               <td v-else-if="hasPendingZim(item)">
                 <pulse-loader
@@ -146,12 +146,12 @@ export default {
     hasPendingZim: function (item) {
       return (
         item.s_status === 'OK' &&
-        item.s_zimfarm_status !== 'NOT_REQUESTED' &&
-        item.s_zimfarm_status !== 'FILE_READY'
+        item.z_status !== 'NOT_REQUESTED' &&
+        item.z_status !== 'FILE_READY'
       );
     },
     zimFailed: function (item) {
-      return item.s_zimfarm_status === 'FAILED';
+      return item.z_status === 'FAILED';
     },
     hasSelectionError: function (item) {
       return item.s_status !== null && item.s_status !== 'OK';

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -298,9 +298,11 @@ def schedule_zim_file(redis,
   with wp10db.cursor() as cursor:
     cursor.execute(
         '''UPDATE zim_files SET
-             z_status = 'REQUESTED', z_task_id = %s, z_requested_at = %s
+             z_status = 'REQUESTED', z_task_id = %s, z_requested_at = %s,
+             z_long_description = %s, z_description = %s
            WHERE z_selection_id = %s
-        ''', (task_id, utcnow().strftime(TS_FORMAT_WP10), selection.s_id))
+        ''', (task_id, utcnow().strftime(TS_FORMAT_WP10), description or
+              None, long_description or None, selection.s_id))
   wp10db.commit()
 
   return task_id

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -226,12 +226,15 @@ def latest_zim_file_url_for(wp10db, builder_id):
   if selection is None:
     return None
 
-  if selection.s_zimfarm_status != b'FILE_READY':
+  zim_file = logic_selection.latest_zim_file_for_selection(wp10db, selection)
+  if zim_file is None:
+    return None
+  if zim_file.z_status != b'FILE_READY':
     logger.warning('Attempt to get ZIM URL before file ready, builder id=%s',
                    builder_id)
     return None
 
-  return logic_selection.zim_file_url_for_selection(selection)
+  return logic_selection.url_from_zim_file(zim_file)
 
 
 def latest_selections_with_errors(wp10db, builder_id):
@@ -308,7 +311,11 @@ def latest_zimfarm_status(wp10db, builder_id):
                                    'text/tab-separated-values')
   if selection is None:
     return None
-  return selection.s_zimfarm_status.decode('utf-8')
+
+  zim_file = logic_selection.latest_zim_file_for_selection(wp10db, selection)
+  if zim_file is None:
+    return None
+  return zim_file.z_status.decode('utf-8')
 
 
 def latest_zimfarm_task_url(wp10db, builder_id):
@@ -318,7 +325,7 @@ def latest_zimfarm_task_url(wp10db, builder_id):
     return None
 
   zim_file = logic_selection.latest_zim_file_for_selection(wp10db, selection)
-  if zim_file.z_task_id is None:
+  if zim_file is None or zim_file.z_task_id is None:
     return None
 
   base_url = zimfarm.get_zimfarm_url()

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -235,16 +235,17 @@ class BuilderTest(BaseWpOneDbTest):
       cursor.execute(
           '''INSERT INTO selections
                (s_id, s_builder_id, s_content_type, s_updated_at, s_version,
-                s_object_key, s_status, s_error_messages)
+                s_object_key, s_status, s_error_messages, s_zim_version)
              VALUES
-               (%s, %s, %s, "20191225044444", %s, %s, %s, %s)
+               (%s, %s, %s, "20191225044444", %s, %s, %s, %s, 1)
           ''', (id_, builder_id, content_type, version, object_key, status,
                 error_messages))
       cursor.execute(
           '''INSERT INTO zim_files
-               (z_selection_id, z_task_id, z_status, z_updated_at, z_requested_at)
+               (z_selection_id, z_task_id, z_status, z_updated_at,
+                z_requested_at, z_version)
              VALUES
-               (%s, "5678", %s, %s, "20230101020202")
+               (%s, "5678", %s, %s, "20230101020202", 1)
           ''', (id_, zimfarm_status, zim_file_updated_at))
     self.wp10db.commit()
 

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -83,10 +83,10 @@ def latest_zim_file_for_selection(wp10db, selection):
     return ZimFile(**db_zim)
 
 
-def zim_file_url_for_selection(selection):
-  if not selection:
-    raise ValueError('Cannot get zim file url for empty selection')
-  return zim_file_url_for(selection.s_zimfarm_task_id)
+def url_from_zim_file(zim_file):
+  if not zim_file:
+    raise ValueError('Cannot get url from empty zim file')
+  return zim_file_url_for(zim_file.z_task_id)
 
 
 def zim_file_url_for(task_id):

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -75,8 +75,10 @@ def latest_zim_file_for_selection(wp10db, selection):
     raise ValueError('Cannot get zim file for empty selection')
 
   with wp10db.cursor() as cursor:
-    cursor.execute('SELECT * FROM zim_files WHERE z_selection_id = %s',
-                   (selection.s_id,))
+    cursor.execute(
+        'SELECT * FROM zim_files WHERE'
+        ' z_selection_id = %s AND z_version = %s',
+        (selection.s_id, selection.s_zim_version))
     db_zim = cursor.fetchone()
     if db_zim is None:
       return None

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -7,6 +7,7 @@ import attr
 
 from wp1.constants import CONTENT_TYPE_TO_EXT, TS_FORMAT_WP10
 from wp1.models.wp10.selection import Selection
+from wp1.models.wp10.zim_file import ZimFile
 from wp1.storage import connect_storage
 from wp1.logic import util
 from wp1.timestamp import utcnow
@@ -29,14 +30,15 @@ def insert_selection(wp10db, selection):
     cursor.execute(
         '''INSERT INTO selections
              (s_id, s_builder_id, s_version, s_content_type, s_updated_at,
-              s_object_key, s_status, s_error_messages, s_zimfarm_task_id,
-              s_zim_file_updated_at, s_zim_file_requested_at)
+              s_object_key, s_status, s_error_messages, s_zim_version)
              VALUES
              (%(s_id)s, %(s_builder_id)s, %(s_version)s, %(s_content_type)s,
               %(s_updated_at)s, %(s_object_key)s, %(s_status)s, %(s_error_messages)s,
-              %(s_zimfarm_task_id)s, %(s_zim_file_updated_at)s,
-              %(s_zim_file_requested_at)s)
+              1)
     ''', attr.asdict(selection))
+    cursor.execute(
+        'INSERT INTO zim_files (z_selection_id, z_status, z_version)'
+        ' VALUES (%s, "NOT_REQUESTED", 1)', (selection.s_id,))
   wp10db.commit()
 
 
@@ -68,6 +70,19 @@ def url_for(object_key):
   return '%s/%s' % (S3_PUBLIC_URL, path)
 
 
+def latest_zim_file_for_selection(wp10db, selection):
+  if not selection:
+    raise ValueError('Cannot get zim file for empty selection')
+
+  with wp10db.cursor() as cursor:
+    cursor.execute('SELECT * FROM zim_files WHERE z_selection_id = %s',
+                   (selection.s_id,))
+    db_zim = cursor.fetchone()
+    if db_zim is None:
+      return None
+    return ZimFile(**db_zim)
+
+
 def zim_file_url_for_selection(selection):
   if not selection:
     raise ValueError('Cannot get zim file url for empty selection')
@@ -81,13 +96,13 @@ def zim_file_url_for(task_id):
 def zim_file_requested_at_for(wp10db, task_id):
   with wp10db.cursor() as cursor:
     cursor.execute(
-        'SELECT s_zim_file_requested_at '
-        'FROM selections WHERE s_zimfarm_task_id = %s', task_id)
+        'SELECT z_requested_at '
+        'FROM zim_files WHERE z_task_id = %s', task_id)
     data = cursor.fetchone()
-    if data is None or data['s_zim_file_requested_at'] is None:
+    if data is None or data['z_requested_at'] is None:
       return None
 
-  return util.wp10_timestamp_to_unix(data['s_zim_file_requested_at'])
+  return util.wp10_timestamp_to_unix(data['z_requested_at'])
 
 
 def object_key_for(selection_id,
@@ -173,14 +188,12 @@ def update_zimfarm_task(wp10db, task_id, status, set_updated_now=False):
       updated_at = utcnow().strftime(TS_FORMAT_WP10).encode('utf-8')
       with wp10db.cursor() as cursor:
         cursor.execute(
-            '''UPDATE selections SET
-                s_zimfarm_status = %s, s_zim_file_updated_at = %s
-               WHERE s_zimfarm_task_id = %s''', (status, updated_at, task_id))
+            '''UPDATE zim_files SET z_status = %s, z_updated_at = %s
+               WHERE z_task_id = %s''', (status, updated_at, task_id))
         found = bool(cursor.rowcount)
     else:
-      cursor.execute(
-          'UPDATE selections SET s_zimfarm_status = %s WHERE s_zimfarm_task_id = %s',
-          (status, task_id))
+      cursor.execute('UPDATE zim_files SET z_status = %s WHERE z_task_id = %s',
+                     (status, task_id))
       found = bool(cursor.rowcount)
   wp10db.commit()
   return found

--- a/wp1/logic/selection_test.py
+++ b/wp1/logic/selection_test.py
@@ -5,6 +5,7 @@ import attr
 from wp1.base_db_test import BaseWpOneDbTest
 import wp1.logic.selection as logic_selection
 from wp1.models.wp10.selection import Selection
+from wp1.models.wp10.zim_file import ZimFile
 
 
 def _get_selection(wp10db):
@@ -12,6 +13,14 @@ def _get_selection(wp10db):
     cursor.execute('SELECT * FROM selections LIMIT 1')
     db_selection = cursor.fetchone()
     return Selection(**db_selection)
+
+
+def _get_zim_file_for_selection(wp10db, selection_id):
+  with wp10db.cursor() as cursor:
+    cursor.execute('SELECT * FROM zim_files WHERE z_selection_id = %s LIMIT 1',
+                   (selection_id,))
+    db_zim_file = cursor.fetchone()
+    return ZimFile(**db_zim_file)
 
 
 class SelectionTest(BaseWpOneDbTest):
@@ -23,34 +32,51 @@ class SelectionTest(BaseWpOneDbTest):
         s_builder_id=b'100',
         s_content_type=b'text/tab-separated-values',
         s_version=1,
+        s_zim_version=1,
         s_updated_at=b'20190830112844',
         s_object_key=b'selections/foo.bar.model/deadbeef/name.tsv',
-        s_zimfarm_status=b'NOT_REQUESTED',
-        s_zimfarm_task_id=b'xyz1',
-        s_zim_file_requested_at=b'20230101020202')
+    )
+    self.zim_file = ZimFile(z_id=1,
+                            z_selection_id=b'deadbeef',
+                            z_status=b'NOT_REQUESTED',
+                            z_task_id=b'xyz1',
+                            z_requested_at=b'20230101020202')
 
-  def _insert_selections(self, selections=None):
+  def _insert_selections(self, selections=None, zim_files=None):
     if selections is None:
       selections = [self.selection]
+    if zim_files is None:
+      zim_files = [self.zim_file]
     selections = [attr.asdict(s) for s in selections]
+    zim_files = [attr.asdict(z) for z in zim_files]
 
     with self.wp10db.cursor() as cursor:
       cursor.executemany(
           '''INSERT INTO selections
               (s_id, s_builder_id, s_version, s_content_type, s_updated_at,
-               s_object_key, s_zimfarm_task_id, s_zim_file_requested_at, s_zimfarm_status)
+               s_object_key)
              VALUES
               (%(s_id)s, %(s_builder_id)s, %(s_version)s, %(s_content_type)s,
-               %(s_updated_at)s, %(s_object_key)s, %(s_zimfarm_task_id)s,
-               %(s_zim_file_requested_at)s, %(s_zimfarm_status)s)
-          ''', selections)
+               %(s_updated_at)s, %(s_object_key)s)
+           ''', selections)
+      cursor.executemany(
+          '''INSERT INTO zim_files
+             (z_id, z_selection_id, z_status, z_task_id, z_requested_at)
+           VALUES
+             (%(z_id)s, %(z_selection_id)s, %(z_status)s, %(z_task_id)s,
+              %(z_requested_at)s)
+          ''', zim_files)
     self.wp10db.commit()
 
   def test_insert_selection(self):
     logic_selection.insert_selection(self.wp10db, self.selection)
     actual = _get_selection(self.wp10db)
-    self.maxDiff = None
+    expected_zim = ZimFile(z_id=1,
+                           z_selection_id=self.selection.s_id,
+                           z_version=1)
+    actual_zim = _get_zim_file_for_selection(self.wp10db, self.selection.s_id)
     self.assertEqual(self.selection, actual)
+    self.assertEqual(expected_zim, actual_zim)
 
   def test_get_next_version_empty_table(self):
     actual = logic_selection.get_next_version(self.wp10db, 100,

--- a/wp1/models/wp10/selection.py
+++ b/wp1/models/wp10/selection.py
@@ -26,11 +26,7 @@ class Selection:
   data = attr.ib(default=None)
   s_status = attr.ib(default=None)
   s_error_messages = attr.ib(default=None)
-  s_zimfarm_task_id = attr.ib(default=None)
-  s_zimfarm_status = attr.ib(default=None)
-  s_zimfarm_error_messages = attr.ib(default=None)
-  s_zim_file_updated_at = attr.ib(default=None)
-  s_zim_file_requested_at = attr.ib(default=None)
+  s_zim_version = attr.ib(default=None)
 
   def set_id(self):
     self.s_id = str(uuid.uuid4()).encode('utf-8')

--- a/wp1/models/wp10/selection.py
+++ b/wp1/models/wp10/selection.py
@@ -47,21 +47,3 @@ class Selection:
   def set_updated_at_now(self):
     """Sets the updated_at field to a timestamp that is equal to now"""
     self.set_updated_at_dt(utcnow())
-
-  @property
-  def zim_file_updated_at_dt(self):
-    """The timestamp parsed into a datetime.datetime object."""
-    return datetime.datetime.strptime(
-        self.s_zim_file_updated_at.decode('utf-8'), TS_FORMAT_WP10)
-
-  def set_zim_file_updated_at_dt(self, dt):
-    """Sets the zim_file_updated_at field using a datetime.datetime object"""
-    if dt is None:
-      logger.warning(
-          'Attempt to set selection zim_file_updated_at to None ignored')
-      return
-    self.s_zim_file_updated_at = dt.strftime(TS_FORMAT_WP10).encode('utf-8')
-
-  def set_zim_file_updated_at_now(self):
-    """Sets the zim_file_updated_at field to a timestamp that is equal to now"""
-    self.set_zim_file_updated_at_dt(utcnow())

--- a/wp1/models/wp10/selection_test.py
+++ b/wp1/models/wp10/selection_test.py
@@ -13,8 +13,7 @@ class ModelsSelectionTest(BaseWpOneDbTest):
                                s_builder_id=100,
                                s_content_type='text/tab-separated-values',
                                s_version=1,
-                               s_updated_at=b'20190830112844',
-                               s_zim_file_updated_at=b'20200830112844')
+                               s_updated_at=b'20190830112844')
 
   def test_updated_at_dt(self):
     dt = self.selection.updated_at_dt
@@ -37,25 +36,3 @@ class ModelsSelectionTest(BaseWpOneDbTest):
     self.selection.set_updated_at_now()
 
     self.assertEqual(b'20191225044444', self.selection.s_updated_at)
-
-  def test_zim_file_updated_at_dt(self):
-    dt = self.selection.zim_file_updated_at_dt
-    self.assertEqual(2020, dt.year)
-    self.assertEqual(8, dt.month)
-    self.assertEqual(30, dt.day)
-    self.assertEqual(11, dt.hour)
-    self.assertEqual(28, dt.minute)
-    self.assertEqual(44, dt.second)
-
-  def test_set_zim_file_updated_at_dt(self):
-    dt = datetime.datetime(2020, 12, 15, 9, 30, 55)
-    self.selection.set_zim_file_updated_at_dt(dt)
-
-    self.assertEqual(b'20201215093055', self.selection.s_zim_file_updated_at)
-
-  @patch('wp1.models.wp10.selection.utcnow',
-         return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
-  def test_set_zim_file_updated_at_now(self, patched_now):
-    self.selection.set_zim_file_updated_at_now()
-
-    self.assertEqual(b'20191225044444', self.selection.s_zim_file_updated_at)

--- a/wp1/models/wp10/zim_file.py
+++ b/wp1/models/wp10/zim_file.py
@@ -17,6 +17,8 @@ class ZimFile:
   z_version = attr.ib(default=None)
   z_requested_at = attr.ib(default=None)
   z_updated_at = attr.ib(default=None)
+  z_long_description = attr.ib(default=None)
+  z_description = attr.ib(default=None)
 
   @property
   def updated_at_dt(self):

--- a/wp1/models/wp10/zim_file.py
+++ b/wp1/models/wp10/zim_file.py
@@ -1,0 +1,14 @@
+import attr
+
+
+@attr.s
+class ZimFile:
+  table_name = 'zim_files'
+
+  z_id = attr.ib()
+  z_selection_id = attr.ib()
+  z_task_id = attr.ib()
+  z_status = attr.ib(default='NOT_REQUESTED')
+  z_version = attr.ib(default=None)
+  z_requested_at = attr.ib(default=None)
+  z_updated_at = attr.ib(default=None)

--- a/wp1/models/wp10/zim_file.py
+++ b/wp1/models/wp10/zim_file.py
@@ -12,8 +12,8 @@ class ZimFile:
 
   z_id = attr.ib()
   z_selection_id = attr.ib()
-  z_task_id = attr.ib()
-  z_status = attr.ib(default='NOT_REQUESTED')
+  z_status = attr.ib(default=b'NOT_REQUESTED')
+  z_task_id = attr.ib(default=None)
   z_version = attr.ib(default=None)
   z_requested_at = attr.ib(default=None)
   z_updated_at = attr.ib(default=None)

--- a/wp1/models/wp10/zim_file.py
+++ b/wp1/models/wp10/zim_file.py
@@ -1,4 +1,9 @@
+import datetime
+
 import attr
+
+from wp1.constants import TS_FORMAT_WP10
+from wp1.timestamp import utcnow
 
 
 @attr.s
@@ -12,3 +17,21 @@ class ZimFile:
   z_version = attr.ib(default=None)
   z_requested_at = attr.ib(default=None)
   z_updated_at = attr.ib(default=None)
+
+  @property
+  def updated_at_dt(self):
+    """The timestamp parsed into a datetime.datetime object."""
+    return datetime.datetime.strptime(self.z_updated_at.decode('utf-8'),
+                                      TS_FORMAT_WP10)
+
+  def set_updated_at_dt(self, dt):
+    """Sets the updated_at field using a datetime.datetime object"""
+    if dt is None:
+      logger.warning(
+          'Attempt to set selection zim_file_updated_at to None ignored')
+      return
+    self.z_updated_at = dt.strftime(TS_FORMAT_WP10).encode('utf-8')
+
+  def set_updated_at_now(self):
+    """Sets the zim_file_updated_at field to a timestamp that is equal to now"""
+    self.set_updated_at_dt(utcnow())

--- a/wp1/models/wp10/zim_file_test.py
+++ b/wp1/models/wp10/zim_file_test.py
@@ -1,0 +1,37 @@
+import datetime
+from unittest.mock import patch
+
+from wp1.base_db_test import BaseWpOneDbTest
+from wp1.models.wp10.zim_file import ZimFile
+
+
+class ZimFileTest(BaseWpOneDbTest):
+
+  def setUp(self):
+    super().setUp()
+    self.zim_file = ZimFile(z_id=1,
+                            z_selection_id='deadbeef',
+                            z_task_id='abcd-5678',
+                            z_updated_at=b'20190830112844')
+
+  def test_updated_at_dt(self):
+    dt = self.zim_file.updated_at_dt
+    self.assertEqual(2019, dt.year)
+    self.assertEqual(8, dt.month)
+    self.assertEqual(30, dt.day)
+    self.assertEqual(11, dt.hour)
+    self.assertEqual(28, dt.minute)
+    self.assertEqual(44, dt.second)
+
+  def test_set_updated_at_dt(self):
+    dt = datetime.datetime(2020, 12, 15, 9, 30, 55)
+    self.zim_file.set_updated_at_dt(dt)
+
+    self.assertEqual(b'20201215093055', self.zim_file.z_updated_at)
+
+  @patch('wp1.models.wp10.zim_file.utcnow',
+         return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
+  def test_set_updated_at_now(self, patched_now):
+    self.zim_file.set_updated_at_now()
+
+    self.assertEqual(b'20191225044444', self.zim_file.z_updated_at)

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -138,6 +138,8 @@ def create_zim_file_for_builder(builder_id):
 
   data = flask.request.get_json()
   desc = data.get('description')
+  if not desc:
+    return 'Description is required for ZIM file', 400
   long_desc = data.get('long_description')
 
   try:

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -83,14 +83,14 @@ class BuildersTest(BaseWebTestcase):
       cursor.executemany(
           '''INSERT INTO selections
                (s_id, s_builder_id, s_content_type, s_updated_at,
-                s_version, s_object_key)
-             VALUES (%s, %s, %s, %s, %s, %s)
+                s_version, s_object_key, s_zim_version)
+             VALUES (%s, %s, %s, %s, %s, %s, 1)
       ''', [s[:6] for s in selections])
       cursor.execute(
           '''INSERT INTO zim_files
-               (z_id, z_selection_id, z_task_id, z_status)
+               (z_id, z_selection_id, z_task_id, z_status, z_version)
              VALUES
-               (1, %s, %s, %s)''', (
+               (1, %s, %s, %s, 1)''', (
               selections[2][0],
               selections[2][6],
               selections[2][7],

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -71,36 +71,30 @@ class BuildersTest(BaseWebTestcase):
     return self.builder.b_id.decode('utf-8')
 
   def _insert_selections(self, builder_id):
+    selections = [(1, builder_id, 'text/tab-separated-values', '20201225105544',
+                   1, 'object_key1'),
+                  (2, builder_id, 'application/vnd.ms-excel', '20201225105544',
+                   1, 'object_key2'),
+                  (3, builder_id, 'text/tab-separated-values', '20201225105544',
+                   2, 'latest_object_key_tsv', 'task-id-1234', 'FILE_READY'),
+                  (4, builder_id, 'application/vnd.ms-excel', '20201225105544',
+                   2, 'latest_object_key_xls')]
     with self.wp10db.cursor() as cursor:
-      cursor.execute(
+      cursor.executemany(
           '''INSERT INTO selections
                (s_id, s_builder_id, s_content_type, s_updated_at,
                 s_version, s_object_key)
-             VALUES
-               (1, %s, "text/tab-separated-values", "20201225105544",
-                1, "object_key1")''', builder_id)
+             VALUES (%s, %s, %s, %s, %s, %s)
+      ''', [s[:6] for s in selections])
       cursor.execute(
-          '''INSERT INTO selections
-                (s_id, s_builder_id, s_content_type, s_updated_at,
-                 s_version, s_object_key)
-              VALUES
-                (2, %s, "application/vnd.ms-excel", "20201225105544",
-                 1, "object_key2")''', builder_id)
-      cursor.execute(
-          '''INSERT INTO selections
-               (s_id, s_builder_id, s_content_type, s_updated_at,
-                s_version, s_object_key, s_zimfarm_task_id, s_zimfarm_status)
+          '''INSERT INTO zim_files
+               (z_id, z_selection_id, z_task_id, z_status)
              VALUES
-               (3, %s, "text/tab-separated-values", "20201225105544",
-                2, "latest_object_key_tsv", "task-id-1234", "FILE_READY")''',
-          builder_id)
-      cursor.execute(
-          '''INSERT INTO selections
-               (s_id, s_builder_id, s_content_type, s_updated_at,
-                s_version, s_object_key)
-             VALUES
-               (4, %s, "application/vnd.ms-excel", "20201225105544",
-                2, "latest_object_key_xls")''', builder_id)
+               (1, %s, %s, %s)''', (
+              selections[2][0],
+              selections[2][6],
+              selections[2][7],
+          ))
     self.wp10db.commit()
 
   def test_create_unsuccessful(self):
@@ -419,20 +413,18 @@ class BuildersTest(BaseWebTestcase):
     with self.override_db(self.app), self.app.test_client() as client:
       with client.session_transaction() as sess:
         sess['user'] = self.USER
-      rv = client.post('/v1/builders/%s/zim' % builder_id, json={})
+      rv = client.post('/v1/builders/%s/zim' % builder_id,
+                       json={'description': 'Test description'})
       self.assertEqual('204 NO CONTENT', rv.status)
 
     patched_schedule_zim_file.assert_called_once()
     with self.wp10db.cursor() as cursor:
-      cursor.execute('''SELECT s_zimfarm_task_id, s_zimfarm_status,
-                               s_zimfarm_error_messages
-                        FROM selections
-                        WHERE s_id = 3''')
+      cursor.execute('SELECT z_task_id, z_status FROM zim_files '
+                     'WHERE z_selection_id = 3')
       data = cursor.fetchone()
 
-    self.assertEqual(b'1234-a', data['s_zimfarm_task_id'])
-    self.assertEqual(b'REQUESTED', data['s_zimfarm_status'])
-    self.assertIsNone(data['s_zimfarm_error_messages'])
+    self.assertEqual(b'1234-a', data['z_task_id'])
+    self.assertEqual(b'REQUESTED', data['z_status'])
 
   @patch('wp1.zimfarm.schedule_zim_file')
   def test_create_zim_file_for_builder_not_found(self,
@@ -444,7 +436,8 @@ class BuildersTest(BaseWebTestcase):
     with self.override_db(self.app), self.app.test_client() as client:
       with client.session_transaction() as sess:
         sess['user'] = self.USER
-      rv = client.post('/v1/builders/1234-not-found/zim', json={})
+      rv = client.post('/v1/builders/1234-not-found/zim',
+                       json={'description': 'Test description'})
       self.assertEqual('404 NOT FOUND', rv.status)
 
   @patch('wp1.zimfarm.schedule_zim_file')
@@ -457,7 +450,8 @@ class BuildersTest(BaseWebTestcase):
     with self.override_db(self.app), self.app.test_client() as client:
       with client.session_transaction() as sess:
         sess['user'] = self.UNAUTHORIZED_USER
-      rv = client.post('/v1/builders/%s/zim' % builder_id, json={})
+      rv = client.post('/v1/builders/%s/zim' % builder_id,
+                       json={'description': 'Test description'})
       self.assertEqual('403 FORBIDDEN', rv.status)
 
   @patch('wp1.zimfarm.schedule_zim_file')
@@ -471,8 +465,21 @@ class BuildersTest(BaseWebTestcase):
     with self.override_db(self.app), self.app.test_client() as client:
       with client.session_transaction() as sess:
         sess['user'] = self.USER
-      rv = client.post('/v1/builders/%s/zim' % builder_id, json={})
+      rv = client.post('/v1/builders/%s/zim' % builder_id,
+                       json={'description': 'Test description'})
       self.assertEqual('500 INTERNAL SERVER ERROR', rv.status)
+
+  @patch('wp1.zimfarm.schedule_zim_file')
+  def test_create_zim_file_for_builder_400(self, patched_schedule_zim_file):
+    builder_id = self._insert_builder()
+    self._insert_selections(builder_id)
+
+    self.app = create_app()
+    with self.override_db(self.app), self.app.test_client() as client:
+      with client.session_transaction() as sess:
+        sess['user'] = self.USER
+      rv = client.post('/v1/builders/%s/zim' % builder_id, json={})
+      self.assertEqual('400 BAD REQUEST', rv.status)
 
   @patch('wp1.web.builders.queues.poll_for_zim_file_status')
   def test_update_zimfarm_status(self, patched_poll):
@@ -492,13 +499,13 @@ class BuildersTest(BaseWebTestcase):
       patched_poll.assert_called_once()
 
     with self.wp10db.cursor() as cursor:
-      cursor.execute('SELECT s_zimfarm_status, s_zim_file_updated_at '
-                     'FROM selections WHERE s_zimfarm_task_id = "task-id-1234"')
+      cursor.execute('SELECT z_status, z_updated_at '
+                     'FROM zim_files WHERE z_task_id = "task-id-1234"')
       status = cursor.fetchone()
 
     self.assertIsNotNone(status)
-    self.assertEqual(b'ENDED', status['s_zimfarm_status'])
-    self.assertIsNone(status['s_zim_file_updated_at'])
+    self.assertEqual(b'ENDED', status['z_status'])
+    self.assertIsNone(status['z_updated_at'])
 
   @patch('wp1.web.builders.queues.poll_for_zim_file_status')
   @patch('wp1.logic.selection.utcnow',
@@ -524,13 +531,13 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('204 NO CONTENT', rv.status)
 
     with self.wp10db.cursor() as cursor:
-      cursor.execute('SELECT s_zimfarm_status, s_zim_file_updated_at '
-                     'FROM selections WHERE s_zimfarm_task_id = "task-id-1234"')
+      cursor.execute('SELECT z_status, z_updated_at '
+                     'FROM zim_files WHERE z_task_id = "task-id-1234"')
       status = cursor.fetchone()
 
     self.assertIsNotNone(status)
-    self.assertEqual(b'FILE_READY', status['s_zimfarm_status'])
-    self.assertEqual(b'20221225000102', status['s_zim_file_updated_at'])
+    self.assertEqual(b'FILE_READY', status['z_status'])
+    self.assertEqual(b'20221225000102', status['z_updated_at'])
 
   def test_update_zimfarm_status_bad_token(self):
     builder_id = self._insert_builder()

--- a/wp10_test.down.sql
+++ b/wp10_test.down.sql
@@ -11,3 +11,4 @@ DROP TABLE IF EXISTS `users`;
 DROP TABLE IF EXISTS `builders`;
 DROP TABLE IF EXISTS `selections`;
 DROP TABLE IF EXISTS `custom`;
+DROP TABLE IF EXISTS `zim_files`;

--- a/wp10_test.up.sql
+++ b/wp10_test.up.sql
@@ -134,7 +134,9 @@ CREATE TABLE zim_files (
   z_task_id VARBINARY(255),
   z_requested_at BINARY(14),
   z_updated_at BINARY(14),
-  z_version INTEGER
+  z_version INTEGER,
+  z_long_description blob,
+  z_description tinyblob
 );
 
 INSERT INTO `global_rankings` (gr_type, gr_rating, gr_ranking) VALUES ('importance', 'Unknown-Class', 0);

--- a/wp10_test.up.sql
+++ b/wp10_test.up.sql
@@ -130,8 +130,8 @@ CREATE TABLE custom (
 CREATE TABLE zim_files (
   z_id INTEGER NOT NULL PRIMARY KEY AUTO_INCREMENT,
   z_selection_id VARBINARY(255) NOT NULL,
-  z_task_id VARBINARY(255) NOT NULL,
   z_status VARBINARY(255) DEFAULT "NOT_REQUESTED",
+  z_task_id VARBINARY(255),
   z_requested_at BINARY(14),
   z_updated_at BINARY(14),
   z_version INTEGER

--- a/wp10_test.up.sql
+++ b/wp10_test.up.sql
@@ -112,7 +112,8 @@ CREATE TABLE `selections` (
   s_version int(11) NOT NULL,
   s_object_key VARBINARY(255),
   s_status VARBINARY(255) DEFAULT 'OK',
-  s_error_messages BLOB
+  s_error_messages BLOB,
+  s_zim_version INTEGER
 );
 
 CREATE TABLE custom (
@@ -132,7 +133,8 @@ CREATE TABLE zim_files (
   z_task_id VARBINARY(255) NOT NULL,
   z_status VARBINARY(255) DEFAULT "NOT_REQUESTED",
   z_requested_at BINARY(14),
-  z_updated_at BINARY(14)
+  z_updated_at BINARY(14),
+  z_version INTEGER
 );
 
 INSERT INTO `global_rankings` (gr_type, gr_rating, gr_ranking) VALUES ('importance', 'Unknown-Class', 0);

--- a/wp10_test.up.sql
+++ b/wp10_test.up.sql
@@ -112,12 +112,7 @@ CREATE TABLE `selections` (
   s_version int(11) NOT NULL,
   s_object_key VARBINARY(255),
   s_status VARBINARY(255) DEFAULT 'OK',
-  s_error_messages BLOB,
-  s_zimfarm_task_id VARBINARY(255),
-  s_zimfarm_error_messages BLOB,
-  s_zimfarm_status VARBINARY(255) DEFAULT "NOT_REQUESTED",
-  s_zim_file_updated_at BINARY(14),
-  s_zim_file_requested_at BINARY(14)
+  s_error_messages BLOB
 );
 
 CREATE TABLE custom (
@@ -129,6 +124,15 @@ CREATE TABLE custom (
   c_created_at BINARY(20),
   c_updated_at BINARY(20),
   c_is_active TINYINT
+);
+
+CREATE TABLE zim_files (
+  z_id INTEGER NOT NULL PRIMARY KEY AUTO_INCREMENT,
+  z_selection_id VARBINARY(255) NOT NULL,
+  z_task_id VARBINARY(255) NOT NULL,
+  z_status VARBINARY(255) DEFAULT "NOT_REQUESTED",
+  z_requested_at BINARY(14),
+  z_updated_at BINARY(14)
 );
 
 INSERT INTO `global_rankings` (gr_type, gr_rating, gr_ranking) VALUES ('importance', 'Unknown-Class', 0);


### PR DESCRIPTION
Fixes #612.

This is mostly a refactor in preparation for #581. We need to have a separate ZIM file table, since the old file needs to be retained while the new one is auto-generated. We also need to keep track of the `description` and `long_description` of the ZIM file so that we can automatically re-request it without re-prompting the user.

This PR adds no new features and the migrations are designed so that everything already in place keeps working.