### PR TITLE
Allow for Selection based on Petscan URL

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,10 +11,12 @@ cachelib==0.9.0
 certifi==2022.12.7
 cfgv==2.0.1
 chardet==3.0.4
+charset-normalizer==3.2.0
 click==8.1.3
 coverage==5.5
 croniter==0.3.30
 crontab==1.0.0
+decorator==5.1.1
 Deprecated==1.2.13
 distlib==0.3.6
 fakeredis==2.4.0
@@ -72,6 +74,7 @@ supervisor==4.2.2
 tabulate==0.8.9
 toml==0.10.0
 urllib3==1.26.5
+validators==0.20.0
 virtualenv==20.17.1
 watchdog==3.0.0
 Werkzeug==2.3.3

--- a/wp1-frontend/src/components/PetscanBuilder.vue
+++ b/wp1-frontend/src/components/PetscanBuilder.vue
@@ -1,0 +1,80 @@
+<template>
+  <BaseBuilder
+    :key="$route.path"
+    :listName="'Petscan Selection'"
+    :model="'wp1.selection.models.petscan'"
+    :params="params"
+    :builderId="$route.params.builder_id"
+    :invalidItems="invalidItems"
+    @onBuilderLoaded="onBuilderLoaded"
+    @onBeforeSubmit="onBeforeSubmit"
+    @onValidationError="onValidationError"
+  >
+    <template #create-desc>
+      <p>
+        Use this tool to create an article selection list for the Wikipedia
+        project of your choice, based off a Petscan URL. Your selection will be
+        saved in public cloud storage and can be accessed through URLs that will
+        be provided once it has been saved.
+      </p>
+      <p class="mb-0">
+        For more information on creating a Petscan selection, see the
+        <a href="https://wp1.readthedocs.io/en/latest/user/selections/"
+          >end user documentation</a
+        >
+        or the
+        <a href="https://meta.wikimedia.org/wiki/PetScan/en"
+          >Petscan User Manual</a
+        >.
+      </p>
+    </template>
+    <template #extra-params>
+      <div id="items" class="form-group m-4">
+        <label for="items">URL</label>
+        <input
+          id="petscanUrl"
+          ref="petscanUrl"
+          class="form-control my-2"
+          v-model="params.url"
+        />
+        <div class="invalid-feedback">Please provide a valid URL</div>
+      </div>
+    </template>
+  </BaseBuilder>
+</template>
+
+<script>
+import BaseBuilder from './BaseBuilder.vue';
+
+export default {
+  components: { BaseBuilder },
+  name: 'SimpleBuilder',
+  data: function () {
+    return {
+      url: '',
+      invalidItems: '',
+      params: {},
+    };
+  },
+  methods: {
+    validationOnBlur: function (event) {
+      if (event.target.value) {
+        event.target.classList.remove('is-invalid');
+      } else {
+        event.target.classList.add('is-invalid');
+      }
+    },
+    onBuilderLoaded: function (builder) {
+      this.params = builder.params;
+    },
+    onBeforeSubmit: function () {
+      this.$refs.petscanUrl.setCustomValidity('');
+    },
+    onValidationError: function (data) {
+      this.$refs.petscanUrl.setCustomValidity('URL not valid');
+    },
+  },
+};
+</script>
+
+<style scoped></style>

--- a/wp1-frontend/src/components/SecondaryNav.vue
+++ b/wp1-frontend/src/components/SecondaryNav.vue
@@ -49,6 +49,18 @@
               >SPARQL Selection</router-link
             >
           </li>
+          <li
+            :class="
+              'nav-item ' +
+              (this.$route.path.startsWith('/selections/petscan')
+                ? 'active'
+                : '')
+            "
+          >
+            <router-link class="nav-link" to="/selections/petscan"
+              >Petscan Selection</router-link
+            >
+          </li>
         </ul>
       </div>
     </nav>

--- a/wp1-frontend/src/main.js
+++ b/wp1-frontend/src/main.js
@@ -11,6 +11,7 @@ import VueRouter from 'vue-router';
 
 import App from './App.vue';
 import ArticlePage from './components/ArticlePage.vue';
+import PetscanBuilder from './components/PetscanBuilder.vue';
 import SimpleBuilder from './components/SimpleBuilder.vue';
 import SparqlBuilder from './components/SparqlBuilder.vue';
 import ComparePage from './components/ComparePage.vue';
@@ -111,6 +112,13 @@ const routes = [
     },
   },
   {
+    path: '/selections/petscan',
+    component: PetscanBuilder,
+    meta: {
+      title: () => BASE_TITLE + ' - Create Petscan Selection',
+    },
+  },
+  {
     path: '/selections/simple/:builder_id',
     component: SimpleBuilder,
     meta: {
@@ -122,6 +130,13 @@ const routes = [
     component: SparqlBuilder,
     meta: {
       title: () => BASE_TITLE + ' - Edit SPARQL Selection',
+    },
+  },
+  {
+    path: '/selections/petscan/:builder_id',
+    component: PetscanBuilder,
+    meta: {
+      title: () => BASE_TITLE + ' - Edit Petscan Selection',
     },
   },
   {

--- a/wp1/selection/models/petscan.py
+++ b/wp1/selection/models/petscan.py
@@ -43,11 +43,11 @@ class Builder(AbstractBuilder):
       return ('', '', ['Missing URL parameter'])
 
     if not validators.url(params['url']):
-      return ('', params['url'], 'That doesn\'t look like a valid URL.')
+      return ('', params['url'], ['That doesn\'t look like a valid URL.'])
 
     parsed_url = urllib.parse.urlparse(params['url'])
     if 'petscan.wmflabs.org' not in parsed_url.netloc:
       return ('', params['url'],
-              'Only URLs that lead to petscan.wmflabs.org are allowed.')
+              ['Only URLs that lead to petscan.wmflabs.org are allowed.'])
 
     return ('', '', [])

--- a/wp1/selection/models/petscan.py
+++ b/wp1/selection/models/petscan.py
@@ -19,7 +19,8 @@ class Builder(AbstractBuilder):
     if 'url' not in params:
       raise Wp1FatalSelectionError('Missing required param: url')
     if not isinstance(params['url'], str):
-      raise Wp1FatalSelectionError('Param `url` was not str')
+      raise Wp1FatalSelectionError('Param `url` is not str')
+
 
     # Set the result data format to json
     parsed_url = urllib.parse.urlparse(params['url'])

--- a/wp1/selection/models/petscan.py
+++ b/wp1/selection/models/petscan.py
@@ -4,6 +4,7 @@ import urllib
 import requests
 import validators
 
+from wp1.constants import WP1_USER_AGENT
 from wp1.exceptions import Wp1FatalSelectionError
 from wp1.selection.abstract_builder import AbstractBuilder
 
@@ -27,7 +28,7 @@ class Builder(AbstractBuilder):
     final_url = parsed_url._replace(
         query=urllib.parse.urlencode(parsed_query, doseq=True)).geturl()
 
-    resp = requests.get(final_url)
+    resp = requests.get(final_url, headers={'User-Agent': WP1_USER_AGENT})
     try:
       resp.raise_for_status()
     except requests.exceptions.HTTPError as e:

--- a/wp1/selection/models/petscan.py
+++ b/wp1/selection/models/petscan.py
@@ -1,0 +1,53 @@
+import logging
+import urllib
+
+import requests
+import validators
+
+from wp1.exceptions import Wp1FatalSelectionError
+from wp1.selection.abstract_builder import AbstractBuilder
+
+logger = logging.getLogger(__name__)
+
+
+class Builder(AbstractBuilder):
+
+  def build(self, content_type, **params):
+    if content_type != 'text/tab-separated-values':
+      raise Wp1FatalSelectionError('Unrecognized content type')
+    if 'url' not in params:
+      raise Wp1FatalSelectionError('Missing required param: url')
+    if not isinstance(params['url'], str):
+      raise Wp1FatalSelectionError('Param `url` was not str')
+
+    # Set the result data format to json
+    parsed_url = urllib.parse.urlparse(params['url'])
+    parsed_query = urllib.parse.parse_qs(parsed_url.query)
+    parsed_query['format'] = ['json']
+    final_url = parsed_url._replace(
+        query=urllib.parse.urlencode(parsed_query, doseq=True)).geturl()
+
+    resp = requests.get(final_url)
+    try:
+      resp.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+      logger.exception('Error status received from Petscan server')
+      raise Wp1FatalSelectionError('Error status from Petscan server') from e
+
+    data = resp.json()
+    titles = [item['title'] for item in data['*'][0]['a']['*']]
+    return '\n'.join(titles).encode('utf-8')
+
+  def validate(self, **params):
+    if 'url' not in params:
+      return ('', '', ['Missing URL parameter'])
+
+    if not validators.url(params['url']):
+      return ('', params['url'], 'That doesn\'t look like a valid URL.')
+
+    parsed_url = urllib.parse.urlparse(params['url'])
+    if 'petscan.wmflabs.org' not in parsed_url.netloc:
+      return ('', params['url'],
+              'Only URLs that lead to petscan.wmflabs.org are allowed.')
+
+    return ('', '', [])

--- a/wp1/selection/models/petscan_test.py
+++ b/wp1/selection/models/petscan_test.py
@@ -116,13 +116,13 @@ class PetscanBuilderTest(BaseWpOneDbTest):
     self.assertEqual(('', '', ['Missing URL parameter']), actual)
 
   def test_validate_not_a_url(self):
-    afctual = self.builder.validate(url='http:// foo bar [baz]')
+    actual = self.builder.validate(url='http:// foo bar [baz]')
     self.assertEqual(
         ('', 'http:// foo bar [baz]', ['That doesn\'t look like a valid URL.']),
         actual)
 
   def test_validate_not_a_petscan_url(self):
-    afctual = self.builder.validate(url='http://en.wikipedia.org/')
+    actual = self.builder.validate(url='http://en.wikipedia.org/')
     self.assertEqual(
         ('', 'http://en.wikipedia.org/',
          ['Only URLs that lead to petscan.wmflabs.org are allowed.']), actual)

--- a/wp1/selection/models/petscan_test.py
+++ b/wp1/selection/models/petscan_test.py
@@ -75,7 +75,10 @@ class PetscanBuilderTest(BaseWpOneDbTest):
     actual = self.builder.build('text/tab-separated-values',
                                 url='https://petscan.wmflabs.org.fake/?psid=42')
     mock_requests.get.assert_called_with(
-        'https://petscan.wmflabs.org.fake/?psid=42&format=json')
+        'https://petscan.wmflabs.org.fake/?psid=42&format=json',
+        headers={
+            'User-Agent': 'WP 1.0 bot 1.0.0/Audiodude <audiodude@gmail.com>'
+        })
 
   @patch('wp1.selection.models.petscan.requests')
   def test_build_other_format(self, mock_requests):
@@ -87,7 +90,10 @@ class PetscanBuilderTest(BaseWpOneDbTest):
         'text/tab-separated-values',
         url='https://petscan.wmflabs.org.fake/?psid=42&format=wiki')
     mock_requests.get.assert_called_with(
-        'https://petscan.wmflabs.org.fake/?psid=42&format=json')
+        'https://petscan.wmflabs.org.fake/?psid=42&format=json',
+        headers={
+            'User-Agent': 'WP 1.0 bot 1.0.0/Audiodude <audiodude@gmail.com>'
+        })
 
   @patch('wp1.selection.models.petscan.requests.get')
   def test_build_non_200(self, mock_requests_get):

--- a/wp1/selection/models/petscan_test.py
+++ b/wp1/selection/models/petscan_test.py
@@ -1,0 +1,101 @@
+from unittest.mock import MagicMock, patch
+
+from wp1.base_db_test import BaseWpOneDbTest, get_first_selection
+from wp1.exceptions import Wp1FatalSelectionError
+from wp1.models.wp10.builder import Builder
+from wp1.selection.models.petscan import Builder as PetscanBuilder
+
+import requests
+
+
+class PetscanBuilderTest(BaseWpOneDbTest):
+  mock_petscan_response = {
+      '*': [{
+          'a': {
+              '*': [{
+                  'title': 'Foo'
+              }, {
+                  'title': 'Bar'
+              }]
+          }
+      }]
+  }
+
+  def setUp(self):
+    super().setUp()
+    self.s3 = MagicMock()
+    self.builder_model = Builder(
+        b_id=b'1a-2b-3c-4d',
+        b_name=b'Petscan Builder',
+        b_user_id=1234,
+        b_project=b'en.wikipedia.fake',
+        b_model=b'wp1.selection.models.petscan',
+        b_params='{"url":"https://petscan.wmflabs.org/?psid=552"}')
+    self.builder = PetscanBuilder()
+
+  @patch('wp1.selection.models.petscan.requests')
+  def test_materialize(self, mock_requests):
+    self.builder.materialize(self.s3, self.wp10db, self.builder_model,
+                             'text/tab-separated-values', 1)
+    actual = get_first_selection(self.wp10db)
+    self.assertEqual(actual.s_content_type, b'text/tab-separated-values')
+    self.assertEqual(actual.s_builder_id, b'1a-2b-3c-4d')
+
+  @patch('wp1.selection.models.petscan.requests')
+  def test_build(self, mock_requests):
+    mock_response = MagicMock()
+    mock_response.json.return_value = self.mock_petscan_response
+    mock_requests.get.return_value = mock_response
+
+    actual = self.builder.build('text/tab-separated-values',
+                                url='https://petscan.wmflabs.org.fake/?psid=42')
+    self.assertEqual(b'Foo\nBar', actual)
+
+  def test_build_wrong_content_type(self):
+    with self.assertRaises(Wp1FatalSelectionError):
+      actual = self.builder.build(
+          None, url='https://petscan.wmflabs.org.fake/?psid=42')
+
+  def test_build_missing_url(self):
+    with self.assertRaises(Wp1FatalSelectionError):
+      actual = self.builder.build('text/tab-separated-values')
+
+  def test_build_url_not_str(self):
+    with self.assertRaises(Wp1FatalSelectionError):
+      actual = self.builder.build(
+          'text/tab-separated-values',
+          url=['https://petscan.wmflabs.org.fake/?psid=42'])
+
+  @patch('wp1.selection.models.petscan.requests')
+  def test_build_no_format(self, mock_requests):
+    mock_response = MagicMock()
+    mock_response.json.return_value = self.mock_petscan_response
+    mock_requests.get.return_value = mock_response
+
+    actual = self.builder.build('text/tab-separated-values',
+                                url='https://petscan.wmflabs.org.fake/?psid=42')
+    mock_requests.get.assert_called_with(
+        'https://petscan.wmflabs.org.fake/?psid=42&format=json')
+
+  @patch('wp1.selection.models.petscan.requests')
+  def test_build_other_format(self, mock_requests):
+    mock_response = MagicMock()
+    mock_response.json.return_value = self.mock_petscan_response
+    mock_requests.get.return_value = mock_response
+
+    actual = self.builder.build(
+        'text/tab-separated-values',
+        url='https://petscan.wmflabs.org.fake/?psid=42&format=wiki')
+    mock_requests.get.assert_called_with(
+        'https://petscan.wmflabs.org.fake/?psid=42&format=json')
+
+  @patch('wp1.selection.models.petscan.requests.get')
+  def test_build_non_200(self, mock_requests_get):
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError
+    mock_requests_get.return_value = mock_response
+
+    with self.assertRaises(Wp1FatalSelectionError):
+      actual = self.builder.build(
+          'text/tab-separated-values',
+          url='https://petscan.wmflabs.org.fake/?psid=42')

--- a/wp1/selection/models/petscan_test.py
+++ b/wp1/selection/models/petscan_test.py
@@ -105,3 +105,24 @@ class PetscanBuilderTest(BaseWpOneDbTest):
       actual = self.builder.build(
           'text/tab-separated-values',
           url='https://petscan.wmflabs.org.fake/?psid=42')
+
+  def test_validate(self):
+    actual = self.builder.validate(
+        url='https://petscan.wmflabs.org.fake/?psid=42&format=wiki')
+    self.assertEqual(('', '', []), actual)
+
+  def test_validate_missing_url(self):
+    actual = self.builder.validate()
+    self.assertEqual(('', '', ['Missing URL parameter']), actual)
+
+  def test_validate_not_a_url(self):
+    afctual = self.builder.validate(url='http:// foo bar [baz]')
+    self.assertEqual(
+        ('', 'http:// foo bar [baz]', ['That doesn\'t look like a valid URL.']),
+        actual)
+
+  def test_validate_not_a_petscan_url(self):
+    afctual = self.builder.validate(url='http://en.wikipedia.org/')
+    self.assertEqual(
+        ('', 'http://en.wikipedia.org/',
+         ['Only URLs that lead to petscan.wmflabs.org are allowed.']), actual)

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -26,7 +26,7 @@ def _create_or_update_builder(data, builder_id=None):
   params = data['params']
 
   if not list_name or not project or not model or not params:
-    flask.abort(400)
+    return 'Missing list_name or project or model or params', 400
 
   builder_module = importlib.import_module(model)
   Builder = getattr(builder_module, 'Builder')


### PR DESCRIPTION
[Petscan](https://petscan.wmflabs.org/) allows for powerful methods for selecting articles based on union or intersection of categories, among other features. Particularly notable is the fact that for a category such as `Living_people`, which has over a million results, Petscan is able to generate the article list. It is dubious if our SPARQL Builder would be able to create such a list.

This PR implements a Petscan Builder, as well as a frontend that allows for Petscan selection based on URL.