### PR TITLE
Automatically update ZIM files when the Selection is updated

### DIFF
--- a/db/migrations/20230528_01_cSwUS-remove-selection-and-zim-file-versions.py
+++ b/db/migrations/20230528_01_cSwUS-remove-selection-and-zim-file-versions.py
@@ -1,0 +1,14 @@
+"""
+Remove selection and zim_file versions
+"""
+
+from yoyo import step
+
+__depends__ = {'20230513_01_4PsR6-add-descriptions-to-zim-file-table'}
+
+steps = [
+    step('ALTER TABLE selections DROP COLUMN s_zim_version',
+         'ALTER TABLE selections ADD COLUMN s_zim_version INTEGER'),
+    step('ALTER TABLE zim_files DROP COLUMN z_version',
+         'ALTER TABLE selections ADD COLUMN z_version INTEGER'),
+]

--- a/db/migrations/20230528_02_pL6ka-add-b-selection-zim-version-to-builders.py
+++ b/db/migrations/20230528_02_pL6ka-add-b-selection-zim-version-to-builders.py
@@ -1,0 +1,15 @@
+"""
+Add b_selection_zim_version to builders
+"""
+
+from yoyo import step
+
+__depends__ = {'20230528_01_cSwUS-remove-selection-and-zim-file-versions'}
+
+steps = [
+    step(
+        'ALTER TABLE builders ADD COLUMN b_selection_zim_version INTEGER',
+        'ALTER TABLE builders DROP COLUMN b_selection_zim_version',
+    ),
+    step('UPDATE builders SET b_selection_zim_version = b_current_version')
+]

--- a/db/migrations/20230528_02_pL6ka-add-b-selection-zim-version-to-builders.py
+++ b/db/migrations/20230528_02_pL6ka-add-b-selection-zim-version-to-builders.py
@@ -8,7 +8,7 @@ __depends__ = {'20230528_01_cSwUS-remove-selection-and-zim-file-versions'}
 
 steps = [
     step(
-        'ALTER TABLE builders ADD COLUMN b_selection_zim_version INTEGER',
+        'ALTER TABLE builders ADD COLUMN b_selection_zim_version INTEGER NOT NULL DEFAULT 0',
         'ALTER TABLE builders DROP COLUMN b_selection_zim_version',
     ),
     step('UPDATE builders SET b_selection_zim_version = b_current_version')

--- a/wp1-frontend/cypress/e2e/myLists.cy.js
+++ b/wp1-frontend/cypress/e2e/myLists.cy.js
@@ -6,12 +6,13 @@ describe('the user selection list page', () => {
       cy.intercept('v1/selection/simple/lists', { fixture: 'list_data.json' });
       cy.intercept('v1/oauth/identify', { fixture: 'identity.json' });
       cy.visit('/#/selections/user');
+      cy.get('select').select('25');
     });
 
     it('successfully loads', () => {});
 
     it('displays the datatables view', () => {
-      cy.get('.dataTables_info').contains('Showing 1 to 10 of 10 entries');
+      cy.get('.dataTables_info').contains('Showing 1 to 11 of 11 entries');
     });
 
     it('displays list and its contents', () => {
@@ -166,6 +167,32 @@ describe('the user selection list page', () => {
             cy.get('td').eq(6).should('contain', '12/17/22');
           });
       });
+    });
+  });
+
+  describe('when there is an outdated ZIM', () => {
+    it('displays the download ZIM link', () => {
+      cy.contains('td', 'outdated zim')
+        .parent('tr')
+        .within(() => {
+          cy.get('td').eq(7).get('a').should('contain', 'Download ZIM');
+        });
+    });
+
+    it('displays the ZIM updated date', () => {
+      cy.contains('td', 'outdated zim')
+        .parent('tr')
+        .within(() => {
+          cy.get('td').eq(6).should('contain', '6/18/23');
+        });
+    });
+
+    it('shows the info hover', () => {
+      cy.contains('td', 'outdated zim')
+        .parent('tr')
+        .within(() => {
+          cy.get('td').eq(7).get('span').should('exist');
+        });
     });
   });
 

--- a/wp1-frontend/cypress/fixtures/list_data.json
+++ b/wp1-frontend/cypress/fixtures/list_data.json
@@ -169,6 +169,23 @@
       "z_updated_at": null,
       "z_url": null,
       "z_status": "FAILED"
+    },
+    {
+      "created_at": 1685974621,
+      "id": "dcea7035-cc69-471e-b0e6-08dfbafd5e7c",
+      "model": "wp1.selection.models.simple",
+      "name": "outdated zim",
+      "project": "en.wikipedia.org",
+      "s_content_type": "text/tab-separated-values",
+      "s_extension": "tsv",
+      "s_id": "1b767bca-8fa6-48e3-9893-eb7b6d0ada91",
+      "s_status": "OK",
+      "s_updated_at": 1687109228,
+      "s_url": "http://localhost:5000/v1/builders/dcea7035-cc69-471e-b0e6-08dfbafd5e7c/selection/latest.tsv",
+      "updated_at": 1687109226,
+      "z_status": "FILE_READY",
+      "z_updated_at": 1687108510,
+      "z_url": "http://localhost:5000/v1/builders/dcea7035-cc69-471e-b0e6-08dfbafd5e7c/zim/latest"
     }
   ]
 }

--- a/wp1-frontend/src/components/MyLists.vue
+++ b/wp1-frontend/src/components/MyLists.vue
@@ -225,6 +225,10 @@ export default {
         if (this.hasPendingZim(item)) {
           hasPendingZim = true;
         }
+        if (this.hasOutdatedZim(item)) {
+          // Outdated ZIMs are treated like pending, poll every 5 minutes.
+          hasPendingZim = true;
+        }
       });
       const pollTimeoutMs = hasPendingSelections
         ? 20000

--- a/wp1-frontend/src/components/MyLists.vue
+++ b/wp1-frontend/src/components/MyLists.vue
@@ -65,12 +65,25 @@
                   ></span>
                 </div>
               </td>
-              <td v-if="item.z_url && !isPending(item)">
+              <td
+                v-if="item.z_url"
+                :class="{ 'outdated-zim': hasOutdatedZim(item) }"
+              >
                 {{ localDate(item.z_updated_at) }}
               </td>
               <td v-else>-</td>
-              <td v-if="item.z_url && !isPending(item)">
+              <td
+                v-if="item.z_url"
+                :class="{ 'outdated-zim': hasOutdatedZim(item) }"
+              >
                 <a :href="item.z_url">Download ZIM</a>
+                <span
+                  v-if="hasOutdatedZim(item)"
+                  data-toggle="tooltip"
+                  data-placement="top"
+                  title="The ZIM file is out of date. A new one has automatically been requested."
+                  ><i class="bi bi-info-circle"></i
+                ></span>
               </td>
               <td v-else-if="hasPendingZim(item)">
                 <pulse-loader
@@ -92,6 +105,13 @@
                     Create ZIM
                   </button></router-link
                 >
+                <span
+                  v-if="hasDeletedZim(item)"
+                  data-toggle="tooltip"
+                  data-placement="top"
+                  title="Your previous ZIM file has expired (2 weeks)."
+                  ><i class="bi bi-info-circle"></i
+                ></span>
               </td>
               <td v-else>-</td>
               <td>
@@ -155,6 +175,13 @@ export default {
     },
     hasSelectionError: function (item) {
       return item.s_status !== null && item.s_status !== 'OK';
+    },
+    hasOutdatedZim: function (item) {
+      return item.z_updated_at < item.s_updated_at;
+    },
+    hasDeletedZim: function (item) {
+      // ZIMs older than 2 weeks get deleted.
+      return Date.now() - item.z_updated_at > 14 * 24 * 60 * 60 * 1000;
     },
     localDate: function (secs) {
       const fmt = new Intl.DateTimeFormat('en-US', {
@@ -243,6 +270,11 @@ export default {
 
 .zim-failed a {
   color: #dc3545 !important;
+}
+
+.outdated-zim,
+.outdated-zim a {
+  color: #cc7204;
 }
 
 .failed {

--- a/wp1-frontend/src/components/ZimFile.vue
+++ b/wp1-frontend/src/components/ZimFile.vue
@@ -83,7 +83,7 @@
             <div v-if="!success" class="error-list errors">
               <p>The following errors occurred:</p>
               <ul>
-                <li v-for="msg in errorMessages" v-bind:key="msg">
+                <li v-for="msg in errors" v-bind:key="msg">
                   {{ msg }}
                 </li>
               </ul>

--- a/wp1/credentials.py.dev.example
+++ b/wp1/credentials.py.dev.example
@@ -67,6 +67,7 @@ CREDENTIALS = {
         'CLIENT_URL': {
             'domains': ['http://localhost:5173'],
             'homepage': 'http://localhost:5173/#/',
+            'api': 'http://localhost:5000',
         },
 
         # Configuration for the storage backend for storing selection lists. You MUST

--- a/wp1/credentials.py.e2e
+++ b/wp1/credentials.py.e2e
@@ -58,6 +58,10 @@ CREDENTIALS = {
             'port': 3306,
             'db': 'enwp10_test',
         },
+        'REDIS': {
+            'host': 'localhost',
+            'port': 6379,  # Specified in docker-compose-dev.yml
+        },
         'CLIENT_URL': {
             'api': 'http://test.server.fake'
         },

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -162,10 +162,8 @@ def materialize_builder(builder_cls, builder_id, content_type):
 
 def maybe_update_selection_zim_version(wp10db, builder, selection_version):
   current_zim = latest_zim_file_for(wp10db, builder.b_id)
-  if current_zim is None:
-    raise ValueError('Tried to update selection_zim_version but zim was None')
 
-  if current_zim.z_status == b'FILE_READY':
+  if current_zim is not None and current_zim.z_status == b'FILE_READY':
     # There is an existing ZIM that's ready. Leave it for now and
     # the version will get updated when the new ZIM is uploaded.
     return False

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -470,23 +470,14 @@ def get_builders_with_selections(wp10db, user_id):
            LEFT JOIN selections s
              ON s.s_builder_id = b.b_id
              AND s.s_version = b.b_current_version
+           LEFT JOIN selections s1
+             ON s1.s_builder_id = b.b_id
+             AND s1.s_version = b.b_selection_zim_version
            LEFT JOIN zim_files z
-             ON z.z_selection_id = s.s_id
-             AND s.s_version = b.b_selection_zim_version
+             ON z.z_selection_id = s1.s_id
            WHERE b_user_id = %s
            ORDER BY b.b_updated_at DESC
       ''', (user_id,))
-    # cursor.execute(
-    #     '''SELECT * FROM selections
-    #        LEFT JOIN zim_files
-    #          ON selections.s_id = zim_files.z_selection_id
-    #          AND selections.s_zim_version = zim_files.z_version
-    #        RIGHT JOIN builders
-    #          ON selections.s_builder_id = builders.b_id
-    #          AND selections.s_version = builders.b_current_version
-    #        WHERE b_user_id = %(b_user_id)s
-    #        ORDER BY builders.b_updated_at DESC
-    #     ''', {'b_user_id': user_id})
     data = cursor.fetchall()
 
   builders = {}

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -155,7 +155,7 @@ def materialize_builder(builder_cls, builder_id, content_type):
       # be automatically created. We don't need to do this if the ZIM
       # version was updated, because that indicates that the ZIM file
       # was never requested or errored and should remain in that state.
-      schedule_zim_file(redis, wp10db, builder_id)
+      schedule_zim_file(s3, redis, wp10db, builder_id)
   finally:
     wp10db.close()
 

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -155,7 +155,7 @@ def materialize_builder(builder_cls, builder_id, content_type):
       # that's ready that needs to be replaced. Schedule the ZIM file to
       # be automatically created. We don't need to do this if the ZIM
       # version was updated, because that indicates that the ZIM file
-      # was never requested or errored and should remain in that state.\
+      # was never requested or errored and should remain in that state.
       zim_file = latest_zim_file_for(wp10db, builder.b_id)
       description = zim_file.z_description.decode(
           'utf-8') if zim_file.z_description is not None else None

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -1016,3 +1016,29 @@ class BuilderTest(BaseWpOneDbTest):
     self.assertIsNotNone(data)
     self.assertEqual(b'FAILED', data['z_status'])
     self.assertIsNone(data['z_updated_at'])
+
+  def test_update_version_for_finished_zim(self):
+    builder_id = self._insert_builder(zim_version=1)
+    self._insert_selection(1,
+                           'text/tab-separated-values',
+                           version=1,
+                           builder_id=builder_id,
+                           has_errors=False,
+                           zim_file_ready=True)
+    self._insert_selection(2,
+                           'text/tab-separated-values',
+                           version=2,
+                           builder_id=builder_id,
+                           has_errors=False,
+                           zim_task_id='9abc',
+                           zim_file_ready=True)
+
+    logic_builder.update_version_for_finished_zim(self.wp10db, '9abc')
+
+    with self.wp10db.cursor() as cursor:
+      cursor.execute(
+          'SELECT b.b_selection_zim_version '
+          'FROM builders b WHERE b.b_id = %s', builder_id)
+      data = cursor.fetchone()
+
+    self.assertEqual(2, data['b_selection_zim_version'])

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -451,7 +451,7 @@ class BuilderTest(BaseWpOneDbTest):
 
   @patch('wp1.models.wp10.builder.utcnow',
          return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
-  def test_get_builders_with_no_builders(self, mock_utcnow):
+  def test_get_builders_with_selection_no_builders(self, mock_utcnow):
     self._insert_selection(1, 'text/tab-separated-values')
     article_data = logic_builder.get_builders_with_selections(
         self.wp10db, '0000')
@@ -473,7 +473,14 @@ class BuilderTest(BaseWpOneDbTest):
   @patch('wp1.models.wp10.builder.utcnow',
          return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
   def test_get_builders_zimfarm_status(self, mock_utcnow):
-    self._insert_selection(1, 'text/tab-separated-values', zim_file_ready=True)
+    self._insert_selection(1,
+                           'text/tab-separated-values',
+                           zim_file_ready=True,
+                           version=1)
+    self._insert_selection(2,
+                           'text/tab-separated-values',
+                           zim_file_ready=False,
+                           version=2)
     self._insert_builder()
     article_data = logic_builder.get_builders_with_selections(
         self.wp10db, '1234')

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -388,8 +388,12 @@ class BuilderTest(BaseWpOneDbTest):
 
       logic_builder.materialize_builder(TestBuilderClass, id_,
                                         'text/tab-separated-values')
-      patched_schedule_zim_file.assert_called_once_with(s3, redis, self.wp10db,
-                                                        id_)
+      patched_schedule_zim_file.assert_called_once_with(s3,
+                                                        redis,
+                                                        self.wp10db,
+                                                        id_,
+                                                        description=None,
+                                                        long_description=None)
     finally:
       self.wp10db.close = orig_close
 
@@ -908,7 +912,7 @@ class BuilderTest(BaseWpOneDbTest):
 
     with self.wp10db.cursor() as cursor:
       cursor.execute('SELECT z_status, z_updated_at '
-                     'FROM zim_files WHERE z_selection_id = 1')
+                     'FROM zim_files WHERE z_selection_id = 2')
       data = cursor.fetchone()
 
     self.assertIsNotNone(data)

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -30,15 +30,14 @@ def insert_selection(wp10db, selection):
     cursor.execute(
         '''INSERT INTO selections
              (s_id, s_builder_id, s_version, s_content_type, s_updated_at,
-              s_object_key, s_status, s_error_messages, s_zim_version)
+              s_object_key, s_status, s_error_messages)
              VALUES
              (%(s_id)s, %(s_builder_id)s, %(s_version)s, %(s_content_type)s,
-              %(s_updated_at)s, %(s_object_key)s, %(s_status)s, %(s_error_messages)s,
-              1)
+              %(s_updated_at)s, %(s_object_key)s, %(s_status)s, %(s_error_messages)s)
     ''', attr.asdict(selection))
     cursor.execute(
-        'INSERT INTO zim_files (z_selection_id, z_status, z_version)'
-        ' VALUES (%s, "NOT_REQUESTED", 1)', (selection.s_id,))
+        'INSERT INTO zim_files (z_selection_id, z_status)'
+        ' VALUES (%s, "NOT_REQUESTED")', (selection.s_id,))
   wp10db.commit()
 
 
@@ -68,31 +67,6 @@ def url_for(object_key):
   path = urllib.parse.quote(
       object_key if isinstance(object_key, str) else object_key.decode('utf-8'))
   return '%s/%s' % (S3_PUBLIC_URL, path)
-
-
-def latest_zim_file_for_selection(wp10db, selection):
-  if not selection:
-    raise ValueError('Cannot get zim file for empty selection')
-
-  with wp10db.cursor() as cursor:
-    cursor.execute(
-        'SELECT * FROM zim_files WHERE'
-        ' z_selection_id = %s AND z_version = %s',
-        (selection.s_id, selection.s_zim_version))
-    db_zim = cursor.fetchone()
-    if db_zim is None:
-      return None
-    return ZimFile(**db_zim)
-
-
-def url_from_zim_file(zim_file):
-  if not zim_file:
-    raise ValueError('Cannot get url from empty zim file')
-  return zim_file_url_for(zim_file.z_task_id)
-
-
-def zim_file_url_for(task_id):
-  return zimfarm.zim_file_url_for_task_id(task_id)
 
 
 def zim_file_requested_at_for(wp10db, task_id):

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -162,6 +162,9 @@ def update_zimfarm_task(wp10db, task_id, status, set_updated_now=False):
   with wp10db.cursor() as cursor:
     if set_updated_now:
       updated_at = utcnow().strftime(TS_FORMAT_WP10).encode('utf-8')
+      print(updated_at)
+      print(utcnow())
+      print(utcnow())
       with wp10db.cursor() as cursor:
         cursor.execute(
             '''UPDATE zim_files SET z_status = %s, z_updated_at = %s

--- a/wp1/logic/selection_test.py
+++ b/wp1/logic/selection_test.py
@@ -32,7 +32,6 @@ class SelectionTest(BaseWpOneDbTest):
         s_builder_id=b'100',
         s_content_type=b'text/tab-separated-values',
         s_version=1,
-        s_zim_version=1,
         s_updated_at=b'20190830112844',
         s_object_key=b'selections/foo.bar.model/deadbeef/name.tsv',
     )
@@ -71,9 +70,7 @@ class SelectionTest(BaseWpOneDbTest):
   def test_insert_selection(self):
     logic_selection.insert_selection(self.wp10db, self.selection)
     actual = _get_selection(self.wp10db)
-    expected_zim = ZimFile(z_id=1,
-                           z_selection_id=self.selection.s_id,
-                           z_version=1)
+    expected_zim = ZimFile(z_id=1, z_selection_id=self.selection.s_id)
     actual_zim = _get_zim_file_for_selection(self.wp10db, self.selection.s_id)
     self.assertEqual(self.selection, actual)
     self.assertEqual(expected_zim, actual_zim)

--- a/wp1/models/wp10/builder.py
+++ b/wp1/models/wp10/builder.py
@@ -29,6 +29,7 @@ class Builder:
   b_created_at = attr.ib(default=None)
   b_updated_at = attr.ib(default=None)
   b_current_version = attr.ib(default=0)
+  b_selection_zim_version = attr.ib(default=0)
 
   @property
   def created_at_dt(self):

--- a/wp1/models/wp10/selection.py
+++ b/wp1/models/wp10/selection.py
@@ -26,7 +26,6 @@ class Selection:
   data = attr.ib(default=None)
   s_status = attr.ib(default=None)
   s_error_messages = attr.ib(default=None)
-  s_zim_version = attr.ib(default=None)
 
   def set_id(self):
     self.s_id = str(uuid.uuid4()).encode('utf-8')

--- a/wp1/models/wp10/zim_file.py
+++ b/wp1/models/wp10/zim_file.py
@@ -14,7 +14,6 @@ class ZimFile:
   z_selection_id = attr.ib()
   z_status = attr.ib(default=b'NOT_REQUESTED')
   z_task_id = attr.ib(default=None)
-  z_version = attr.ib(default=None)
   z_requested_at = attr.ib(default=None)
   z_updated_at = attr.ib(default=None)
   z_long_description = attr.ib(default=None)

--- a/wp1/selection/abstract_builder.py
+++ b/wp1/selection/abstract_builder.py
@@ -26,14 +26,12 @@ class AbstractBuilder:
     s3.upload_fileobj(upload_data, key=object_key)
     selection.s_object_key = object_key
 
-  def materialize(self, s3, wp10db, builder, content_type):
+  def materialize(self, s3, wp10db, builder, content_type, version):
     params = json.loads(builder.b_params)
-    next_version = logic_selection.get_next_version(wp10db, builder.b_id,
-                                                    content_type)
 
     selection = Selection(s_content_type=content_type.encode('utf-8'),
                           s_builder_id=builder.b_id,
-                          s_version=next_version,
+                          s_version=version,
                           s_status=b'OK')
     selection.set_id()
     try:
@@ -55,7 +53,6 @@ class AbstractBuilder:
     logger.info('Saving selection %s to database' %
                 selection.s_id.decode('utf-8'))
     logic_selection.insert_selection(wp10db, selection)
-    logic_builder.update_current_version(wp10db, builder, next_version)
 
   def build(self, content_type, **params):
     raise NotImplementedError()

--- a/wp1/selection/abstract_builder_test.py
+++ b/wp1/selection/abstract_builder_test.py
@@ -63,7 +63,7 @@ class AbstractBuilderTest(BaseWpOneDbTest):
 
   def test_materialize_creates_selection(self):
     self.test_builder.materialize(self.s3, self.wp10db, self.builder,
-                                  'text/tab-separated-values')
+                                  'text/tab-separated-values', 1)
 
     actual = get_first_selection(self.wp10db)
 
@@ -73,7 +73,7 @@ class AbstractBuilderTest(BaseWpOneDbTest):
   @patch('wp1.models.wp10.selection.uuid.uuid4', return_value='abcd-1234')
   def test_materialize_selection_id(self, mock_uuid4):
     self.test_builder.materialize(self.s3, self.wp10db, self.builder,
-                                  'text/tab-separated-values')
+                                  'text/tab-separated-values', 1)
 
     actual = get_first_selection(self.wp10db)
 
@@ -82,7 +82,7 @@ class AbstractBuilderTest(BaseWpOneDbTest):
   @patch('wp1.models.wp10.selection.uuid.uuid4', return_value='abcd-1234')
   def test_materialize_selection_object_key(self, mock_uuid4):
     self.test_builder.materialize(self.s3, self.wp10db, self.builder,
-                                  'text/tab-separated-values')
+                                  'text/tab-separated-values', 1)
 
     actual = get_first_selection(self.wp10db)
 
@@ -94,7 +94,7 @@ class AbstractBuilderTest(BaseWpOneDbTest):
          return_value=datetime(2020, 12, 25, 10, 55, 44))
   def test_materialize_selection_updated_at(self, mock_utcnow):
     self.test_builder.materialize(self.s3, self.wp10db, self.builder,
-                                  'text/tab-separated-values')
+                                  'text/tab-separated-values', 1)
 
     actual = get_first_selection(self.wp10db)
 
@@ -103,7 +103,7 @@ class AbstractBuilderTest(BaseWpOneDbTest):
   @patch('wp1.models.wp10.selection.uuid.uuid4', return_value='abcd-1234')
   def test_materialize_uploads_to_s3(self, mock_uuid4):
     self.test_builder.materialize(self.s3, self.wp10db, self.builder,
-                                  'text/tab-separated-values')
+                                  'text/tab-separated-values', 1)
 
     data = self.s3.upload_fileobj.call_args[0][0]
     object_key = self.s3.upload_fileobj.call_args[1]['key']
@@ -112,10 +112,18 @@ class AbstractBuilderTest(BaseWpOneDbTest):
         'selections/wp1.selection.models.fake/abcd-1234/MyBuilder.tsv',
         object_key)
 
+  def test_materialize_version(self):
+    self.test_builder.materialize(self.s3, self.wp10db, self.builder,
+                                  'text/tab-separated-values', 5)
+
+    actual = get_first_selection(self.wp10db)
+
+    self.assertEqual(5, actual.s_version)
+
   def test_materialize_retryable_error(self):
     builder_obj = TestBuilderRetryable()
     builder_obj.materialize(self.s3, self.wp10db, self.builder,
-                            'text/tab-separated-values')
+                            'text/tab-separated-values', 1)
 
     actual = get_first_selection(self.wp10db)
 
@@ -124,7 +132,7 @@ class AbstractBuilderTest(BaseWpOneDbTest):
   def test_materialize_retryable_error_messages(self):
     builder_obj = TestBuilderRetryable()
     builder_obj.materialize(self.s3, self.wp10db, self.builder,
-                            'text/tab-separated-values')
+                            'text/tab-separated-values', 1)
 
     actual = get_first_selection(self.wp10db)
 
@@ -139,7 +147,7 @@ class AbstractBuilderTest(BaseWpOneDbTest):
   def test_materialize_fatal_error(self):
     builder_obj = TestBuilderFatal()
     builder_obj.materialize(self.s3, self.wp10db, self.builder,
-                            'text/tab-separated-values')
+                            'text/tab-separated-values', 1)
 
     actual = get_first_selection(self.wp10db)
 
@@ -148,7 +156,7 @@ class AbstractBuilderTest(BaseWpOneDbTest):
   def test_materialize_fatal_error_messages(self):
     builder_obj = TestBuilderFatal()
     builder_obj.materialize(self.s3, self.wp10db, self.builder,
-                            'text/tab-separated-values')
+                            'text/tab-separated-values', 1)
 
     actual = get_first_selection(self.wp10db)
 
@@ -163,7 +171,7 @@ class AbstractBuilderTest(BaseWpOneDbTest):
   def test_materialize_no_context_messages(self):
     builder_obj = TestBuilderNoContext()
     builder_obj.materialize(self.s3, self.wp10db, self.builder,
-                            'text/tab-separated-values')
+                            'text/tab-separated-values', 1)
 
     actual = get_first_selection(self.wp10db)
 
@@ -173,7 +181,7 @@ class AbstractBuilderTest(BaseWpOneDbTest):
   def test_materialize_suppressed_message(self):
     builder_obj = TestBuilderSuppressedException()
     builder_obj.materialize(self.s3, self.wp10db, self.builder,
-                            'text/tab-separated-values')
+                            'text/tab-separated-values', 1)
 
     actual = get_first_selection(self.wp10db)
 

--- a/wp1/selection/models/simple_test.py
+++ b/wp1/selection/models/simple_test.py
@@ -40,7 +40,7 @@ of text than an actual article name.', 'Not_an_<article_name>',
   def test_materialize(self):
     simple_test_builder = SimpleBuilder()
     simple_test_builder.materialize(self.s3, self.wp10db, self.builder,
-                                    'text/tab-separated-values')
+                                    'text/tab-separated-values', 1)
     actual = get_first_selection(self.wp10db)
     self.assertEqual(actual.s_content_type, b'text/tab-separated-values')
     self.assertEqual(actual.s_builder_id, b'1a-2b-3c-4d')

--- a/wp1/selection/models/sparql_test.py
+++ b/wp1/selection/models/sparql_test.py
@@ -102,14 +102,11 @@ class SparqlBuilderTest(BaseWpOneDbTest):
     mock_requests.post.return_value = response
 
     self.builder.materialize(self.s3, self.wp10db, self.builder_model,
-                             'text/tab-separated-values')
+                             'text/tab-separated-values', 1)
 
     actual = get_first_selection(self.wp10db)
     self.assertEqual(b'text/tab-separated-values', actual.s_content_type)
-    self.assertEqual(
-        b'1a-2b-3c-4d',
-        actual.s_builder_id,
-    )
+    self.assertEqual(b'1a-2b-3c-4d', actual.s_builder_id)
 
   @patch('wp1.selection.models.sparql.requests')
   def test_build(self, mock_requests):

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -148,14 +148,13 @@ def create_zim_file_for_builder(builder_id):
     task_id = logic_builder.schedule_zim_file(s3,
                                               redis,
                                               wp10db,
-                                              user_id,
                                               builder_id,
+                                              user_id=user_id,
                                               description=desc,
                                               long_description=long_desc)
   except ObjectNotFoundError:
-    return flask.jsonify({
-        'error_messages': ['No builder found with id = %s\n' % builder_id]
-    }), 404
+    return flask.jsonify(
+        {'error_messages': ['No builder found with id = %s' % builder_id]}), 404
   except UserNotAuthorizedError:
     return flask.jsonify({
         'error_messages': [

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -167,14 +167,6 @@ def create_zim_file_for_builder(builder_id):
       error_messages.append(str(e.__cause__))
     return flask.jsonify({'error_messages': error_messages}), 500
 
-  # In production, there is a web hook from the Zimfarm that notifies us
-  # that the task is finished and we can start polling for the ZIM file
-  # to be uploaded. The web hook obviously doesn't work in development
-  # because the localhost server is not routable. To make ZIM file
-  # creation work end to end, start polling immediately in Development.
-  if ENV == Environment.DEVELOPMENT:
-    queues.poll_for_zim_file_status(redis, task_id)
-
   return '', 204
 
 

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -44,28 +44,28 @@ class BuildersTest(BaseWebTestcase):
   valid_article_name = ['Eiffel_Tower', 'Statue of Liberty']
   successful_response = {'success': True, 'items': {}}
 
-  builder = Builder(
-      b_id=b'1a-2b-3c-4d',
-      b_name=b'My Builder',
-      b_user_id=1234,
-      b_project=b'en.wikipedia.fake',
-      b_model=b'wp1.selection.models.simple',
-      b_params=b'{"list": ["a", "b", "c"]}',
-      b_created_at=b'20191225044444',
-      b_updated_at=b'20191225044444',
-      b_current_version=2,
-  )
+  builder = Builder(b_id=b'1a-2b-3c-4d',
+                    b_name=b'My Builder',
+                    b_user_id=1234,
+                    b_project=b'en.wikipedia.fake',
+                    b_model=b'wp1.selection.models.simple',
+                    b_params=b'{"list": ["a", "b", "c"]}',
+                    b_created_at=b'20191225044444',
+                    b_updated_at=b'20191225044444',
+                    b_current_version=2,
+                    b_selection_zim_version=2)
 
   def _insert_builder(self):
     with self.wp10db.cursor() as cursor:
       cursor.execute(
           '''INSERT INTO builders
                (b_id, b_name, b_user_id, b_project, b_params, b_model,
-                b_created_at, b_updated_at, b_current_version)
+                b_created_at, b_updated_at, b_current_version,
+                b_selection_zim_version)
              VALUES
                (%(b_id)s, %(b_name)s, %(b_user_id)s, %(b_project)s,
                 %(b_params)s, %(b_model)s, %(b_created_at)s,
-                %(b_updated_at)s, %(b_current_version)s)
+                %(b_updated_at)s, %(b_current_version)s, %(b_selection_zim_version)s)
         ''', attr.asdict(self.builder))
     self.wp10db.commit()
     return self.builder.b_id.decode('utf-8')
@@ -83,14 +83,14 @@ class BuildersTest(BaseWebTestcase):
       cursor.executemany(
           '''INSERT INTO selections
                (s_id, s_builder_id, s_content_type, s_updated_at,
-                s_version, s_object_key, s_zim_version)
-             VALUES (%s, %s, %s, %s, %s, %s, 1)
+                s_version, s_object_key)
+             VALUES (%s, %s, %s, %s, %s, %s)
       ''', [s[:6] for s in selections])
       cursor.execute(
           '''INSERT INTO zim_files
-               (z_id, z_selection_id, z_task_id, z_status, z_version)
+               (z_id, z_selection_id, z_task_id, z_status)
              VALUES
-               (1, %s, %s, %s, 1)''', (
+               (1, %s, %s, %s)''', (
               selections[2][0],
               selections[2][6],
               selections[2][7],

--- a/wp1/web/selection_test.py
+++ b/wp1/web/selection_test.py
@@ -134,19 +134,19 @@ class SelectionTest(BaseWebTestcase):
 
   def _insert_selection(self, values, zim_values=None):
     if zim_values is None:
-      zim_values = ('NOT_REQUESTED', 1)
+      zim_values = ('NOT_REQUESTED',)
     zim_values = zim_values + (values[0],)
 
     with self.wp10db.cursor() as cursor:
       cursor.execute(
           '''INSERT INTO selections
               (s_id, s_builder_id, s_content_type, s_updated_at, s_version,
-               s_object_key, s_status, s_error_messages, s_zim_version)
+               s_object_key, s_status, s_error_messages)
             VALUES
-              (%s, %s, %s, %s, %s, %s, %s, %s, 1)
+              (%s, %s, %s, %s, %s, %s, %s, %s)
         ''', values)
       cursor.execute(
-          'INSERT INTO zim_files (z_status, z_version, z_selection_id) VALUES (%s, %s, %s)',
+          'INSERT INTO zim_files (z_status, z_selection_id) VALUES (%s, %s)',
           zim_values)
     self.wp10db.commit()
 
@@ -172,7 +172,7 @@ class SelectionTest(BaseWebTestcase):
            'object_key_1', 'CAN_RETRY', '{"errors"["error1"]}'))
       self._insert_selection((2, '1a-2b-3c-4d', 'application/vnd.ms-excel',
                               '20201225105544', 1, 'object_key_2', None, None),
-                             ('NOT_REQUESTED', 1))
+                             ('NOT_REQUESTED',))
       self.wp10db.commit()
       with client.session_transaction() as sess:
         sess['user'] = self.USER

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -128,6 +128,9 @@ def _get_params(s3, wp10db, builder, description='', long_description=''):
   project = builder.b_project.decode('utf-8')
   selection = logic_builder.latest_selection_for(wp10db, builder.b_id,
                                                  'text/tab-separated-values')
+  selection_id_frag = selection.s_id.decode('utf-8').split('-')[-1]
+  custom_title = '%s-%s' % (util.safe_name(
+      builder.b_name.decode('utf-8')), selection_id_frag)
 
   config = {
       'task_name': 'mwoffliner',
@@ -147,8 +150,7 @@ def _get_params(s3, wp10db, builder, description='', long_description=''):
           'articleList':
               logic_selection.url_for_selection(selection),
           'customZimTitle':
-              util.safe_name(builder.b_name.decode('utf-8')),
-          # TODO(#584): Replace these placeholders with input from the user.
+              custom_title,
           'customZimDescription':
               description
               if description else 'ZIM file created from a WP1 Selection',
@@ -158,7 +160,7 @@ def _get_params(s3, wp10db, builder, description='', long_description=''):
       }
   }
 
-  name = 'wp1_selection_%s' % selection.s_id.decode('utf-8').split('-')[-1]
+  name = 'wp1_selection_%s' % selection_id_frag
   webhook_url = get_webhook_url()
 
   return {

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -197,6 +197,9 @@ def schedule_zim_file(s3,
   if token is None:
     raise ZimfarmError('Error retrieving auth token for request')
 
+  if builder is None:
+    raise ObjectNotFoundError('Cannot schedule for None builder')
+
   params = _get_params(s3,
                        wp10db,
                        builder,

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -226,7 +226,7 @@ def schedule_zim_file(s3,
     data = r.json()
     requested = data.get('requested')
     task_id = requested[0] if requested else None
-    logger.info('Found task id=%s for builder id=%s', (task_id, builder_id))
+    logger.info('Found task id=%s for builder id=%s', task_id, builder_id)
 
     if task_id is None:
       raise ZimFarmError('Did not get scheduled task id')

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -72,7 +72,12 @@ class ZimFarmTest(BaseWpOneDbTest):
     self._insert_builder()
     self._insert_selection(b'abc-12345-def')
 
-    actual = zimfarm._get_params(s3, self.wp10db, self.builder)
+    actual = zimfarm._get_params(
+        s3,
+        self.wp10db,
+        self.builder,
+        description='This is the short description',
+        long_description='This is the long description')
 
     self.maxDiff = None
     self.assertEqual(
@@ -110,9 +115,9 @@ class ZimFarmTest(BaseWpOneDbTest):
                 'monitor': False,
                 'flags': {
                     'customZimDescription':
-                        'ZIM file created from a WP1 Selection',
+                        'This is the short description',
                     'customZimLongDescription':
-                        'ZIM file created from a WP1 Selection',
+                        'This is the long description',
                     'mwUrl':
                         'https://en.wikipedia.fake/',
                     'adminEmail':
@@ -120,7 +125,7 @@ class ZimFarmTest(BaseWpOneDbTest):
                     'articleList':
                         'http://credentials.not.found.fake/selections/foo/1234/name.tsv',
                     'customZimTitle':
-                        'MyBuilder'
+                        'MyBuilder-def'
                 }
             }
         }, actual)
@@ -298,8 +303,7 @@ class ZimFarmTest(BaseWpOneDbTest):
     mock_response.json.return_value = {'requested': ['9876']}
     mock_requests.post.side_effect = (MagicMock(), mock_response, MagicMock())
 
-    actual = zimfarm.schedule_zim_file(s3, redis, self.wp10db,
-                                       'builder-1234-abcd')
+    actual = zimfarm.schedule_zim_file(s3, redis, self.wp10db, self.builder)
 
     self.assertEqual('9876', actual)
 
@@ -333,8 +337,7 @@ class ZimFarmTest(BaseWpOneDbTest):
     mock_response.json.return_value = {'requested': ['9876']}
     mock_requests.post.side_effect = (MagicMock(), mock_response)
 
-    actual = zimfarm.schedule_zim_file(s3, redis, self.wp10db,
-                                       'builder-1234-abcd')
+    actual = zimfarm.schedule_zim_file(s3, redis, self.wp10db, self.builder)
 
     schedule_create_call = call(
         'https://fake.farm/v1/schedules/',
@@ -379,8 +382,7 @@ class ZimFarmTest(BaseWpOneDbTest):
     mock_requests.post.side_effect = (create_schedule_response, mock_response)
 
     with self.assertRaises(ZimFarmError):
-      actual = zimfarm.schedule_zim_file(s3, redis, self.wp10db,
-                                         'builder-1234-abcd')
+      actual = zimfarm.schedule_zim_file(s3, redis, self.wp10db, self.builder)
 
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
@@ -400,8 +402,7 @@ class ZimFarmTest(BaseWpOneDbTest):
     )
 
     with self.assertRaises(ZimFarmError):
-      actual = zimfarm.schedule_zim_file(s3, redis, self.wp10db,
-                                         'builder-1234-abcd')
+      actual = zimfarm.schedule_zim_file(s3, redis, self.wp10db, self.builder)
 
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
@@ -421,8 +422,7 @@ class ZimFarmTest(BaseWpOneDbTest):
     mock_requests.exceptions.HTTPError = requests.exceptions.HTTPError
 
     with self.assertRaises(ZimFarmError):
-      actual = zimfarm.schedule_zim_file(s3, redis, self.wp10db,
-                                         'builder-1234-abcd')
+      actual = zimfarm.schedule_zim_file(s3, redis, self.wp10db, self.builder)
 
     mock_requests.delete.assert_called_once()
 
@@ -441,8 +441,7 @@ class ZimFarmTest(BaseWpOneDbTest):
     mock_requests.post.side_effect = (MagicMock(), mock_response, MagicMock())
 
     with self.assertRaises(ZimFarmError):
-      actual = zimfarm.schedule_zim_file(s3, redis, self.wp10db,
-                                         'builder-1234-abcd')
+      actual = zimfarm.schedule_zim_file(s3, redis, self.wp10db, self.builder)
 
   @patch('wp1.zimfarm.requests.get')
   def test_is_zim_file_ready(self, patched_get):

--- a/wp10_test.up.sql
+++ b/wp10_test.up.sql
@@ -101,7 +101,8 @@ CREATE TABLE `builders` (
   b_current_version int(11) NOT NULL DEFAULT '0',
   b_params BLOB,
   b_created_at BINARY(14),
-  b_updated_at BINARY(14)
+  b_updated_at BINARY(14),
+  b_selection_zim_version INTEGER
 );
 
 CREATE TABLE `selections` (
@@ -112,8 +113,7 @@ CREATE TABLE `selections` (
   s_version int(11) NOT NULL,
   s_object_key VARBINARY(255),
   s_status VARBINARY(255) DEFAULT 'OK',
-  s_error_messages BLOB,
-  s_zim_version INTEGER
+  s_error_messages BLOB
 );
 
 CREATE TABLE custom (
@@ -134,7 +134,6 @@ CREATE TABLE zim_files (
   z_task_id VARBINARY(255),
   z_requested_at BINARY(14),
   z_updated_at BINARY(14),
-  z_version INTEGER,
   z_long_description blob,
   z_description tinyblob
 );

--- a/wp10_test.up.sql
+++ b/wp10_test.up.sql
@@ -98,11 +98,11 @@ CREATE TABLE `builders` (
   b_user_id INTEGER NOT NULL,
   b_project VARBINARY(255) NOT NULL,
   b_model VARBINARY(255) NOT NULL,
-  b_current_version int(11) NOT NULL DEFAULT '0',
+  b_current_version int(11) NOT NULL DEFAULT 0,
   b_params BLOB,
   b_created_at BINARY(14),
   b_updated_at BINARY(14),
-  b_selection_zim_version INTEGER
+  b_selection_zim_version int(11) NOT NULL DEFAULT 0
 );
 
 CREATE TABLE `selections` (


### PR DESCRIPTION
Fixes #581.

This PR follows the requirements outlined in #581. When a user updates their selection, and they have already requested a ZIM file, a new ZIM file is requested for them automatically. The Selections list (`MyLists.vue`) will show the outdated ZIM file in warning orange with a tooltip that informs the user that the ZIM is outdated and a new one has been requested. Note that no new ZIM is requested if there wasn't an existing ZIM file. Once the new ZIM file is ready (via the same webhook/polling as before), the Builder for that Selection/ZIM is updated and the new ZIM file displays in the UI. There is also polling added (every 5 minutes) for outdated ZIM file, so if the user comes back to the page they will see the new file when it is ready (no spinner though).

As far as the implementation, the initial design, which stored multiple versions of ZIM files on a Selection, was flawed. Selections cannot have multiple ZIM files. By definition, a Selection version is a specific formula for creating a materialized list of articles from a Builder specification. In this system, when a selection is "updated" what happens in fact is that a new Selection row is inserted, with a new S3 object_key for the materialized Selection. Therefore, the schema has been updated so that only one ZIM file is stored per Selection. The choice of ZIM file version for a Builder has been elevated to the `builders` table, as `b_selection_zim_version`. It now references the Selection version which contains the relevant ZIM file.

This version is initially set to the initial Selection version. Suppose a ZIM file is then created for `b_selection_zim_version = 1`. If the selection gets updated to version 2, that version's ZIM file is automatically requested, but the `b_selection_zim_version` will remain 1, so the user is able to download the existing outdated ZIM file. Once the new ZIM file has been verified through polling, the version is updated to 2 and the user proceeds to download the new ZIM.

This PR also contains logic in the frontend for hiding outdated ZIM files (older than 2 weeks) and prompting the user to create a new ZIM.

Finally, there is a possible bug in this implementation with a certain edge case. If the user updates their selections rapidly in succession, the existing ZIM file jobs remain active on the Zimfarm. Then, there is a race condition where whichever file finishes last will be the ZIM download link (though it may not be the most up to date file). This is tracked in #622.