### PR TITLE
Add WikiProject Builder model, only in Python not exposed to frontend yet

### DIFF
--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -131,7 +131,9 @@ def get_builder(wp10db, id_):
   with wp10db.cursor() as cursor:
     cursor.execute('SELECT * FROM builders WHERE b_id = %s', id_)
     db_builder = cursor.fetchone()
-    return Builder(**db_builder) if db_builder else None
+    if db_builder is None:
+      raise ObjectNotFoundError(f'No builder with id={id_}')
+    return Builder(**db_builder)
 
 
 def materialize_builder(builder_cls, builder_id, content_type):

--- a/wp1/selection/abstract_builder.py
+++ b/wp1/selection/abstract_builder.py
@@ -50,7 +50,6 @@ class AbstractBuilder:
 
     selection.set_updated_at_now()
     # Data might be None if build operation didn't succeed.
-    print(selection.data)
     if selection.data:
       self._upload_to_storage(s3, selection, builder)
 

--- a/wp1/selection/abstract_builder.py
+++ b/wp1/selection/abstract_builder.py
@@ -37,16 +37,20 @@ class AbstractBuilder:
     try:
       selection.data = self.build(content_type,
                                   project=builder.b_project.decode('utf-8'),
+                                  wp10db=wp10db,
                                   **params)
     except Wp1RetryableSelectionError as e:
+      logger.exception('Error materializing builder id=%s', builder.b_id)
       selection.s_status = 'CAN_RETRY'
       logic_selection.set_error_messages(selection, e)
     except (Wp1FatalSelectionError, Wp1SelectionError) as e:
+      logger.exception('Error materializing builder id=%s', builder.b_id)
       selection.s_status = 'FAILED'
       logic_selection.set_error_messages(selection, e)
 
     selection.set_updated_at_now()
     # Data might be None if build operation didn't succeed.
+    print(selection.data)
     if selection.data:
       self._upload_to_storage(s3, selection, builder)
 

--- a/wp1/selection/models/wikiproject.py
+++ b/wp1/selection/models/wikiproject.py
@@ -11,7 +11,7 @@ def _get_articles_for_project(wp10db, project):
 
 def _project_exists(wp10db, project):
   with wp10db.cursor() as cursor:
-    cursor.execute('SELECT 1 FROM ratings WHERE r_project = %s',
+    cursor.execute('SELECT 1 FROM projects WHERE p_project = %s',
                    (project.encode('utf-8'),))
     return cursor.fetchone() is not None
 

--- a/wp1/selection/models/wikiproject.py
+++ b/wp1/selection/models/wikiproject.py
@@ -23,28 +23,31 @@ class Builder(AbstractBuilder):
       raise Wp1FatalSelectionError('Unrecognized content type')
     if 'wp10db' not in params:
       raise Wp1FatalSelectionError('Missing param `wp10db`')
-    if 'add' not in params:
-      raise Wp1FatalSelectionError('Missing param `add`')
+    if 'include' not in params:
+      raise Wp1FatalSelectionError('Missing param `include`')
 
-    add = set()
-    for project in params['add']:
-      add.update(_get_articles_for_project(params['wp10db'], project))
+    included_articles = set()
+    for project in params['include']:
+      included_articles.update(
+          _get_articles_for_project(params['wp10db'], project))
 
-    subtract = set()
-    for project in params.get('subtract', []):
-      subtract.update(_get_articles_for_project(params['wp10db'], project))
+    excluded_articles = set()
+    for project in params.get('exclude', []):
+      excluded_articles.update(
+          _get_articles_for_project(params['wp10db'], project))
 
-    return '\n'.join(add.difference(subtract)).encode('utf-8')
+    return '\n'.join(
+        included_articles.difference(excluded_articles)).encode('utf-8')
 
   def validate(self, **params):
     if 'wp10db' not in params:
       raise Wp1FatalSelectionError('Cannot validate without param `wp10db`')
-    if 'add' not in params:
-      return ([], [], ['Missing articles to add'])
+    if 'include' not in params:
+      return ([], [], ['Missing articles to include'])
 
     valid = []
     invalid = []
-    for project in params['add'] + params.get('subtract', []):
+    for project in params['include'] + params.get('exclude', []):
       if _project_exists(params['wp10db'], project):
         valid.append(project)
       else:

--- a/wp1/selection/models/wikiproject.py
+++ b/wp1/selection/models/wikiproject.py
@@ -5,14 +5,14 @@ from wp1.selection.abstract_builder import AbstractBuilder
 def _get_articles_for_project(wp10db, project):
   with wp10db.cursor() as cursor:
     cursor.execute('SELECT r_article FROM ratings WHERE r_project = %s',
-                   (project,))
+                   (project.strip().replace(' ', '_'),))
     return [row['r_article'].decode('utf-8') for row in cursor.fetchall()]
 
 
 def _project_exists(wp10db, project):
   with wp10db.cursor() as cursor:
     cursor.execute('SELECT 1 FROM projects WHERE p_project = %s',
-                   (project.encode('utf-8'),))
+                   (project.replace(' ', '_').encode('utf-8'),))
     return cursor.fetchone() is not None
 
 

--- a/wp1/selection/models/wikiproject.py
+++ b/wp1/selection/models/wikiproject.py
@@ -1,0 +1,57 @@
+from wp1.exceptions import Wp1FatalSelectionError
+from wp1.selection.abstract_builder import AbstractBuilder
+
+
+def _get_articles_for_project(wp10db, project):
+  with wp10db.cursor() as cursor:
+    cursor.execute('SELECT r_article FROM ratings WHERE r_project = %s',
+                   (project,))
+    return [row['r_article'].decode('utf-8') for row in cursor.fetchall()]
+
+
+def _project_exists(wp10db, project):
+  with wp10db.cursor() as cursor:
+    cursor.execute('SELECT 1 FROM ratings WHERE r_project = %s',
+                   (project.encode('utf-8'),))
+    return cursor.fetchone() is not None
+
+
+class Builder(AbstractBuilder):
+
+  def build(self, content_type, **params):
+    if content_type != 'text/tab-separated-values':
+      raise Wp1FatalSelectionError('Unrecognized content type')
+    if 'wp10db' not in params:
+      raise Wp1FatalSelectionError('Missing param `wp10db`')
+    if 'add' not in params:
+      raise Wp1FatalSelectionError('Missing param `add`')
+
+    add = set()
+    for project in params['add']:
+      add.update(_get_articles_for_project(params['wp10db'], project))
+
+    subtract = set()
+    for project in params.get('subtract', []):
+      subtract.update(_get_articles_for_project(params['wp10db'], project))
+
+    return '\n'.join(add.difference(subtract)).encode('utf-8')
+
+  def validate(self, **params):
+    if 'wp10db' not in params:
+      raise Wp1FatalSelectionError('Cannot validate without param `wp10db`')
+    if 'add' not in params:
+      return ([], [], ['Missing articles to add'])
+
+    valid = []
+    invalid = []
+    for project in params['add'] + params.get('subtract', []):
+      if _project_exists(params['wp10db'], project):
+        valid.append(project)
+      else:
+        invalid.append(project)
+
+    errors = []
+    if invalid:
+      errors = ['Not all given projects exist']
+
+    return (valid, invalid, errors)

--- a/wp1/selection/models/wikiproject_test.py
+++ b/wp1/selection/models/wikiproject_test.py
@@ -1,0 +1,126 @@
+import unittest
+
+from wp1.base_db_test import BaseWpOneDbTest
+from wp1.exceptions import Wp1FatalSelectionError
+from wp1.selection.models.wikiproject import Builder as WikiProjectBuilder
+
+
+class WikiProjectTest(BaseWpOneDbTest):
+
+  def setUp(self):
+    super().setUp()
+    self.builder = WikiProjectBuilder()
+
+    # Four "projects" with a list of somewhat overlapping "articles" for each
+    projects = ('Water', 'Fire', 'Wind', 'Èarth')
+    water_articles = ('Ocëan', 'Lake')
+    fire_articles = ('Campfire', 'Åsh')
+    wind_articles = ('Breeze', 'Ocëan', 'Campfire', 'Åsh')
+    earth_articles = ('Mountain', 'Cave', 'Åsh')
+    all_articles = [
+        water_articles, fire_articles, wind_articles, earth_articles
+    ]
+
+    all_rows = []
+    for i, p in enumerate(projects):
+      all_rows.extend(zip((p,) * len(all_articles[i]), all_articles[i]))
+
+    with self.wp10db.cursor() as cursor:
+      cursor.executemany(
+          'INSERT INTO ratings (r_project, r_namespace, r_article) VALUES (%s, 0, %s)',
+          all_rows)
+
+  def test_validate(self):
+    params = {
+        'add': ['Water', 'Fire', 'Lava'],
+        'subtract': ['Wind', 'Èarth', 'Stone']
+    }
+    actual = self.builder.validate(wp10db=self.wp10db, **params)
+    self.assertEqual((['Water', 'Fire', 'Wind', 'Èarth'
+                      ], ['Lava', 'Stone'], ['Not all given projects exist']),
+                     actual)
+
+  def test_validate_all_valid(self):
+    params = {'add': ['Water', 'Fire'], 'subtract': ['Wind', 'Èarth']}
+    actual = self.builder.validate(wp10db=self.wp10db, **params)
+    self.assertEqual((['Water', 'Fire', 'Wind', 'Èarth'], [], []), actual)
+
+  def test_validate_all_invalid(self):
+    params = {'add': ['Lava'], 'subtract': ['Stone']}
+    actual = self.builder.validate(wp10db=self.wp10db, **params)
+    self.assertEqual(([], ['Lava', 'Stone'], ['Not all given projects exist']),
+                     actual)
+
+  def test_validate_missing_add(self):
+    params = {'subtract': ['Water', 'Fire']}
+    actual = self.builder.validate(wp10db=self.wp10db, **params)
+    self.assertEqual(([], [], ['Missing articles to add']), actual)
+
+  def test_validate_missing_subtract(self):
+    params = {'add': ['Water', 'Fire']}
+    actual = self.builder.validate(wp10db=self.wp10db, **params)
+    self.assertEqual((['Water', 'Fire'], [], []), actual)
+
+  def test_build(self):
+    params = {'add': ['Water', 'Èarth'], 'subtract': ['Fire']}
+    actual = self.builder.build('text/tab-separated-values',
+                                wp10db=self.wp10db,
+                                **params)
+
+    # Ordering is not stable
+    actual_set = set(actual.split(b'\n'))
+    expected_set = set((b'Lake', 'Ocëan'.encode('utf-8'), b'Mountain', b'Cave'))
+
+    self.assertEqual(expected_set, actual_set)
+
+  def test_build_single_project(self):
+    params = {'add': ['Water']}
+    actual = self.builder.build('text/tab-separated-values',
+                                wp10db=self.wp10db,
+                                **params)
+
+    # Ordering is not stable
+    actual_set = set(actual.split(b'\n'))
+    expected_set = set((b'Lake', 'Ocëan'.encode('utf-8')))
+
+    self.assertEqual(expected_set, actual_set)
+
+  def test_build_empty_set(self):
+
+    params = {'add': ['Water', 'Èarth'], 'subtract': ['Water', 'Èarth']}
+    actual = self.builder.build('text/tab-separated-values',
+                                wp10db=self.wp10db,
+                                **params)
+
+    self.assertEqual(b'', actual)
+
+  def test_build_multiples(self):
+    params = {'add': ['Water', 'Earth', 'Water'], 'subtract': ['Fire', 'Fire']}
+    actual = self.builder.build('text/tab-separated-values',
+                                wp10db=self.wp10db,
+                                **params)
+
+    # Ordering is not stable
+    articles = actual.split(b'\n')
+    self.assertEqual(2, len(articles))
+    actual_set = set(articles)
+    expected_set = set((b'Lake', 'Ocëan'.encode('utf-8')))
+
+    self.assertEqual(expected_set, actual_set)
+
+  def test_build_invalid_content_type(self):
+    params = {'add': ['Water', 'Èarth'], 'subtract': ['Fire']}
+    with self.assertRaises(Wp1FatalSelectionError):
+      self.builder.build('foo/bar', wp10db=self.wp10db, **params)
+
+  def test_build_missing_wp10db(self):
+    params = {'add': ['Water', 'Èarth'], 'subtract': ['Fire']}
+    with self.assertRaises(Wp1FatalSelectionError):
+      self.builder.build('text/tab-separated-values', **params)
+
+  def test_build_missing_add(self):
+    params = {'subtract': ['Fire']}
+    with self.assertRaises(Wp1FatalSelectionError):
+      self.builder.build('text/tab-separated-values',
+                         wp10db=self.wp10db,
+                         **params)

--- a/wp1/selection/models/wikiproject_test.py
+++ b/wp1/selection/models/wikiproject_test.py
@@ -35,8 +35,8 @@ class WikiProjectTest(BaseWpOneDbTest):
 
   def test_validate(self):
     params = {
-        'add': ['Water Elements', 'Fire', 'Lava'],
-        'subtract': ['Wind', 'Èarth', 'Stone']
+        'include': ['Water Elements', 'Fire', 'Lava'],
+        'exclude': ['Wind', 'Èarth', 'Stone']
     }
     actual = self.builder.validate(wp10db=self.wp10db, **params)
     self.assertEqual((['Water Elements', 'Fire', 'Wind', 'Èarth'
@@ -44,29 +44,37 @@ class WikiProjectTest(BaseWpOneDbTest):
                      actual)
 
   def test_validate_all_valid(self):
-    params = {'add': ['Water Elements', 'Fire'], 'subtract': ['Wind', 'Èarth']}
+    params = {
+        'include': ['Water Elements', 'Fire'],
+        'exclude': ['Wind', 'Èarth']
+    }
     actual = self.builder.validate(wp10db=self.wp10db, **params)
     self.assertEqual((['Water Elements', 'Fire', 'Wind', 'Èarth'], [], []),
                      actual)
 
   def test_validate_all_invalid(self):
-    params = {'add': ['Lava'], 'subtract': ['Stone']}
+    params = {'include': ['Lava'], 'exclude': ['Stone']}
     actual = self.builder.validate(wp10db=self.wp10db, **params)
     self.assertEqual(([], ['Lava', 'Stone'], ['Not all given projects exist']),
                      actual)
 
-  def test_validate_missing_add(self):
-    params = {'subtract': ['Water Elements', 'Fire']}
+  def test_validate_missing_include(self):
+    params = {'exclude': ['Water Elements', 'Fire']}
     actual = self.builder.validate(wp10db=self.wp10db, **params)
-    self.assertEqual(([], [], ['Missing articles to add']), actual)
+    self.assertEqual(([], [], ['Missing articles to include']), actual)
 
-  def test_validate_missing_subtract(self):
-    params = {'add': ['Water Elements', 'Fire']}
+  def test_validate_missing_exclude(self):
+    params = {'include': ['Water Elements', 'Fire']}
     actual = self.builder.validate(wp10db=self.wp10db, **params)
     self.assertEqual((['Water Elements', 'Fire'], [], []), actual)
 
+  def test_validate_missing_wp10db(self):
+    params = {'include': ['Lava'], 'exclude': ['Stone']}
+    with self.assertRaises(Wp1FatalSelectionError):
+      self.builder.validate(**params)
+
   def test_build(self):
-    params = {'add': ['Water Elements', 'Èarth'], 'subtract': ['Fire']}
+    params = {'include': ['Water Elements', 'Èarth'], 'exclude': ['Fire']}
     actual = self.builder.build('text/tab-separated-values',
                                 wp10db=self.wp10db,
                                 **params)
@@ -78,7 +86,7 @@ class WikiProjectTest(BaseWpOneDbTest):
     self.assertEqual(expected_set, actual_set)
 
   def test_build_single_project(self):
-    params = {'add': ['Water Elements']}
+    params = {'include': ['Water Elements']}
     actual = self.builder.build('text/tab-separated-values',
                                 wp10db=self.wp10db,
                                 **params)
@@ -92,8 +100,8 @@ class WikiProjectTest(BaseWpOneDbTest):
   def test_build_empty_set(self):
 
     params = {
-        'add': ['Water Elements', 'Èarth'],
-        'subtract': ['Water Elements', 'Èarth']
+        'include': ['Water Elements', 'Èarth'],
+        'exclude': ['Water Elements', 'Èarth']
     }
     actual = self.builder.build('text/tab-separated-values',
                                 wp10db=self.wp10db,
@@ -103,8 +111,8 @@ class WikiProjectTest(BaseWpOneDbTest):
 
   def test_build_multiples(self):
     params = {
-        'add': ['Water Elements', 'Earth', 'Water Elements'],
-        'subtract': ['Fire', 'Fire']
+        'include': ['Water Elements', 'Earth', 'Water Elements'],
+        'exclude': ['Fire', 'Fire']
     }
     actual = self.builder.build('text/tab-separated-values',
                                 wp10db=self.wp10db,
@@ -119,17 +127,17 @@ class WikiProjectTest(BaseWpOneDbTest):
     self.assertEqual(expected_set, actual_set)
 
   def test_build_invalid_content_type(self):
-    params = {'add': ['Water Elements', 'Èarth'], 'subtract': ['Fire']}
+    params = {'include': ['Water Elements', 'Èarth'], 'exclude': ['Fire']}
     with self.assertRaises(Wp1FatalSelectionError):
       self.builder.build('foo/bar', wp10db=self.wp10db, **params)
 
   def test_build_missing_wp10db(self):
-    params = {'add': ['Water Elements', 'Èarth'], 'subtract': ['Fire']}
+    params = {'include': ['Water Elements', 'Èarth'], 'exclude': ['Fire']}
     with self.assertRaises(Wp1FatalSelectionError):
       self.builder.build('text/tab-separated-values', **params)
 
-  def test_build_missing_add(self):
-    params = {'subtract': ['Fire']}
+  def test_build_missing_include(self):
+    params = {'exclude': ['Fire']}
     with self.assertRaises(Wp1FatalSelectionError):
       self.builder.build('text/tab-separated-values',
                          wp10db=self.wp10db,

--- a/wp1/selection/models/wikiproject_test.py
+++ b/wp1/selection/models/wikiproject_test.py
@@ -12,7 +12,7 @@ class WikiProjectTest(BaseWpOneDbTest):
     self.builder = WikiProjectBuilder()
 
     # Four "projects" with a list of somewhat overlapping "articles" for each
-    projects = ('Water', 'Fire', 'Wind', 'Èarth')
+    projects = ('Water_Elements', 'Fire', 'Wind', 'Èarth')
     water_articles = ('Ocëan', 'Lake')
     fire_articles = ('Campfire', 'Åsh')
     wind_articles = ('Breeze', 'Ocëan', 'Campfire', 'Åsh')
@@ -35,18 +35,19 @@ class WikiProjectTest(BaseWpOneDbTest):
 
   def test_validate(self):
     params = {
-        'add': ['Water', 'Fire', 'Lava'],
+        'add': ['Water Elements', 'Fire', 'Lava'],
         'subtract': ['Wind', 'Èarth', 'Stone']
     }
     actual = self.builder.validate(wp10db=self.wp10db, **params)
-    self.assertEqual((['Water', 'Fire', 'Wind', 'Èarth'
+    self.assertEqual((['Water Elements', 'Fire', 'Wind', 'Èarth'
                       ], ['Lava', 'Stone'], ['Not all given projects exist']),
                      actual)
 
   def test_validate_all_valid(self):
-    params = {'add': ['Water', 'Fire'], 'subtract': ['Wind', 'Èarth']}
+    params = {'add': ['Water Elements', 'Fire'], 'subtract': ['Wind', 'Èarth']}
     actual = self.builder.validate(wp10db=self.wp10db, **params)
-    self.assertEqual((['Water', 'Fire', 'Wind', 'Èarth'], [], []), actual)
+    self.assertEqual((['Water Elements', 'Fire', 'Wind', 'Èarth'], [], []),
+                     actual)
 
   def test_validate_all_invalid(self):
     params = {'add': ['Lava'], 'subtract': ['Stone']}
@@ -55,17 +56,17 @@ class WikiProjectTest(BaseWpOneDbTest):
                      actual)
 
   def test_validate_missing_add(self):
-    params = {'subtract': ['Water', 'Fire']}
+    params = {'subtract': ['Water Elements', 'Fire']}
     actual = self.builder.validate(wp10db=self.wp10db, **params)
     self.assertEqual(([], [], ['Missing articles to add']), actual)
 
   def test_validate_missing_subtract(self):
-    params = {'add': ['Water', 'Fire']}
+    params = {'add': ['Water Elements', 'Fire']}
     actual = self.builder.validate(wp10db=self.wp10db, **params)
-    self.assertEqual((['Water', 'Fire'], [], []), actual)
+    self.assertEqual((['Water Elements', 'Fire'], [], []), actual)
 
   def test_build(self):
-    params = {'add': ['Water', 'Èarth'], 'subtract': ['Fire']}
+    params = {'add': ['Water Elements', 'Èarth'], 'subtract': ['Fire']}
     actual = self.builder.build('text/tab-separated-values',
                                 wp10db=self.wp10db,
                                 **params)
@@ -77,7 +78,7 @@ class WikiProjectTest(BaseWpOneDbTest):
     self.assertEqual(expected_set, actual_set)
 
   def test_build_single_project(self):
-    params = {'add': ['Water']}
+    params = {'add': ['Water Elements']}
     actual = self.builder.build('text/tab-separated-values',
                                 wp10db=self.wp10db,
                                 **params)
@@ -90,7 +91,10 @@ class WikiProjectTest(BaseWpOneDbTest):
 
   def test_build_empty_set(self):
 
-    params = {'add': ['Water', 'Èarth'], 'subtract': ['Water', 'Èarth']}
+    params = {
+        'add': ['Water Elements', 'Èarth'],
+        'subtract': ['Water Elements', 'Èarth']
+    }
     actual = self.builder.build('text/tab-separated-values',
                                 wp10db=self.wp10db,
                                 **params)
@@ -98,7 +102,10 @@ class WikiProjectTest(BaseWpOneDbTest):
     self.assertEqual(b'', actual)
 
   def test_build_multiples(self):
-    params = {'add': ['Water', 'Earth', 'Water'], 'subtract': ['Fire', 'Fire']}
+    params = {
+        'add': ['Water Elements', 'Earth', 'Water Elements'],
+        'subtract': ['Fire', 'Fire']
+    }
     actual = self.builder.build('text/tab-separated-values',
                                 wp10db=self.wp10db,
                                 **params)
@@ -112,12 +119,12 @@ class WikiProjectTest(BaseWpOneDbTest):
     self.assertEqual(expected_set, actual_set)
 
   def test_build_invalid_content_type(self):
-    params = {'add': ['Water', 'Èarth'], 'subtract': ['Fire']}
+    params = {'add': ['Water Elements', 'Èarth'], 'subtract': ['Fire']}
     with self.assertRaises(Wp1FatalSelectionError):
       self.builder.build('foo/bar', wp10db=self.wp10db, **params)
 
   def test_build_missing_wp10db(self):
-    params = {'add': ['Water', 'Èarth'], 'subtract': ['Fire']}
+    params = {'add': ['Water Elements', 'Èarth'], 'subtract': ['Fire']}
     with self.assertRaises(Wp1FatalSelectionError):
       self.builder.build('text/tab-separated-values', **params)
 

--- a/wp1/selection/models/wikiproject_test.py
+++ b/wp1/selection/models/wikiproject_test.py
@@ -29,6 +29,9 @@ class WikiProjectTest(BaseWpOneDbTest):
       cursor.executemany(
           'INSERT INTO ratings (r_project, r_namespace, r_article) VALUES (%s, 0, %s)',
           all_rows)
+      cursor.executemany(
+          'INSERT INTO projects (p_project, p_timestamp) VALUES (%s, 0)',
+          projects)
 
   def test_validate(self):
     params = {

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -19,7 +19,7 @@ builders = flask.Blueprint('builders', __name__)
 logger = logging.getLogger(__name__)
 
 
-def _create_or_update_builder(data, builder_id=None):
+def _create_or_update_builder(wp10db, data, builder_id=None):
   list_name = data['name']
   project = data['project']
   model = data['model']
@@ -36,6 +36,7 @@ def _create_or_update_builder(data, builder_id=None):
 
   builder = Builder()
   valid_values, invalid_values, errors = builder.validate(project=project,
+                                                          wp10db=wp10db,
                                                           **params)
   if invalid_values or errors:
     return flask.jsonify({
@@ -73,15 +74,17 @@ def _create_or_update_builder(data, builder_id=None):
 @builders.route('/', methods=['POST'])
 @authenticate
 def create_builder():
+  wp10db = get_db('wp10db')
   data = flask.request.get_json()
-  return _create_or_update_builder(data)
+  return _create_or_update_builder(wp10db, data)
 
 
 @builders.route('/<builder_id>', methods=['POST'])
 @authenticate
 def update_builder(builder_id):
+  wp10db = get_db('wp10db')
   data = flask.request.get_json()
-  return _create_or_update_builder(data, builder_id)
+  return _create_or_update_builder(wp10db, data, builder_id)
 
 
 @builders.route('/<builder_id>')


### PR DESCRIPTION
In WP1, we have the concept of a Builder, which is a sort of module that knows how to "build" selections from various data sources and parameters. For example, the Simple builder takes a `list=['Article 1', 'Article 2', ...]` parameter and does some validation before echoing back the list as a selection. The SPARQL Builder sends a SPARQL query to the Wikidata API and formats the response into a selection.

Note that in the codebase, "builder" is also the name given to a user's specific instance of a Builder, with the parameters instantiated and saved in the database.

In this PR, we introduce the WikiProject Builder, to create a selection based on the articles that are part of one or more WikiProjects. WP1 already has a mapping of WikiProjects -> articles, based on the work of the WP1.0 Bot. The WikiProject Builder takes two parameters:

`add` - A list of WikiProjects whose articles should be added, calculated as the articles that are a unique set of articles from the union of these projects

`subtract` - A list of WikiPorjects whose articles should be excluded, again calculated as the articles that are a unique set of articles from the union of the projects.

The end result is the set difference between the articles generated by `add` and those generated by `subtract`. So the full formula is:

```
For A, B in ADD; C, D in SUBTRACT:
(A ∪ B) - (C ∪ D)
```

Additionally, the validation step confirms that every WikiProject specified in either parameter actually exists in the database.

Finally, we add a new parameter that AbstractBuilder sends to it's subclasses, `wp10db=`, which is the database connection to the application database. This is possible because the `build` and `validate` methods have a contract where they accept a `**params` list of parameters, so additional keyword arguments can be added freely and are ignored by Builder implementations that are not expecting them.

As part of this system, the `b_params` field of the `builders` table in the database is a JSON encoded string that represents the `params` dictionary. So in the case of the SimpleBuilder mentioned above:

```
b_params == '{"list": ["Article 1", Article 2"]}'
```

This system makes it easy to store arbitrary parameters that a Builder might need, and pass them to the Builder implementation at runtime without any knowledge of a "schema".