### PR TITLE
Another attempt at fixing flaky cypress tests

### DIFF
--- a/wp1-frontend/cypress/e2e/myLists.cy.js
+++ b/wp1-frontend/cypress/e2e/myLists.cy.js
@@ -6,8 +6,11 @@ describe('the user selection list page', () => {
       cy.intercept('v1/selection/simple/lists', {
         fixture: 'list_data.json',
       }).as('list');
-      cy.intercept('v1/oauth/identify', { fixture: 'identity.json' });
+      cy.intercept('v1/oauth/identify', { fixture: 'identity.json' }).as(
+        'login',
+      );
       cy.visit('/#/selections/user');
+      cy.wait('@login');
       cy.wait('@list');
       cy.get('select').select('25');
     });

--- a/wp1-frontend/cypress/e2e/myLists.cy.js
+++ b/wp1-frontend/cypress/e2e/myLists.cy.js
@@ -12,7 +12,6 @@ describe('the user selection list page', () => {
       cy.visit('/#/selections/user');
       cy.wait('@login');
       cy.wait('@list');
-      cy.get('select').select('25');
     });
 
     it('successfully loads', () => {});

--- a/wp1-frontend/src/components/MyLists.vue
+++ b/wp1-frontend/src/components/MyLists.vue
@@ -201,7 +201,7 @@ export default {
         {
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
-        }
+        },
       );
       var data = await response.json();
       this.list = data.builders;
@@ -210,6 +210,7 @@ export default {
           $('#list-table').DataTable({
             columnDefs: [{ orderable: false, targets: [5, 7, 8] }],
             order: [[2, 'desc']],
+            iDisplayLength: 25,
           });
         });
       } else {


### PR DESCRIPTION
This time, we set the default datatables view to 25 entries, so we don't have to change it in the Cypress test, which was flaky.