### PR TITLE
Add name to docker compose files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       # This is the dev database, the dev redis, and the dev workers.
       # We don't technically need that last one.
       - name: Start Docker dev services
-        run: docker-compose -f docker-compose-dev.yml up -d --build
+        run: docker compose -f docker-compose-dev.yml up -d --build
 
       - name: Wait for Docker dev services to be up (30s)
         run: sleep 30s
@@ -141,7 +141,7 @@ jobs:
       - name: Stop containers
         continue-on-error: true
         if: always()
-        run: docker-compose -f "docker-compose-dev.yml" down
+        run: docker compose -f "docker-compose-dev.yml" down
 
       - uses: actions/upload-artifact@v3
         continue-on-error: true

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,4 +1,6 @@
 version: '3.5'
+
+name: wp1-dev
 services:
   redis:
     image: redis

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,5 +1,6 @@
 version: '3.5'
 
+name: wp1-test
 services:
   redis:
     image: redis


### PR DESCRIPTION
By default, the "name" of the docker graph created by docker-compose is the same as the directory in which the files are run from. This means that when running`docker-compose up -f docker-compose-dev.yml` and running `docker-compose up -f docker-compose-test.yml`, they both get the same project name. This causes a conflict between the `redis` image in each.

This change adds a name field to each compose file, so the graphs run under different 'projects' and no longer conflict.