### PR TITLE
Remove mkdocs from main requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,6 @@ Markdown==3.3.7
 MarkupSafe==2.1.2
 meld3==1.0.2
 mergedeep==1.3.4
-mkdocs==1.4.2
 more-itertools==7.2.0
 mwclient==0.9.3
 mwoauth==0.3.8
@@ -49,6 +48,7 @@ nose==1.3.7
 nose-cprof==0.2.1
 oauthlib==2.1.0
 packaging==21.3
+pathspec==0.11.2
 platformdirs==2.6.2
 pre-commit==2.21.0
 PyJWT==2.4.0


### PR DESCRIPTION
This was included in the main `requirements.txt`, probably as mkdocs was being developed, but is not needed there.