### PR TITLE
Use validation results for building Simple Selections

### DIFF
--- a/wp1/selection/models/simple.py
+++ b/wp1/selection/models/simple.py
@@ -1,6 +1,6 @@
 import urllib.parse
 
-from wp1.exceptions import Wp1FatalSelectionError
+from wp1.exceptions import Wp1FatalSelectionError, Wp1RetryableSelectionError
 from wp1.selection.abstract_builder import AbstractBuilder
 
 
@@ -31,12 +31,12 @@ class Builder(AbstractBuilder):
     if 'list' not in params:
       raise Wp1FatalSelectionError('Missing required param: list')
 
-    list_minus_comments = [
-        line.strip()
-        for line in params['list']
-        if line.strip() != '' and not line.startswith('#')
-    ]
-    return '\n'.join(list_minus_comments).encode('utf-8')
+    valid, invalid, errors = self.validate(**params)
+
+    if errors:
+      raise Wp1RetryableSelectionError('The selection contained invalid parameters')
+    
+    return '\n'.join(valid).encode('utf-8')
 
   def validate(self, **params):
     if not params['list']:

--- a/wp1/selection/models/simple_test.py
+++ b/wp1/selection/models/simple_test.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import MagicMock
 
 from wp1.base_db_test import BaseWpOneDbTest, get_first_selection
-from wp1.exceptions import Wp1FatalSelectionError
+from wp1.exceptions import Wp1FatalSelectionError, Wp1RetryableSelectionError
 from wp1.models.wp10.builder import Builder
 from wp1.selection.models.simple import Builder as SimpleBuilder
 
@@ -115,6 +115,11 @@ of text than an actual article name.',
     actual = simple_test_builder.build('text/tab-separated-values',
                                        list=self.valid_items)
     self.assertEqual(expected, actual)
+
+  def test_build_disallows_invalid(self):
+    simple_test_builder = SimpleBuilder()
+    with self.assertRaises(Wp1RetryableSelectionError):
+      simple_test_builder.build('text/tab-separated-values', list=['Foo#Bar'])
 
   def test_validate_items(self):
     simple_builder_test = SimpleBuilder()


### PR DESCRIPTION
Fixes #717. Fixes #719.

This is because the validation results already strip comments and url decode, and invalid lists should not be allowed to be built anyway.