### PR TITLE
Update ZIM page to allow re-requesting ZIM files that have expired

### DIFF
--- a/wp1-frontend/cypress/e2e/zimFile.cy.js
+++ b/wp1-frontend/cypress/e2e/zimFile.cy.js
@@ -67,7 +67,8 @@ describe('the zim file creation page', () => {
               statusCode: 204,
             }).as('request');
 
-            cy.get('#desc').click().type('Description from user');
+            cy.get('#desc').click();
+            cy.get('#desc').type('Description from user');
             cy.get('#request').click();
           });
 
@@ -160,7 +161,8 @@ describe('the zim file creation page', () => {
               statusCode: 204,
             }).as('request');
 
-            cy.get('#desc').click().type('Description from user');
+            cy.get('#desc').click();
+            cy.get('#desc').type('Description from user');
             cy.get('#request').click();
           });
 

--- a/wp1-frontend/cypress/e2e/zimFile.cy.js
+++ b/wp1-frontend/cypress/e2e/zimFile.cy.js
@@ -169,6 +169,32 @@ describe('the zim file creation page', () => {
           });
         });
       });
+
+      describe('when the zim file is expired', () => {
+        beforeEach(() => {
+          cy.intercept('v1/builders/1/zim/status', {
+            fixture: 'zim_status_deleted.json',
+          }).as('status');
+          cy.visit('/#/selections/1/zim');
+          cy.wait('@identity');
+          cy.wait('@builder');
+          cy.wait('@status');
+        });
+
+        it('displays the form for entering descriptions', () => {
+          cy.get('#desc').should('be.visible');
+          cy.get('#longdesc').should('be.visible');
+        });
+
+        it('does not show the spinner', () => {
+          cy.get('#loader').should('not.be.visible');
+        });
+
+        it('displays the Request ZIM file button', () => {
+          cy.get('#request').should('be.visible');
+          cy.get('#request').should('not.have.attr', 'disabled');
+        });
+      });
     });
 
     describe('and the builder is not found', () => {

--- a/wp1-frontend/cypress/fixtures/zim_status_deleted.json
+++ b/wp1-frontend/cypress/fixtures/zim_status_deleted.json
@@ -1,7 +1,7 @@
 {
-  "status": "REQUESTED",
+  "status": "FILE_READY",
   "error_url": "https://error.fake/404",
-  "is_deleted": false,
+  "is_deleted": true,
   "description": "Description for test",
   "long_description": "Long Description for test"
 }

--- a/wp1-frontend/cypress/fixtures/zim_status_failed.json
+++ b/wp1-frontend/cypress/fixtures/zim_status_failed.json
@@ -1,4 +1,7 @@
 {
   "status": "FAILED",
-  "error_url": "https://example.fake/failed"
+  "error_url": "https://example.fake/failed",
+  "is_deleted": false,
+  "description": "Description for test",
+  "long_description": "Long Description for test"
 }

--- a/wp1-frontend/cypress/fixtures/zim_status_not_requested.json
+++ b/wp1-frontend/cypress/fixtures/zim_status_not_requested.json
@@ -1,3 +1,7 @@
 {
-  "status": "NOT_REQUESTED"
+  "status": "NOT_REQUESTED",
+  "error_url": "https://error.fake/404",
+  "is_deleted": false,
+  "description": null,
+  "long_description": null
 }

--- a/wp1-frontend/cypress/fixtures/zim_status_ready.json
+++ b/wp1-frontend/cypress/fixtures/zim_status_ready.json
@@ -1,3 +1,7 @@
 {
-  "status": "FILE_READY"
+  "status": "FILE_READY",
+  "error_url": "https://error.fake/404",
+  "is_deleted": false,
+  "description": "Description for test",
+  "long_description": "Long Description for test"
 }

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -693,13 +693,6 @@ class BuilderTest(BaseWpOneDbTest):
         actual,
         'http://credentials.not.found.fake/proper/selection/4321/name.tsv')
 
-  def test_latest_zimfarm_task_url(self):
-    builder_id = self._insert_builder_with_multiple_version_selections()
-
-    actual = logic_builder.latest_zimfarm_task_url(self.wp10db, builder_id)
-
-    self.assertEqual('https://fake.farm/v1/tasks/5678', actual)
-
   @patch('wp1.logic.builder.zimfarm.zim_file_url_for_task_id',
          return_value='https://zim.fake/1234')
   def test_latest_zim_file_url_for(self, mock_zimfarm_url_for):

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -5,7 +5,7 @@ import urllib.parse
 
 import attr
 
-from wp1.constants import CONTENT_TYPE_TO_EXT, TS_FORMAT_WP10
+from wp1.constants import CONTENT_TYPE_TO_EXT, TS_FORMAT_WP10, ZIM_FILE_TTL
 from wp1.models.wp10.selection import Selection
 from wp1.models.wp10.zim_file import ZimFile
 from wp1.storage import connect_storage
@@ -173,6 +173,10 @@ def update_zimfarm_task(wp10db, task_id, status, set_updated_now=False):
       found = bool(cursor.rowcount)
   wp10db.commit()
   return found
+
+
+def is_zim_file_deleted(update_at_timestamp):
+  return utcnow().timestamp() - update_at_timestamp > ZIM_FILE_TTL
 
 
 TASK_CPU = 3

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -141,7 +141,8 @@ def create_zim_file_for_builder(builder_id):
   data = flask.request.get_json()
   desc = data.get('description')
   if not desc:
-    return 'Description is required for ZIM file', 400
+    return flask.jsonify(
+        {'error_messages': 'Description is required for ZIM file'}), 400
   long_desc = data.get('long_description')
 
   try:
@@ -173,9 +174,7 @@ def create_zim_file_for_builder(builder_id):
 @builders.route('/<builder_id>/zim/status')
 def zimfarm_status(builder_id):
   wp10db = get_db('wp10db')
-  status = logic_builder.latest_zimfarm_status(wp10db, builder_id)
-  error_url = logic_builder.latest_zimfarm_task_url(wp10db, builder_id)
-  return flask.jsonify({'status': status, 'error_url': error_url})
+  return flask.jsonify(logic_builder.zim_file_status_for(wp10db, builder_id))
 
 
 @builders.route('/zim/status', methods=['POST'])

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -596,7 +596,10 @@ class BuildersTest(BaseWebTestcase):
     self.assertEqual(
         {
             'error_url': 'https://fake.farm/v1/tasks/task-id-1234',
-            'status': 'FILE_READY'
+            'status': 'FILE_READY',
+            'description': None,
+            'long_description': None,
+            'is_deleted': None,
         }, rv.get_json())
 
   @patch('wp1.logic.builder.zimfarm.zim_file_url_for_task_id',


### PR DESCRIPTION
Fixes #637

This change passes the `is_deleted` flag to the ZIM creation page. If it sees that value, it notifies the user that their ZIM has expired and allows them to re-request.