### PR TITLE
Zim title

### DIFF
--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -162,9 +162,6 @@ def update_zimfarm_task(wp10db, task_id, status, set_updated_now=False):
   with wp10db.cursor() as cursor:
     if set_updated_now:
       updated_at = utcnow().strftime(TS_FORMAT_WP10).encode('utf-8')
-      print(updated_at)
-      print(utcnow())
-      print(utcnow())
       with wp10db.cursor() as cursor:
         cursor.execute(
             '''UPDATE zim_files SET z_status = %s, z_updated_at = %s

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -125,6 +125,8 @@ class ZimFarmTest(BaseWpOneDbTest):
                     'articleList':
                         'http://credentials.not.found.fake/selections/foo/1234/name.tsv',
                     'customZimTitle':
+                        'My Builder',
+                    'filenamePrefix':
                         'MyBuilder-def'
                 }
             }


### PR DESCRIPTION
Fixes #626.

Minor change to update `customZimTitle` to be the full name of the Builder, and use `filenamePrefix` to create a unique slug for the ZIM file.

During the testing of this change, a couple of bugs with the previous PRs were found:

1. The `task_id` being sent to the Zimfarm to cancel was bytes, not str, so it created an encoding error in the URL
1. ZIM files weren't being marked as CANCELLED once they were cancelled, so if another new ZIM was requested, the old ZIMs would be (harmlessly) requested to be cancelled over and over.