### PR TITLE
Fix bug with deleted ZIMs in UI

### DIFF
--- a/wp1-frontend/cypress/e2e/myLists.cy.js
+++ b/wp1-frontend/cypress/e2e/myLists.cy.js
@@ -3,7 +3,9 @@
 describe('the user selection list page', () => {
   describe('when the user is logged in', () => {
     beforeEach(() => {
-      cy.intercept('v1/selection/simple/lists', { fixture: 'list_data.json' });
+      cy.intercept('v1/selection/simple/lists', {
+        fixture: 'list_data.json',
+      }).as('list');
       cy.intercept('v1/oauth/identify', { fixture: 'identity.json' });
       cy.visit('/#/selections/user');
       cy.get('select').select('25');
@@ -12,7 +14,7 @@ describe('the user selection list page', () => {
     it('successfully loads', () => {});
 
     it('displays the datatables view', () => {
-      cy.get('.dataTables_info').contains('Showing 1 to 11 of 11 entries');
+      cy.get('.dataTables_info').contains('Showing 1 to 12 of 12 entries');
     });
 
     it('displays list and its contents', () => {
@@ -152,6 +154,16 @@ describe('the user selection list page', () => {
     });
 
     describe('when the ZIM file is ready', () => {
+      beforeEach(() => {
+        cy.clock(1685991600000);
+        cy.visit('/#/selections/user');
+        cy.wait('@list')
+          .then(cy.clock)
+          .then((clock) => {
+            console.log('restoring');
+            clock.restore();
+          });
+      });
       it('displays the download ZIM link', () => {
         cy.contains('td', 'zim ready')
           .parent('tr')
@@ -164,35 +176,61 @@ describe('the user selection list page', () => {
         cy.contains('td', 'zim ready')
           .parent('tr')
           .within(() => {
-            cy.get('td').eq(6).should('contain', '12/17/22');
+            cy.get('td').eq(6).should('contain', '6/1/23');
           });
       });
     });
-  });
 
-  describe('when there is an outdated ZIM', () => {
-    it('displays the download ZIM link', () => {
-      cy.contains('td', 'outdated zim')
-        .parent('tr')
-        .within(() => {
-          cy.get('td').eq(7).get('a').should('contain', 'Download ZIM');
-        });
+    describe('when there is an outdated ZIM', () => {
+      it('displays the download ZIM link', () => {
+        cy.contains('td', 'outdated zim')
+          .parent('tr')
+          .within(() => {
+            cy.get('td').eq(7).get('a').should('contain', 'Download ZIM');
+          });
+      });
+
+      it('displays the ZIM updated date', () => {
+        cy.contains('td', 'outdated zim')
+          .parent('tr')
+          .within(() => {
+            cy.get('td').eq(6).should('contain', '6/1/23');
+          });
+      });
+
+      it('shows the info hover', () => {
+        cy.contains('td', 'outdated zim')
+          .parent('tr')
+          .within(() => {
+            cy.get('td').eq(7).get('span').should('exist');
+          });
+      });
     });
 
-    it('displays the ZIM updated date', () => {
-      cy.contains('td', 'outdated zim')
-        .parent('tr')
-        .within(() => {
-          cy.get('td').eq(6).should('contain', '6/18/23');
-        });
-    });
+    describe('when there is an deleted ZIM', () => {
+      it('displays the download ZIM link', () => {
+        cy.contains('td', 'deleted zim')
+          .parent('tr')
+          .within(() => {
+            cy.get('td').eq(7).get('a').should('contain', 'Download ZIM');
+          });
+      });
 
-    it('shows the info hover', () => {
-      cy.contains('td', 'outdated zim')
-        .parent('tr')
-        .within(() => {
-          cy.get('td').eq(7).get('span').should('exist');
-        });
+      it('displays the ZIM updated date', () => {
+        cy.contains('td', 'deleted zim')
+          .parent('tr')
+          .within(() => {
+            cy.get('td').eq(6).should('contain', '6/18/23');
+          });
+      });
+
+      it('shows the info hover', () => {
+        cy.contains('td', 'deleted zim')
+          .parent('tr')
+          .within(() => {
+            cy.get('td').eq(7).get('span').should('exist');
+          });
+      });
     });
   });
 

--- a/wp1-frontend/cypress/fixtures/list_data.json
+++ b/wp1-frontend/cypress/fixtures/list_data.json
@@ -15,7 +15,8 @@
       "s_url": "https://www.example.fake/abcd-efgh",
       "z_updated_at": null,
       "z_url": null,
-      "z_status": "NOT_REQUESTED"
+      "z_status": "NOT_REQUESTED",
+      "z_is_deleted": null
     },
     {
       "id": 2,
@@ -32,7 +33,8 @@
       "s_url": null,
       "z_updated_at": null,
       "z_url": null,
-      "z_status": "NOT_REQUESTED"
+      "z_status": "NOT_REQUESTED",
+      "z_is_deleted": null
     },
     {
       "created_at": 1670251154,
@@ -49,7 +51,8 @@
       "updated_at": 1670261154,
       "z_updated_at": null,
       "z_url": null,
-      "z_status": "NOT_REQUESTED"
+      "z_status": "NOT_REQUESTED",
+      "z_is_deleted": null
     },
     {
       "created_at": 1669778531,
@@ -66,7 +69,8 @@
       "updated_at": 1670247215,
       "z_updated_at": null,
       "z_url": null,
-      "z_status": "NOT_REQUESTED"
+      "z_status": "NOT_REQUESTED",
+      "z_is_deleted": null
     },
     {
       "created_at": 1669778531,
@@ -83,7 +87,8 @@
       "updated_at": 1670247215,
       "z_updated_at": null,
       "z_url": null,
-      "z_status": "NOT_REQUESTED"
+      "z_status": "NOT_REQUESTED",
+      "z_is_deleted": null
     },
     {
       "created_at": 1669778531,
@@ -100,7 +105,8 @@
       "updated_at": 1670267215,
       "z_updated_at": null,
       "z_url": null,
-      "z_status": "NOT_REQUESTED"
+      "z_status": "NOT_REQUESTED",
+      "z_is_deleted": null
     },
     {
       "created_at": 1669678531,
@@ -117,7 +123,8 @@
       "updated_at": 1670267215,
       "z_updated_at": null,
       "z_url": null,
-      "z_status": "NOT_REQUESTED"
+      "z_status": "NOT_REQUESTED",
+      "z_is_deleted": null
     },
     {
       "created_at": 1669679000,
@@ -134,10 +141,11 @@
       "updated_at": 1670287215,
       "z_updated_at": null,
       "z_url": null,
-      "z_status": "REQUESTED"
+      "z_status": "REQUESTED",
+      "z_is_deleted": null
     },
     {
-      "created_at": 1669679000,
+      "created_at": 1685646000,
       "id": "7368f534-27f5-4350-bfe3-23b90363df7b",
       "model": "wp1.selection.models.sparql",
       "name": "zim ready",
@@ -146,12 +154,13 @@
       "s_extension": "tsv",
       "s_id": "1234-hijk",
       "s_status": "OK",
-      "s_updated_at": 1671263950,
+      "s_updated_at": 1685646500,
       "s_url": "https://www.example.fake/1234-hijk",
-      "updated_at": 1670287215,
-      "z_updated_at": 1671287215,
+      "updated_at": 1685646150,
+      "z_updated_at": 1685646750,
       "z_url": "https://localhost/zim/latest",
-      "z_status": "FILE_READY"
+      "z_status": "FILE_READY",
+      "z_is_deleted": false
     },
     {
       "created_at": 1682181321,
@@ -168,13 +177,32 @@
       "updated_at": 1682181321,
       "z_updated_at": null,
       "z_url": null,
-      "z_status": "FAILED"
+      "z_status": "FAILED",
+      "z_is_deleted": null
+    },
+    {
+      "created_at": 1685646000,
+      "id": "dcea7035-cc69-471e-b0e6-08dfbafd5e7c",
+      "model": "wp1.selection.models.simple",
+      "name": "outdated zim",
+      "project": "en.wikipedia.org",
+      "s_content_type": "text/tab-separated-values",
+      "s_extension": "tsv",
+      "s_id": "1b767bca-8fa6-48e3-9893-eb7b6d0ada91",
+      "s_status": "OK",
+      "s_updated_at": 1685646500,
+      "s_url": "http://localhost:5000/v1/builders/dcea7035-cc69-471e-b0e6-08dfbafd5e7c/selection/latest.tsv",
+      "updated_at": 1685646150,
+      "z_status": "FILE_READY",
+      "z_updated_at": 1685646300,
+      "z_url": "http://localhost:5000/v1/builders/dcea7035-cc69-471e-b0e6-08dfbafd5e7c/zim/latest",
+      "z_is_deleted": false
     },
     {
       "created_at": 1685974621,
       "id": "dcea7035-cc69-471e-b0e6-08dfbafd5e7c",
       "model": "wp1.selection.models.simple",
-      "name": "outdated zim",
+      "name": "deleted zim",
       "project": "en.wikipedia.org",
       "s_content_type": "text/tab-separated-values",
       "s_extension": "tsv",
@@ -185,7 +213,8 @@
       "updated_at": 1687109226,
       "z_status": "FILE_READY",
       "z_updated_at": 1687108510,
-      "z_url": "http://localhost:5000/v1/builders/dcea7035-cc69-471e-b0e6-08dfbafd5e7c/zim/latest"
+      "z_url": "http://localhost:5000/v1/builders/dcea7035-cc69-471e-b0e6-08dfbafd5e7c/zim/latest",
+      "z_is_deleted": true
     }
   ]
 }

--- a/wp1-frontend/src/components/MyLists.vue
+++ b/wp1-frontend/src/components/MyLists.vue
@@ -181,10 +181,7 @@ export default {
     },
     hasDeletedZim: function (item) {
       // ZIMs older than 2 weeks get deleted.
-      return (
-        !!item.z_updated_at &&
-        Date.now() - item.z_updated_at > 14 * 24 * 60 * 60 * 1000
-      );
+      return !!item.z_is_deleted;
     },
     localDate: function (secs) {
       const fmt = new Intl.DateTimeFormat('en-US', {

--- a/wp1/constants.py
+++ b/wp1/constants.py
@@ -26,6 +26,7 @@ LIST_V2_URL = 'https://wp1.openzim.org/#/project'
 # Timeout for the rq worker jobs, in seconds
 JOB_TIMEOUT = 60 * 60 * 2  # 2 hours
 JOB_FAILURE_TTL = 60 * 60 * 24 * 7  # 7 days
+ZIM_FILE_TTL = 2 * 7 * 24 * 60 * 60  # 2 weeks
 
 LOG_NS = 4
 MAX_LOGS_PER_DAY = 100000

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -55,6 +55,8 @@ class BuilderTest(BaseWpOneDbTest):
           None,
       'z_status':
           'NOT_REQUESTED',
+      'z_is_deleted':
+          None,
   }]
 
   expected_lists_with_multiple_selections = [
@@ -89,6 +91,8 @@ class BuilderTest(BaseWpOneDbTest):
               None,
           'z_status':
               'NOT_REQUESTED',
+          'z_is_deleted':
+              None,
       },
       {
           'id':
@@ -121,6 +125,8 @@ class BuilderTest(BaseWpOneDbTest):
               None,
           'z_status':
               'NOT_REQUESTED',
+          'z_is_deleted':
+              None,
       },
   ]
 
@@ -140,6 +146,7 @@ class BuilderTest(BaseWpOneDbTest):
       'z_updated_at': None,
       'z_url': None,
       'z_status': None,
+      'z_is_deleted': None,
   }]
 
   expected_lists_with_unmapped_selections = [{
@@ -158,6 +165,7 @@ class BuilderTest(BaseWpOneDbTest):
       'z_updated_at': None,
       'z_url': None,
       'z_status': 'NOT_REQUESTED',
+      'z_is_deleted': None,
   }]
 
   expected_list_with_zimfarm_status = [{
@@ -191,6 +199,8 @@ class BuilderTest(BaseWpOneDbTest):
           'http://test.server.fake/v1/builders/1a-2b-3c-4d/zim/latest',
       'z_status':
           'FILE_READY',
+      'z_is_deleted':
+          True,
   }]
 
   def _insert_builder(self, current_version=None, zim_version=None):
@@ -480,6 +490,23 @@ class BuilderTest(BaseWpOneDbTest):
     article_data = logic_builder.get_builders_with_selections(
         self.wp10db, '1234')
     self.assertObjectListsEqual(self.expected_lists_with_unmapped_selections,
+                                article_data)
+
+  @patch('wp1.models.wp10.builder.utcnow',
+         return_value=datetime.datetime(2020, 12, 25, 4, 44, 44))
+  def test_get_builders_deleted_zim(self, mock_utcnow):
+    self._insert_selection(1,
+                           'text/tab-separated-values',
+                           zim_file_ready=True,
+                           version=1)
+    self._insert_selection(2,
+                           'text/tab-separated-values',
+                           zim_file_ready=False,
+                           version=2)
+    self._insert_builder()
+    article_data = logic_builder.get_builders_with_selections(
+        self.wp10db, '1234')
+    self.assertObjectListsEqual(self.expected_list_with_zimfarm_status,
                                 article_data)
 
   @patch('wp1.models.wp10.builder.utcnow',

--- a/wp1/web/selection_test.py
+++ b/wp1/web/selection_test.py
@@ -44,6 +44,8 @@ class SelectionTest(BaseWebTestcase):
               None,
           'z_status':
               'NOT_REQUESTED',
+          'z_is_deleted':
+              None,
       }],
   }
 
@@ -80,6 +82,8 @@ class SelectionTest(BaseWebTestcase):
                   None,
               'z_status':
                   'NOT_REQUESTED',
+              'z_is_deleted':
+                  None,
           },
           {
               'id': '1a-2b-3c-4d',
@@ -97,6 +101,7 @@ class SelectionTest(BaseWebTestcase):
               'z_updated_at': None,
               'z_url': None,
               'z_status': 'NOT_REQUESTED',
+              'z_is_deleted': None,
           },
       ]
   }
@@ -118,6 +123,7 @@ class SelectionTest(BaseWebTestcase):
           'z_updated_at': None,
           'z_url': None,
           'z_status': None,
+          'z_is_deleted': None,
       }]
   }
 


### PR DESCRIPTION
Fixes #634.

Although the technical fix for that issue was to just fix the millisecond conversion so that ZIM updated dates were calculated properly, it proved impossible to test that solution with Cypress (see the issue).

Here, we calculate the deletion status of the ZIM file on the server, so that it doesn't depend on a client `now()` value. This allows us to more easily test it in the frontend.