### PR TITLE
Set resource usage for ZIM file creation based on selection content length

### DIFF
--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -269,7 +269,8 @@ def latest_selections_with_errors(wp10db, builder_id):
   return res
 
 
-def schedule_zim_file(redis,
+def schedule_zim_file(s3,
+                      redis,
                       wp10db,
                       user_id,
                       builder_id,
@@ -287,7 +288,8 @@ def schedule_zim_file(redis,
         'Could not use builder id = %s for user id = %s' %
         (builder_id, user_id))
 
-  task_id = zimfarm.schedule_zim_file(redis,
+  task_id = zimfarm.schedule_zim_file(s3,
+                                      redis,
                                       wp10db,
                                       builder,
                                       description=description,

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -725,6 +725,7 @@ class BuilderTest(BaseWpOneDbTest):
          return_value=datetime.datetime(2022, 12, 25, 0, 1, 2))
   def test_schedule_zim_file(self, patched_utcnow, patched_schedule_zim_file):
     redis = MagicMock()
+    s3 = MagicMock()
     patched_schedule_zim_file.return_value = '1234-a'
 
     builder_id = self._insert_builder()
@@ -733,14 +734,16 @@ class BuilderTest(BaseWpOneDbTest):
                            builder_id=builder_id,
                            has_errors=False)
 
-    logic_builder.schedule_zim_file(redis,
+    logic_builder.schedule_zim_file(s3,
+                                    redis,
                                     self.wp10db,
                                     1234,
                                     builder_id,
                                     description='a',
                                     long_description='z')
 
-    patched_schedule_zim_file.assert_called_once_with(redis,
+    patched_schedule_zim_file.assert_called_once_with(s3,
+                                                      redis,
                                                       self.wp10db,
                                                       self.builder,
                                                       description='a',
@@ -761,14 +764,17 @@ class BuilderTest(BaseWpOneDbTest):
   @patch('wp1.logic.builder.zimfarm.schedule_zim_file')
   def test_schedule_zim_file_404(self, patched_schedule_zim_file):
     redis = MagicMock()
+    s3 = MagicMock()
     patched_schedule_zim_file.return_value = '1234-a'
 
     with self.assertRaises(ObjectNotFoundError):
-      logic_builder.schedule_zim_file(redis, self.wp10db, 1234, '404builder')
+      logic_builder.schedule_zim_file(s3, redis, self.wp10db, 1234,
+                                      '404builder')
 
   @patch('wp1.logic.builder.zimfarm.schedule_zim_file')
   def test_schedule_zim_file_not_authorized(self, patched_schedule_zim_file):
     redis = MagicMock()
+    s3 = MagicMock()
     patched_schedule_zim_file.return_value = '1234-a'
 
     builder_id = self._insert_builder()
@@ -778,7 +784,7 @@ class BuilderTest(BaseWpOneDbTest):
                            has_errors=False)
 
     with self.assertRaises(UserNotAuthorizedError):
-      logic_builder.schedule_zim_file(redis, self.wp10db, 5678, builder_id)
+      logic_builder.schedule_zim_file(s3, redis, self.wp10db, 5678, builder_id)
 
   @patch('wp1.logic.builder.zimfarm.is_zim_file_ready')
   @patch('wp1.logic.builder.wp10_connect')

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -199,3 +199,24 @@ def update_zimfarm_task(wp10db, task_id, status, set_updated_now=False):
       found = bool(cursor.rowcount)
   wp10db.commit()
   return found
+
+
+TASK_CPU = 3
+TASK_MEMORY = 1024 * 1024 * 1024
+TASK_DISK = 2048 * 1024 * 100
+
+
+def get_resource_profile(s3, selection):
+  data = s3.client.head_object(Bucket=s3.bucket_name,
+                               Key=selection.s_object_key.decode('utf-8'))
+  length = data.get('ContentLength', 1024)
+  article_estimate = length / 15  # Assume each article name is 15 chars long.
+  multiplier = (
+      (article_estimate // 1000000) + 1)  # 1 multiplier for every 1M articles
+  return {
+      'cpu': TASK_CPU,
+      # 3 GB of mem for each 1M articles
+      'memory': int(TASK_MEMORY * 3 * multiplier),
+      # 20 GB of disk for each 1M articles
+      'disk': int(TASK_DISK * 20 * multiplier),
+  }

--- a/wp1/logic/selection_test.py
+++ b/wp1/logic/selection_test.py
@@ -339,3 +339,17 @@ class SelectionTest(BaseWpOneDbTest):
     self._insert_selections()
     actual = logic_selection.zim_file_requested_at_for(self.wp10db, 'xyz1')
     self.assertEqual(1672538522, actual)
+
+  def test_get_resource_profile(self):
+    s3 = MagicMock()
+    s3.client.head_object.return_value = {'ContentLength': 20000000}
+    selection = Selection(s_builder_id=b'abcd',
+                          s_content_type=b'text/tab-separated-values',
+                          s_version=1,
+                          s_object_key=b'foo/bar/1234.tsv')
+    actual = logic_selection.get_resource_profile(s3, selection)
+    self.assertEqual({
+        'cpu': 3,
+        'disk': 8388608000,
+        'memory': 6442450944
+    }, actual)

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -12,6 +12,7 @@ from wp1 import zimfarm
 from wp1.web import authenticate
 from wp1.web.db import get_db
 from wp1.web.redis import get_redis
+from wp1.web.storage import get_storage
 
 builders = flask.Blueprint('builders', __name__)
 
@@ -133,6 +134,7 @@ def latest_selection_for_builder(builder_id, ext):
 def create_zim_file_for_builder(builder_id):
   redis = get_redis()
   wp10db = get_db('wp10db')
+  s3 = get_storage()
 
   user_id = flask.session['user']['identity']['sub']
 
@@ -143,7 +145,8 @@ def create_zim_file_for_builder(builder_id):
   long_desc = data.get('long_description')
 
   try:
-    task_id = logic_builder.schedule_zim_file(redis,
+    task_id = logic_builder.schedule_zim_file(s3,
+                                              redis,
                                               wp10db,
                                               user_id,
                                               builder_id,

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -15,10 +15,6 @@ import wp1.logic.selection as logic_selection
 from wp1.timestamp import utcnow
 from wp1.time import get_current_datetime
 
-# TODO(#582): Determine resource profile from Selection list size.
-TASK_CPU = 3
-TASK_MEMORY = 1024 * 1024 * 1024
-TASK_DISK = 2048 * 1024 * 100
 MWOFFLINER_IMAGE = 'ghcr.io/openzim/mwoffliner:latest'
 REDIS_AUTH_KEY = 'zimfarm.auth'
 
@@ -125,7 +121,7 @@ def get_webhook_url():
                                                  urllib.parse.quote(token))
 
 
-def _get_params(wp10db, builder, description='', long_description=''):
+def _get_params(s3, wp10db, builder, description='', long_description=''):
   if builder is None:
     raise ObjectNotFoundError('Given builder was None: %r' % builder)
 
@@ -140,11 +136,7 @@ def _get_params(wp10db, builder, description='', long_description=''):
           'name': MWOFFLINER_IMAGE.split(':')[0],
           'tag': MWOFFLINER_IMAGE.split(':')[1],
       },
-      'resources': {
-          'cpu': TASK_CPU,
-          'memory': TASK_MEMORY,
-          'disk': TASK_DISK,
-      },
+      'resources': logic_selection.get_resource_profile(wp10db, selection),
       'platform': 'wikimedia',
       'monitor': False,
       'flags': {
@@ -153,7 +145,7 @@ def _get_params(wp10db, builder, description='', long_description=''):
           'adminEmail':
               'contact+wp1@kiwix.org',
           'articleList':
-              logic_selection.url_for_selection(selection),
+              logic_selection.url_for_selection(s3, selection),
           'customZimTitle':
               util.safe_name(builder.b_name.decode('utf-8')),
           # TODO(#584): Replace these placeholders with input from the user.
@@ -193,7 +185,8 @@ def _get_zimfarm_headers(token):
   return {"Authorization": "Token %s" % token, 'User-Agent': WP1_USER_AGENT}
 
 
-def schedule_zim_file(redis,
+def schedule_zim_file(s3,
+                      redis,
                       wp10db,
                       builder,
                       description='',
@@ -202,7 +195,8 @@ def schedule_zim_file(redis,
   if token is None:
     raise ZimfarmError('Error retrieving auth token for request')
 
-  params = _get_params(wp10db,
+  params = _get_params(s3,
+                       wp10db,
                        builder,
                        description=description,
                        long_description=long_description)


### PR DESCRIPTION
Fixes #582

We don't need to have a completely precise picture of how many resources to use when generating the ZIM file. It is approximate based on how many millions of articles are in the selection. However, rather than download the selection and count the articles, which would be expensive, we approximate that each 15 characters corresponds to 1 article and base the resource usage off of that.

See comments in #575.