### PR TITLE
Cancel outdated ZIM tasks when a new ZIM is auto-updated

### DIFF
--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -304,3 +304,33 @@ def zim_file_url_for_task_id(task_id):
         'Configuration error, could not find ZIMFARM["s3_url"] in credentials')
 
   return f'{base_url}{warehouse_path}/{name}'
+
+
+def cancel_zim_by_task_id(redis, task_id):
+  token = get_zimfarm_token(redis)
+  if token is None:
+    raise ZimfarmError('Error retrieving auth token for request')
+  base_url = get_zimfarm_url()
+  headers = _get_zimfarm_headers(token)
+
+  logger.info('Deleting task_id=%s', task_id)
+  r = requests.delete('%s/requested-tasks/%s' % (base_url, task_id),
+                      headers=headers)
+
+  try:
+    r.raise_for_status()
+    # Didn't raise, operation was successful.
+    return
+  except requests.exceptions.HTTPError as e:
+    if r.status_code != 404:
+      raise ZimFarmError('Error attempting to delete requested task id=%s' %
+                         task_id) from e
+
+  logger.info('Task was no longer requested, cancelling (task_id=%s)', task_id)
+  r = requests.post('%s/tasks/%s/cancel' % (base_url, task_id), headers=headers)
+
+  try:
+    r.raise_for_status()
+  except requests.exceptions.HTTPError as e:
+    raise ZimFarmError('Task could not be deleted/canceled (task_id=%s)' %
+                       task_id)

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -319,7 +319,6 @@ def cancel_zim_by_task_id(redis, task_id):
 
   try:
     r.raise_for_status()
-    # Didn't raise, operation was successful.
     return
   except requests.exceptions.HTTPError as e:
     if r.status_code != 404:


### PR DESCRIPTION
Fixes #622.

Here, we check for any ZIM file objects in the database for the given builder that are in the REQUESTED state, when auto-queueing a new ZIM file. That way, we can cancel these pending tasks before queueing the new ZIM file for creation. This prevents the race condition described in the bug.