### PR TITLE
Frontend for WikiProject Builder

### DIFF
--- a/wp1-frontend/cypress/e2e/createWikiProjectList.cy.js
+++ b/wp1-frontend/cypress/e2e/createWikiProjectList.cy.js
@@ -1,0 +1,123 @@
+/// <reference types="Cypress" />
+
+describe('the create WikiProject builder page', () => {
+  describe('when the user is logged in', () => {
+    beforeEach(() => {
+      cy.intercept('v1/sites/', { fixture: 'sites.json' });
+      cy.intercept('v1/oauth/identify', { fixture: 'identity.json' });
+      cy.visit('/#/selections/wikiproject');
+    });
+
+    it('successfully loads', () => {});
+
+    it('displays only en.wikipedia.org', () => {
+      cy.get('select').contains('en.wikipedia.org');
+      cy.get('select').find('option').should('have.length', 1);
+    });
+
+    it('validates list name on clicking save', () => {
+      cy.get('#saveListButton').click();
+      cy.get('#listName').contains('Please provide a valid list name');
+    });
+
+    it('validates textbox on clicking save', () => {
+      cy.get('#saveListButton').click();
+      cy.get('#listName > .invalid-feedback').should('be.visible');
+      cy.get('#add-items ~ .invalid-feedback').should('be.visible');
+    });
+
+    it('validates list name on losing focus', () => {
+      cy.get('#listName > .form-control').click();
+      cy.get('#add-items').click();
+      cy.get('#listName > .invalid-feedback').should('be.visible');
+    });
+
+    it('displays a textbox with invalid wikiProjects', () => {
+      cy.get('#listName > .form-control').click().type('List name');
+      cy.get('#add-items').click().type('Fake Project 1\nAnother Fake');
+      cy.intercept('v1/builders/', {
+        fixture: 'save_wikiproject_failure.json',
+      });
+      cy.get('#saveListButton').click();
+
+      cy.get('#add-items').should('have.value', 'Fake Project 1\nAnother Fake');
+      cy.get('#invalid_articles > .form-control').should(
+        'have.value',
+        'Fake Project 1\nAnother Fake',
+      );
+    });
+
+    it('saves successfully after fixing invalid names', () => {
+      let count = 0;
+      cy.intercept('v1/builders/', (req) => {
+        if (count === 0) {
+          // First request fails.
+          count++;
+          req.reply({
+            statusCode: 200,
+            fixture: 'save_wikiproject_failure.json',
+          });
+        } else {
+          req.reply({
+            statusCode: 200,
+            fixture: 'save_list_success.json',
+          });
+        }
+      });
+
+      cy.get('#listName > .form-control').click().type('List Name');
+      cy.get('#add-items').click().type('Fake Project 1\nAnother Fake');
+      cy.get('#saveListButton').click();
+
+      cy.get('#add-items').click().clear().type('Water');
+      cy.get('#saveListButton').click();
+      cy.url().should('eq', 'http://localhost:5173/#/selections/user');
+    });
+
+    describe('when save button clicked', () => {
+      beforeEach(() => {
+        cy.intercept('v1/builders/', (req) => {
+          req.continue(() => {
+            return new Promise((resolve) => {
+              setTimeout(resolve, 4000);
+            });
+          });
+        });
+      });
+
+      it('shows spinner', () => {
+        cy.get('#listName > .form-control').click().type('List Name');
+        cy.get('#add-items').click().type('Fake Project');
+        cy.get('#saveListButton').click();
+        cy.get('#saveLoader').should('be.visible');
+      });
+
+      it('disables save button', () => {
+        cy.get('#listName > .form-control').click().type('List Name');
+        cy.get('#add-items').click().type('Fake Project');
+        cy.get('#saveListButton').click();
+        cy.get('#saveListButton').should('have.attr', 'disabled');
+      });
+    });
+
+    it('redirects on saving valid article names', () => {
+      cy.get('#listName > .form-control').click().type('List Name');
+      cy.get('#add-items').click().type('Fake Project\nAnother Fake');
+      cy.intercept('v1/builders/', { fixture: 'save_list_success.json' });
+      cy.get('#saveListButton').click();
+      cy.url().should('eq', 'http://localhost:5173/#/selections/user');
+    });
+  });
+
+  describe('when the user is not logged in', () => {
+    beforeEach(() => {
+      cy.intercept('v1/sites/', { fixture: 'sites.json' });
+    });
+
+    it('opens login page', () => {
+      cy.visit('/#/selections/simple');
+      cy.contains('Please Log In To Continue');
+      cy.get('.pt-2 > .btn');
+    });
+  });
+});

--- a/wp1-frontend/cypress/e2e/createWikiProjectList.cy.js
+++ b/wp1-frontend/cypress/e2e/createWikiProjectList.cy.js
@@ -68,8 +68,6 @@ describe('the create WikiProject builder page', () => {
       cy.get('#listName > .form-control').click().type('List Name');
       cy.get('#add-items').click().type('Fake Project 1\nAnother Fake');
       cy.get('#saveListButton').click();
-
-      cy.get('#add-items').click().clear().type('Water');
       cy.get('#saveListButton').click();
       cy.url().should('eq', 'http://localhost:5173/#/selections/user');
     });
@@ -100,7 +98,7 @@ describe('the create WikiProject builder page', () => {
       });
     });
 
-    it('redirects on saving valid article names', () => {
+    it('redirects on saving valid project names', () => {
       cy.get('#listName > .form-control').click().type('List Name');
       cy.get('#add-items').click().type('Fake Project\nAnother Fake');
       cy.intercept('v1/builders/', { fixture: 'save_list_success.json' });

--- a/wp1-frontend/cypress/e2e/createWikiProjectList.cy.js
+++ b/wp1-frontend/cypress/e2e/createWikiProjectList.cy.js
@@ -23,24 +23,27 @@ describe('the create WikiProject builder page', () => {
     it('validates textbox on clicking save', () => {
       cy.get('#saveListButton').click();
       cy.get('#listName > .invalid-feedback').should('be.visible');
-      cy.get('#add-items ~ .invalid-feedback').should('be.visible');
+      cy.get('#include-items ~ .invalid-feedback').should('be.visible');
     });
 
     it('validates list name on losing focus', () => {
       cy.get('#listName > .form-control').click();
-      cy.get('#add-items').click();
+      cy.get('#include-items').click();
       cy.get('#listName > .invalid-feedback').should('be.visible');
     });
 
     it('displays a textbox with invalid wikiProjects', () => {
       cy.get('#listName > .form-control').click().type('List name');
-      cy.get('#add-items').click().type('Fake Project 1\nAnother Fake');
+      cy.get('#include-items').click().type('Fake Project 1\nAnother Fake');
       cy.intercept('v1/builders/', {
         fixture: 'save_wikiproject_failure.json',
       });
       cy.get('#saveListButton').click();
 
-      cy.get('#add-items').should('have.value', 'Fake Project 1\nAnother Fake');
+      cy.get('#include-items').should(
+        'have.value',
+        'Fake Project 1\nAnother Fake',
+      );
       cy.get('#invalid_articles > .form-control').should(
         'have.value',
         'Fake Project 1\nAnother Fake',
@@ -66,7 +69,7 @@ describe('the create WikiProject builder page', () => {
       });
 
       cy.get('#listName > .form-control').click().type('List Name');
-      cy.get('#add-items').click().type('Fake Project 1\nAnother Fake');
+      cy.get('#include-items').click().type('Fake Project 1\nAnother Fake');
       cy.get('#saveListButton').click();
       cy.get('#saveListButton').click();
       cy.url().should('eq', 'http://localhost:5173/#/selections/user');
@@ -85,14 +88,14 @@ describe('the create WikiProject builder page', () => {
 
       it('shows spinner', () => {
         cy.get('#listName > .form-control').click().type('List Name');
-        cy.get('#add-items').click().type('Fake Project');
+        cy.get('#include-items').click().type('Fake Project');
         cy.get('#saveListButton').click();
         cy.get('#saveLoader').should('be.visible');
       });
 
       it('disables save button', () => {
         cy.get('#listName > .form-control').click().type('List Name');
-        cy.get('#add-items').click().type('Fake Project');
+        cy.get('#include-items').click().type('Fake Project');
         cy.get('#saveListButton').click();
         cy.get('#saveListButton').should('have.attr', 'disabled');
       });
@@ -100,7 +103,7 @@ describe('the create WikiProject builder page', () => {
 
     it('redirects on saving valid project names', () => {
       cy.get('#listName > .form-control').click().type('List Name');
-      cy.get('#add-items').click().type('Fake Project\nAnother Fake');
+      cy.get('#include-items').click().type('Fake Project\nAnother Fake');
       cy.intercept('v1/builders/', { fixture: 'save_list_success.json' });
       cy.get('#saveListButton').click();
       cy.url().should('eq', 'http://localhost:5173/#/selections/user');

--- a/wp1-frontend/cypress/e2e/createWikiProjectList.cy.js
+++ b/wp1-frontend/cypress/e2e/createWikiProjectList.cy.js
@@ -33,8 +33,10 @@ describe('the create WikiProject builder page', () => {
     });
 
     it('displays a textbox with invalid wikiProjects', () => {
-      cy.get('#listName > .form-control').click().type('List name');
-      cy.get('#include-items').click().type('Fake Project 1\nAnother Fake');
+      cy.get('#listName > .form-control').click();
+      cy.get('#listName > .form-control').type('List name');
+      cy.get('#include-items').click();
+      cy.get('#include-items').type('Fake Project 1\nAnother Fake');
       cy.intercept('v1/builders/', {
         fixture: 'save_wikiproject_failure.json',
       });
@@ -68,8 +70,10 @@ describe('the create WikiProject builder page', () => {
         }
       });
 
-      cy.get('#listName > .form-control').click().type('List Name');
-      cy.get('#include-items').click().type('Fake Project 1\nAnother Fake');
+      cy.get('#listName > .form-control').click();
+      cy.get('#listName > .form-control').type('List Name');
+      cy.get('#include-items').click();
+      cy.get('#include-items').type('Fake Project 1\nAnother Fake');
       cy.get('#saveListButton').click();
       cy.get('#saveListButton').click();
       cy.url().should('eq', 'http://localhost:5173/#/selections/user');
@@ -87,23 +91,29 @@ describe('the create WikiProject builder page', () => {
       });
 
       it('shows spinner', () => {
-        cy.get('#listName > .form-control').click().type('List Name');
-        cy.get('#include-items').click().type('Fake Project');
+        cy.get('#listName > .form-control').click();
+        cy.get('#listName > .form-control').type('List Name');
+        cy.get('#include-items').click();
+        cy.get('#include-items').type('Fake Project');
         cy.get('#saveListButton').click();
         cy.get('#saveLoader').should('be.visible');
       });
 
       it('disables save button', () => {
-        cy.get('#listName > .form-control').click().type('List Name');
-        cy.get('#include-items').click().type('Fake Project');
+        cy.get('#listName > .form-control').click();
+        cy.get('#listName > .form-control').type('List Name');
+        cy.get('#include-items').click();
+        cy.get('#include-items').type('Fake Project');
         cy.get('#saveListButton').click();
         cy.get('#saveListButton').should('have.attr', 'disabled');
       });
     });
 
     it('redirects on saving valid project names', () => {
-      cy.get('#listName > .form-control').click().type('List Name');
-      cy.get('#include-items').click().type('Fake Project\nAnother Fake');
+      cy.get('#listName > .form-control').click();
+      cy.get('#listName > .form-control').type('List Name');
+      cy.get('#include-items').click();
+      cy.get('#include-items').type('Fake Project\nAnother Fake');
       cy.intercept('v1/builders/', { fixture: 'save_list_success.json' });
       cy.get('#saveListButton').click();
       cy.url().should('eq', 'http://localhost:5173/#/selections/user');

--- a/wp1-frontend/cypress/e2e/updateWikiProjectList.cy.js
+++ b/wp1-frontend/cypress/e2e/updateWikiProjectList.cy.js
@@ -1,0 +1,150 @@
+/// <reference types="Cypress" />
+
+describe('the update wikiproject list page', () => {
+  describe('when the user is logged in', () => {
+    beforeEach(() => {
+      cy.intercept('v1/sites/', { fixture: 'sites.json' }).as('sites');
+      cy.intercept('v1/oauth/identify', { fixture: 'identity.json' }).as(
+        'identity',
+      );
+    });
+
+    describe('and the builder is found', () => {
+      beforeEach(() => {
+        cy.intercept('GET', 'v1/builders/1', {
+          fixture: 'wikiproject_builder.json',
+        }).as('builder');
+        cy.visit('/#/selections/wikiproject/1');
+        cy.wait('@sites');
+        cy.wait('@identity');
+        cy.wait('@builder');
+      });
+
+      it('successfully loads', () => {});
+
+      it('displays only en.wikipedia.org', () => {
+        cy.get('select').contains('en.wikipedia.org');
+        cy.get('select').find('option').should('have.length', 1);
+      });
+
+      it('displays builder information', () => {
+        cy.get('#listName > .form-control').should('have.value', 'Builder 1');
+        cy.get('#add-items').should(
+          'have.value',
+          'British Columbia road transport\nNew Brunswick road transport',
+        );
+        cy.get('#project > select').should('have.value', 'en.wikipedia.org');
+      });
+
+      it('does not show invalid list items', () => {
+        cy.get('#add-items ~ .invalid-feedback').should('not.be.visible');
+      });
+
+      it('does not show invalid list name', () => {
+        cy.get('#listName > .invalid-feedback').should('not.be.visible');
+      });
+
+      it('displays a textbox with invalid project names', () => {
+        cy.intercept('v1/builders/1', {
+          fixture: 'save_wikiproject_failure.json',
+        });
+        cy.get('#updateListButton').click();
+
+        cy.get('#invalid_articles > .form-control').should(
+          'have.value',
+          'Fake Project 1\nAnother Fake',
+        );
+      });
+
+      it('redirects on saving valid project names', () => {
+        cy.intercept('POST', 'v1/builders/1', {
+          fixture: 'save_list_success.json',
+        });
+        cy.get('#updateListButton').click();
+        cy.url().should('eq', 'http://localhost:5173/#/selections/user');
+      });
+
+      describe('when update button clicked', () => {
+        beforeEach(() => {
+          cy.intercept('POST', 'v1/builders/1', (req) => {
+            req.continue(() => {
+              return new Promise((resolve) => {
+                setTimeout(resolve, 4000);
+              });
+            });
+          });
+        });
+
+        it('shows spinner', () => {
+          cy.get('#updateListButton').click();
+          cy.get('#updateLoader').should('be.visible');
+        });
+
+        it('disables update button', () => {
+          cy.get('#updateListButton').click();
+          cy.get('#updateListButton').should('have.attr', 'disabled');
+        });
+      });
+    });
+
+    describe('and the builder has fatal errors', () => {
+      beforeEach(() => {
+        cy.intercept('GET', 'v1/builders/1', {
+          fixture: 'wikiproject_builder_fatal_error.json',
+        });
+        cy.visit('/#/selections/wikiproject/1');
+      });
+
+      it('displays the error div', () => {
+        cy.get('.materialize-error').should('be.visible');
+      });
+
+      it('disables the retry button', () => {
+        cy.get('.materialize-error .btn').should('have.attr', 'disabled');
+      });
+    });
+
+    describe('and the builder has retryable errors', () => {
+      beforeEach(() => {
+        cy.intercept('GET', 'v1/builders/1', {
+          fixture: 'wikiproject_builder_retryable_error.json',
+        });
+        cy.visit('/#/selections/wikiproject/1');
+      });
+
+      it('displays the error div', () => {
+        cy.get('.materialize-error').should('be.visible');
+      });
+
+      it('enables the retry button', () => {
+        cy.get('.materialize-error .btn').should('not.have.attr', 'disabled');
+      });
+    });
+
+    describe('and the builder is not found', () => {
+      beforeEach(() => {
+        cy.intercept('GET', 'v1/builders/1', {
+          statusCode: 404,
+          body: '404 NOT FOUND',
+        });
+        cy.visit('/#/selections/wikiproject/1');
+      });
+
+      it('displays the 404 text', () => {
+        cy.get('#404').should('be.visible');
+      });
+    });
+  });
+
+  describe('when the user is not logged in', () => {
+    beforeEach(() => {
+      cy.intercept('v1/sites/', { fixture: 'sites.json' });
+    });
+
+    it('opens login page', () => {
+      cy.visit('/#/selections/wikiproject/1');
+      cy.contains('Please Log In To Continue');
+      cy.get('.pt-2 > .btn');
+    });
+  });
+});

--- a/wp1-frontend/cypress/e2e/updateWikiProjectList.cy.js
+++ b/wp1-frontend/cypress/e2e/updateWikiProjectList.cy.js
@@ -29,7 +29,7 @@ describe('the update wikiproject list page', () => {
 
       it('displays builder information', () => {
         cy.get('#listName > .form-control').should('have.value', 'Builder 1');
-        cy.get('#add-items').should(
+        cy.get('#include-items').should(
           'have.value',
           'British Columbia road transport\nNew Brunswick road transport',
         );
@@ -37,7 +37,7 @@ describe('the update wikiproject list page', () => {
       });
 
       it('does not show invalid list items', () => {
-        cy.get('#add-items ~ .invalid-feedback').should('not.be.visible');
+        cy.get('#include-items ~ .invalid-feedback').should('not.be.visible');
       });
 
       it('does not show invalid list name', () => {

--- a/wp1-frontend/cypress/fixtures/save_wikiproject_failure.json
+++ b/wp1-frontend/cypress/fixtures/save_wikiproject_failure.json
@@ -1,0 +1,8 @@
+{
+  "success": false,
+  "items": {
+    "valid": [],
+    "invalid": ["Fake Project 1", "Another Fake"],
+    "errors": ["Not all given projects exist"]
+  }
+}

--- a/wp1-frontend/cypress/fixtures/wikiproject_builder.json
+++ b/wp1-frontend/cypress/fixtures/wikiproject_builder.json
@@ -1,0 +1,10 @@
+{
+  "params": {
+    "add": ["British Columbia road transport", "New Brunswick road transport"],
+    "subtract": ["Countries"]
+  },
+  "name": "Builder 1",
+  "model": "wp1.selection.models.wikiproject",
+  "project": "en.wikipedia.org",
+  "selection_errors": []
+}

--- a/wp1-frontend/cypress/fixtures/wikiproject_builder.json
+++ b/wp1-frontend/cypress/fixtures/wikiproject_builder.json
@@ -1,7 +1,10 @@
 {
   "params": {
-    "add": ["British Columbia road transport", "New Brunswick road transport"],
-    "subtract": ["Countries"]
+    "include": [
+      "British Columbia road transport",
+      "New Brunswick road transport"
+    ],
+    "exclude": ["Countries"]
   },
   "name": "Builder 1",
   "model": "wp1.selection.models.wikiproject",

--- a/wp1-frontend/cypress/fixtures/wikiproject_builder_fatal_error.json
+++ b/wp1-frontend/cypress/fixtures/wikiproject_builder_fatal_error.json
@@ -1,0 +1,18 @@
+{
+  "params": {
+    "add": ["British Columbia road transport", "New Brunswick road transport"],
+    "subtract": ["Countries"]
+  },
+  "name": "Builder 1",
+  "model": "wp1.selection.models.wikiproject",
+  "project": "en.wikipedia.org",
+  "selection_errors": [
+    {
+      "error_messages": [
+        "Wikidata response was not valid JSON. This is usually caused by a timeout because the result set is too large."
+      ],
+      "ext": "tsv",
+      "status": "FAILED"
+    }
+  ]
+}

--- a/wp1-frontend/cypress/fixtures/wikiproject_builder_fatal_error.json
+++ b/wp1-frontend/cypress/fixtures/wikiproject_builder_fatal_error.json
@@ -1,7 +1,10 @@
 {
   "params": {
-    "add": ["British Columbia road transport", "New Brunswick road transport"],
-    "subtract": ["Countries"]
+    "include": [
+      "British Columbia road transport",
+      "New Brunswick road transport"
+    ],
+    "exclude": ["Countries"]
   },
   "name": "Builder 1",
   "model": "wp1.selection.models.wikiproject",

--- a/wp1-frontend/cypress/fixtures/wikiproject_builder_retryable_error.json
+++ b/wp1-frontend/cypress/fixtures/wikiproject_builder_retryable_error.json
@@ -1,7 +1,10 @@
 {
   "params": {
-    "add": ["British Columbia road transport", "New Brunswick road transport"],
-    "subtract": ["Countries"]
+    "include": [
+      "British Columbia road transport",
+      "New Brunswick road transport"
+    ],
+    "exclude": ["Countries"]
   },
   "name": "Builder 1",
   "model": "wp1.selection.models.wikiproject",

--- a/wp1-frontend/cypress/fixtures/wikiproject_builder_retryable_error.json
+++ b/wp1-frontend/cypress/fixtures/wikiproject_builder_retryable_error.json
@@ -1,0 +1,16 @@
+{
+  "params": {
+    "add": ["British Columbia road transport", "New Brunswick road transport"],
+    "subtract": ["Countries"]
+  },
+  "name": "Builder 1",
+  "model": "wp1.selection.models.wikiproject",
+  "project": "en.wikipedia.org",
+  "selection_errors": [
+    {
+      "error_messages": ["There was a timeout."],
+      "ext": "tsv",
+      "status": "CAN_RETRY"
+    }
+  ]
+}

--- a/wp1-frontend/src/components/BaseBuilder.vue
+++ b/wp1-frontend/src/components/BaseBuilder.vue
@@ -85,10 +85,17 @@
             <div ref="form_group" class="form-group">
               <div id="project" class="mb-4 mx-4">
                 <label>Project</label>
-                <select v-model="builder.project" class="custom-select my-list">
-                  <option v-if="wikiProjects.length == 0" selected>
-                    en.wikipedia.org
-                  </option>
+                <select
+                  v-if="wikiProjects.length == 0"
+                  class="custom-select my-list"
+                >
+                  <option selected>en.wikipedia.org</option>
+                </select>
+                <select
+                  v-else
+                  v-model="builder.project"
+                  class="custom-select my-list"
+                >
                   <option v-for="item in wikiProjects" v-bind:key="item">
                     {{ item }}
                   </option>
@@ -201,6 +208,7 @@ export default {
     model: String,
     params: Object,
     serializeParams: Function,
+    projectFilter: Function,
   },
   data: function () {
     return {
@@ -259,7 +267,7 @@ export default {
     getWikiProjects: async function () {
       const response = await fetch(`${import.meta.env.VITE_API_URL}/sites/`);
       var data = await response.json();
-      this.wikiProjects = data.sites;
+      this.wikiProjects = data.sites.filter(this.projectFilter || (() => true));
     },
     getBuilder: async function () {
       const response = await fetch(
@@ -269,7 +277,7 @@ export default {
         {
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
-        }
+        },
       );
       if (response.status == 404) {
         this.notFound = true;
@@ -340,7 +348,7 @@ export default {
     onDelete: async function () {
       if (
         !window.confirm(
-          'Really delete this list? The definition and all downloadable selections will be permanently deleted.'
+          'Really delete this list? The definition and all downloadable selections will be permanently deleted.',
         )
       ) {
         return;

--- a/wp1-frontend/src/components/BookBuilder.vue
+++ b/wp1-frontend/src/components/BookBuilder.vue
@@ -15,8 +15,8 @@
         Use this tool to create an article selection list for the Wikipedia
         project of your choice, based off a Wikipedia Book that you already
         created. You must first "save" your book, then enter the URL of the
-        saved book. Your selection will be saved in public cloud storage and can
-        be accessed through URLs that will be provided once it has been saved.
+        saved book. Your selection will be saved online and will be accessible
+        through a URL that will be provided once it has been saved.
       </p>
       <p class="mb-0">
         For more information on creating a Book selection, see the

--- a/wp1-frontend/src/components/PetscanBuilder.vue
+++ b/wp1-frontend/src/components/PetscanBuilder.vue
@@ -15,8 +15,8 @@
         Use this tool to create an article selection list for the Wikipedia
         project of your choice, based off a
         <a href="https://petscan.wmflabs.org/">Petscan</a> URL. Your selection
-        will be saved in public cloud storage and can be accessed through URLs
-        that will be provided once it has been saved.
+        will be saved online and will be accessible through a URL that will be
+        provided once it has been saved.
       </p>
       <p class="mb-0">
         For more information on creating a

--- a/wp1-frontend/src/components/SecondaryNav.vue
+++ b/wp1-frontend/src/components/SecondaryNav.vue
@@ -71,6 +71,18 @@
               >Book Selection</router-link
             >
           </li>
+          <li
+            :class="
+              'nav-item ' +
+              (this.$route.path.startsWith('/selections/wikiproject')
+                ? 'active'
+                : '')
+            "
+          >
+            <router-link class="nav-link" to="/selections/wikiproject"
+              >WikiProject Selection</router-link
+            >
+          </li>
         </ul>
       </div>
     </nav>

--- a/wp1-frontend/src/components/SimpleBuilder.vue
+++ b/wp1-frontend/src/components/SimpleBuilder.vue
@@ -13,9 +13,8 @@
     <template #create-desc>
       <p>
         Use this tool to create an article selection list for the Wikipedia
-        project of your choice. Your selection will be saved in public cloud
-        storage and can be accessed through URLs that will be provided once it
-        has been saved.
+        project of your choice. Your selection will be saved online and will be
+        accessible through a URL that will be provided once it has been saved.
       </p>
       <p class="mb-0">
         For more information on creating a Simple selection, see the

--- a/wp1-frontend/src/components/SparqlBuilder.vue
+++ b/wp1-frontend/src/components/SparqlBuilder.vue
@@ -14,8 +14,8 @@
         Use this tool to create an article selection list for the Wikipedia
         project of your choice, using a SPARQL query. The query can either be
         entered directly or provided via a Wikidata query service URL. Your
-        selection will be saved in public cloud storage and can be accessed
-        through URLs that will be provided once it has been saved.
+        selection will be saved online and will be accessible through a URL that
+        will be provided once it has been saved.
       </p>
       <p class="mb-0">
         For more information on creating a SPARQL selection, see the

--- a/wp1-frontend/src/components/WikiProjectBuilder.vue
+++ b/wp1-frontend/src/components/WikiProjectBuilder.vue
@@ -23,12 +23,12 @@
     </template>
     <template #extra-params>
       <div id="lists" class="form-group m-4">
-        <label for="add-items">WikiProjects to include</label>
+        <label for="include-items">WikiProjects to include</label>
         <textarea
-          id="add-items"
-          ref="addItems"
+          id="include-items"
+          ref="includeItems"
           class="form-control my-2"
-          v-model="addText"
+          v-model="includeText"
           rows="5"
           required
         ></textarea>
@@ -37,12 +37,12 @@
           Please provide WikiProjects to include
         </div>
 
-        <label for="subtract-items">WikiProjects to exclude</label>
+        <label for="exclude-items">WikiProjects to exclude</label>
         <textarea
-          id="subtract-items"
-          ref="subtractItems"
+          id="exclude-items"
+          ref="excludeItems"
           class="form-control my-2"
-          v-model="subtractText"
+          v-model="excludeText"
           rows="5"
         ></textarea>
       </div>
@@ -58,19 +58,19 @@ export default {
   name: 'WikiProjectBuilder',
   data: function () {
     return {
-      addText: '',
-      subtractText: '',
+      includeText: '',
+      excludeText: '',
       invalidItems: '',
       params: {},
     };
   },
   methods: {
     onBuilderLoaded: function (builder) {
-      this.addText = builder.params.add.join('\n');
-      this.subtractText = builder.params.subtract.join('\n');
+      this.includeText = builder.params.include.join('\n');
+      this.excludeText = builder.params.exclude.join('\n');
     },
     onBeforeSubmit: function () {
-      this.$refs.addItems.setCustomValidity('');
+      this.$refs.includeItems.setCustomValidity('');
     },
     onValidationError: function (data) {
       this.invalidItems = data.items.invalid.join('\n');
@@ -80,21 +80,21 @@ export default {
     },
   },
   watch: {
-    addText: function () {
-      const add = this.subtractText.split('\n');
-      if (add.length === 1 && add[0] === '') {
-        this.params.add = [];
+    includeText: function () {
+      const include = this.excludeText.split('\n');
+      if (include.length === 1 && include[0] === '') {
+        this.params.include = [];
         return;
       }
-      this.params.add = this.addText.split('\n') || [];
+      this.params.include = this.includeText.split('\n') || [];
     },
-    subtractText: function () {
-      const subtract = this.subtractText.split('\n');
-      if (subtract.length === 1 && subtract[0] === '') {
-        this.params.subtract = [];
+    excludeText: function () {
+      const exclude = this.excludeText.split('\n');
+      if (exclude.length === 1 && exclude[0] === '') {
+        this.params.exclude = [];
         return;
       }
-      this.params.subtract = this.subtractText.split('\n');
+      this.params.exclude = this.excludeText.split('\n');
     },
   },
 };

--- a/wp1-frontend/src/components/WikiProjectBuilder.vue
+++ b/wp1-frontend/src/components/WikiProjectBuilder.vue
@@ -70,13 +70,10 @@ export default {
       this.subtractText = builder.params.subtract.join('\n');
     },
     onBeforeSubmit: function () {
-      this.$refs.list.setCustomValidity('');
+      this.$refs.addItems.setCustomValidity('');
     },
     onValidationError: function (data) {
       this.invalidItems = data.items.invalid.join('\n');
-      this.$refs.list.setCustomValidity(
-        'These WikiProjects could not be found',
-      );
     },
     projectFilter: function (projectName) {
       return projectName == 'en.wikipedia.org';

--- a/wp1-frontend/src/components/WikiProjectBuilder.vue
+++ b/wp1-frontend/src/components/WikiProjectBuilder.vue
@@ -6,6 +6,7 @@
     :params="params"
     :builderId="$route.params.builder_id"
     :invalidItems="invalidItems"
+    :projectFilter="projectFilter"
     @onBuilderLoaded="onBuilderLoaded"
     @onBeforeSubmit="onBeforeSubmit"
     @onValidationError="onValidationError"
@@ -77,6 +78,9 @@ export default {
       this.$refs.list.setCustomValidity(
         'These WikiProjects could not be found',
       );
+    },
+    projectFilter: function (projectName) {
+      return projectName == 'en.wikipedia.org';
     },
   },
   watch: {

--- a/wp1-frontend/src/components/WikiProjectBuilder.vue
+++ b/wp1-frontend/src/components/WikiProjectBuilder.vue
@@ -17,8 +17,8 @@
         only (other languages not supported), based off the articles included in
         the specified
         <a href="https://en.wikipedia.org/wiki/WikiProject">WikiProjects</a>.
-        Your selection will be saved in public cloud storage and can be accessed
-        through URLs that will be provided once it has been saved.
+        Your selection will be saved online and will be accessible through a URL
+        that will be provided once it has been saved.
       </p>
     </template>
     <template #extra-params>

--- a/wp1-frontend/src/components/WikiProjectBuilder.vue
+++ b/wp1-frontend/src/components/WikiProjectBuilder.vue
@@ -1,0 +1,103 @@
+<template>
+  <BaseBuilder
+    :key="$route.path"
+    :listName="'WikiProject Selection'"
+    :model="'wp1.selection.models.wikiproject'"
+    :params="params"
+    :builderId="$route.params.builder_id"
+    :invalidItems="invalidItems"
+    @onBuilderLoaded="onBuilderLoaded"
+    @onBeforeSubmit="onBeforeSubmit"
+    @onValidationError="onValidationError"
+  >
+    <template #create-desc>
+      <p>
+        Use this tool to create an article selection list for English Wikipedia
+        only (other languages not supported), based off the articles included in
+        the specified
+        <a href="https://en.wikipedia.org/wiki/WikiProject">WikiProjects</a>.
+        Your selection will be saved in public cloud storage and can be accessed
+        through URLs that will be provided once it has been saved.
+      </p>
+    </template>
+    <template #extra-params>
+      <div id="add-items" class="form-group m-4">
+        <label for="add-items">WikiProjects to include</label>
+        <textarea
+          id="addItems"
+          ref="addItems"
+          class="form-control my-2"
+          v-model="addText"
+          :placeholder="'Finance & Investment\nEconomics'"
+          rows="5"
+        ></textarea>
+
+        <div class="invalid-feedback">
+          Please provide WikiProjects to include
+        </div>
+
+        <label for="add-items">WikiProjects to exclude</label>
+        <textarea
+          id="subtractItems"
+          ref="subtractItems"
+          class="form-control my-2"
+          v-model="subtractText"
+          placeholder="Countries"
+          rows="5"
+        ></textarea>
+      </div>
+    </template>
+  </BaseBuilder>
+</template>
+
+<script>
+import BaseBuilder from './BaseBuilder.vue';
+
+export default {
+  components: { BaseBuilder },
+  name: 'WikiProjectBuilder',
+  data: function () {
+    return {
+      addText: '',
+      subtractText: '',
+      invalidItems: '',
+      params: {},
+    };
+  },
+  methods: {
+    onBuilderLoaded: function (builder) {
+      this.addText = builder.params.add.join('\n');
+      this.subtractText = builder.params.subtract.join('\n');
+    },
+    onBeforeSubmit: function () {
+      this.$refs.list.setCustomValidity('');
+    },
+    onValidationError: function (data) {
+      this.invalidItems = data.items.invalid.join('\n');
+      this.$refs.list.setCustomValidity(
+        'These WikiProjects could not be found',
+      );
+    },
+  },
+  watch: {
+    addText: function () {
+      const add = this.subtractText.split('\n');
+      if (add.length === 1 && add[0] === '') {
+        this.params.add = [];
+        return;
+      }
+      this.params.add = this.addText.split('\n') || [];
+    },
+    subtractText: function () {
+      const subtract = this.subtractText.split('\n');
+      if (subtract.length === 1 && subtract[0] === '') {
+        this.params.subtract = [];
+        return;
+      }
+      this.params.subtract = this.subtractText.split('\n');
+    },
+  },
+};
+</script>
+
+<style scoped></style>

--- a/wp1-frontend/src/components/WikiProjectBuilder.vue
+++ b/wp1-frontend/src/components/WikiProjectBuilder.vue
@@ -22,28 +22,27 @@
       </p>
     </template>
     <template #extra-params>
-      <div id="add-items" class="form-group m-4">
+      <div id="lists" class="form-group m-4">
         <label for="add-items">WikiProjects to include</label>
         <textarea
-          id="addItems"
+          id="add-items"
           ref="addItems"
           class="form-control my-2"
           v-model="addText"
-          :placeholder="'Finance & Investment\nEconomics'"
           rows="5"
+          required
         ></textarea>
 
         <div class="invalid-feedback">
           Please provide WikiProjects to include
         </div>
 
-        <label for="add-items">WikiProjects to exclude</label>
+        <label for="subtract-items">WikiProjects to exclude</label>
         <textarea
-          id="subtractItems"
+          id="subtract-items"
           ref="subtractItems"
           class="form-control my-2"
           v-model="subtractText"
-          placeholder="Countries"
           rows="5"
         ></textarea>
       </div>

--- a/wp1-frontend/src/main.js
+++ b/wp1-frontend/src/main.js
@@ -21,6 +21,7 @@ import MyLists from './components/MyLists.vue';
 import ProjectPage from './components/ProjectPage.vue';
 import UpdatePage from './components/UpdatePage.vue';
 import ZimFile from './components/ZimFile.vue';
+import WikiProjectBuilder from './components/WikiProjectBuilder.vue';
 
 Vue.config.productionTip = false;
 
@@ -127,6 +128,13 @@ const routes = [
     },
   },
   {
+    path: '/selections/wikiproject',
+    component: WikiProjectBuilder,
+    meta: {
+      title: () => BASE_TITLE + ' - Edit WikiProject Selection',
+    },
+  },
+  {
     path: '/selections/simple/:builder_id',
     component: SimpleBuilder,
     meta: {
@@ -152,6 +160,13 @@ const routes = [
     component: BookBuilder,
     meta: {
       title: () => BASE_TITLE + ' - Edit Book Selection',
+    },
+  },
+  {
+    path: '/selections/wikiproject/:builder_id',
+    component: WikiProjectBuilder,
+    meta: {
+      title: () => BASE_TITLE + ' - Edit WikiProject Selection',
     },
   },
   {


### PR DESCRIPTION
The WP1 frontend is written in Vue js (version 2). We have created a component, which essentially acts as a standalone "page", for each type of Builder. The component for each Builder handles both create/update. Conceptually, the individual Builder components "inherit from" the BaseBuilder.vue, though the mechanism is actually more like parameterization.

The WP1 API, which corresponds to Python functions in wp1.web, operates on instances of Builders generically. Similar to how the backend Python code works, builders simply have a list of properties that are common to all of them, with the `params` key in the request/response JSON varying.

The BaseBuilder handles concerns that are common to all Builder components, like providing instruction text, allowing the user to select a Wikimedia project that the Builder applies to, naming and validating the name of the Builder, doing the POST request and responding to generic errors, as well as simpler concerns such as disabling the save button and showing a spinner while the network request is processing.

WIth this design, the subclassed Builder component provides an HTML block for the specification of it's unique parameters. In this PR, that is the `#add-items` and `#subtract-items` text fields. The subclass also provides hooks for pre and post processing of the input. For example, the text field is a newline separated list of WikiProjects, which is `split('\n')` to produce an array for the JSON request. For updates, when the model is loaded from the API, there is a corresponding `join(\n)` that readies the data for display and editing in the text fields.

A notable addition from this PR is the `projectFilter` property on BaseBuilder. This allows child components to provide a filter function (function that corresponds to the [Array.filter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter) API) in order to select which Wikimedia projects the Builder is valid for. This is necessary because the WikiProject Builder only works on en.wikipedia.org. The BaseBuilder defaults to an "empty" filter that returns true for every element if the filter is undefined.

The cypress tests naturally have a large degree of duplication, since they all test pages that are based off of BaseBuilder. However, conceptually, it is appropriate for each page to test that, for example, the builder cannot be saved without a name, even though we know this functionality is implemented in BaseBuilder for the following reasons:

1. We can't test BaseBuilder directly, and
2. In the future, the implementation may change or be refactored, but we would still want this property to hold true.