### PR TITLE
Calculate pageviews for all articles across all wikipedias

### DIFF
--- a/db/migrations/20240429_01_qtSms-add-scores-table.py
+++ b/db/migrations/20240429_01_qtSms-add-scores-table.py
@@ -1,0 +1,22 @@
+"""
+Add scores table
+"""
+
+from yoyo import step
+
+__depends__ = {'20230528_02_pL6ka-add-b-selection-zim-version-to-builders'}
+
+steps = [
+    step('''CREATE TABLE page_scores (
+                ps_project VARBINARY(255),
+                ps_page_id INTEGER NOT NULL,
+                ps_article VARBINARY(255),
+                ps_views INTEGER DEFAULT 0,
+                ps_links INTEGER DEFAULT 0,
+                ps_lang_links INTEGER DEFAULT 0,
+                ps_score INTEGER DEFAULT 0,
+                KEY `page_title` (`ps_project`,  `ps_article`),
+                KEY `page_id` (`ps_page_id`)
+            )''',
+        "DROP TABLE page_scores")
+]

--- a/db/migrations/20240429_01_qtSms-add-scores-table.py
+++ b/db/migrations/20240429_01_qtSms-add-scores-table.py
@@ -7,16 +7,16 @@ from yoyo import step
 __depends__ = {'20230528_02_pL6ka-add-b-selection-zim-version-to-builders'}
 
 steps = [
-    step('''CREATE TABLE page_scores (
-                ps_project VARBINARY(255),
+    step(
+        '''CREATE TABLE page_scores (
+                ps_lang VARBINARY(255),
                 ps_page_id INTEGER NOT NULL,
-                ps_article VARBINARY(255),
+                ps_article VARBINARY(1024),
                 ps_views INTEGER DEFAULT 0,
                 ps_links INTEGER DEFAULT 0,
                 ps_lang_links INTEGER DEFAULT 0,
                 ps_score INTEGER DEFAULT 0,
-                KEY `page_title` (`ps_project`,  `ps_article`),
-                KEY `page_id` (`ps_page_id`)
-            )''',
-        "DROP TABLE page_scores")
+                PRIMARY KEY (`ps_lang`, `ps_page_id`),
+                KEY `lang_article` (`ps_lang`, `ps_article`)
+            )''', 'DROP TABLE page_scores')
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - /data/wp1bot/credentials.py:/usr/src/app/wp1/credentials.py
       - /data/wp1bot/db/yoyo.ini:/usr/src/app/db/production/yoyo.ini
       - /srv/log/wp1bot/:/var/log/wp1bot/
+      - /srv/data/wp1bot/:/var/data/wp1bot/
     links:
       - redis
     logging:

--- a/docker/dev-db/README.md
+++ b/docker/dev-db/README.md
@@ -14,7 +14,7 @@ The dev database will need to be migrated in the following circumstances:
 To migrate, cd to the `db/dev` directory and run the following command:
 
 ```bash
-PYTHONPATH=$PYTHONPATH:../.. yoyo apply
+PYTHONPATH=$PYTHONPATH:../.. pipenv run yoyo apply
 ```
 
 The `PYTHONPATH` environment variable is necessary because some of the migrations

--- a/wp1/credentials.py.dev.e2e
+++ b/wp1/credentials.py.dev.e2e
@@ -39,6 +39,10 @@ CREDENTIALS = {
             'secret': '',
             'bucket': 'org-kiwix-dev-wp1',
         },
+        'FILE_PATH': {
+            # Path where pageviews.bz2 file (~3GB) will be downloaded.
+            'pageviews': '/tmp/pageviews',
+        }
     },
     Environment.TEST: {},
     Environment.PRODUCTION: {}

--- a/wp1/credentials.py.e2e
+++ b/wp1/credentials.py.e2e
@@ -71,6 +71,10 @@ CREDENTIALS = {
             'user': 'farmuser',
             'password': 'farmpass',
             'hook_token': 'hook-token-abc',
+        },
+       'FILE_PATH': {
+            # Path where pageviews.bz2 file (~3GB) will be downloaded.
+            'pageviews': '/tmp/pageviews',
         }
     },
     Environment.PRODUCTION: {},

--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -122,6 +122,11 @@ CREDENTIALS = {
             # server, to ensure requests to the webhook endpoint are valid.
             'hook_token': '', # EDIT this line
         },
+
+        'FILE_PATH': {
+            # Path where pageviews.bz2 file (~3GB) will be downloaded.
+            'pageviews': '/tmp/pageviews',
+        }
     },
 
     # Environment for python nosetests. In this environment, only the MySQL database
@@ -253,4 +258,9 @@ CREDENTIALS = {
     #       # server, to ensure requests to the webhook endpoint are valid.
     #       'hook_token': '', # EDIT this line
     #   },
+
+    #  'FILE_PATH': {
+    #    # Path where pageviews.bz2 file (~3GB) will be downloaded.
+    #    'pageviews': '/var/data/wp1bot/pageviews',
+    #  }
 }

--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -178,6 +178,11 @@ CREDENTIALS = {
             'password': 'farmpass',
             'hook_token': 'hook-token-abc',
         }
+
+        'FILE_PATH': {
+            # Path where pageviews.bz2 file (~3GB) will be downloaded.
+            'pageviews': '/tmp/pageviews',
+        }
     },
 
     # EDIT: Remove the next line after you've provided actual production credentials.

--- a/wp1/exceptions.py
+++ b/wp1/exceptions.py
@@ -24,3 +24,6 @@ class ObjectNotFoundError(Wp1Error):
 
 class UserNotAuthorizedError(Wp1Error):
   pass
+
+class Wp1ScoreProcessingError(Wp1Error):
+  pass

--- a/wp1/scores.py
+++ b/wp1/scores.py
@@ -85,7 +85,7 @@ def download_pageviews():
 
   with requests.get(get_pageview_url(), stream=True) as r:
     r.raise_for_status()
-    with open(PAGEVIEW_FILE_NAME, 'wb') as f:
+    with open(cur_filepath, 'wb') as f:
       # Read data in 8 KB chunks
       for chunk in r.iter_content(chunk_size=8 * 1024):
         f.write(chunk)
@@ -140,7 +140,7 @@ def pageview_components():
     try:
       views = int(parts[4])
     except ValueError:
-      log.warning('Views field wasn\'t int in pageview dump: %r', line)
+      logger.warning('Views field wasn\'t int in pageview dump: %r', line)
       continue
 
     if (tally is not None and tally.lang == lang and tally.name == name and
@@ -172,7 +172,7 @@ def update_db_pageviews(wp10db, lang, article, page_id, views):
         })
 
 
-def update_pageviews(filter_lang=None):
+def update_pageviews(filter_lang=None, commit_after=50000):
   download_pageviews()
 
   # Convert filter lang to bytes if necessary
@@ -191,7 +191,7 @@ def update_pageviews(filter_lang=None):
       update_db_pageviews(wp10db, lang, article, page_id, views)
 
     n += 1
-    if n >= 50000:
+    if n >= commit_after:
       logger.debug('Committing')
       wp10db.commit()
       n = 0

--- a/wp1/scores.py
+++ b/wp1/scores.py
@@ -1,3 +1,5 @@
+from bz2 import BZ2Decompressor
+
 import csv
 import requests
 
@@ -18,3 +20,37 @@ def wiki_languages():
   next(reader, None)
   for row in reader:
     yield row[2]
+
+
+def raw_pageviews(decode=True):
+
+  def as_bytes():
+    with requests.get(
+        'https://dumps.wikimedia.org/other/pageview_complete/monthly/2024/2024-03/pageviews-202403-automated.bz2',
+        stream=True) as r:
+
+      decompressor = BZ2Decompressor()
+      trailing = b''
+      # Read data in 1 MB chunks
+      for http_chunk in r.iter_content(chunk_size=1024 * 1024):
+        data = decompressor.decompress(http_chunk)
+        lines = [line for line in data.split(b'\n') if line]
+        if not lines:
+          continue
+
+        yield trailing + lines[0]
+        yield from lines[1:-1]
+        trailing = lines[-1]
+
+  if decode:
+    for line in as_bytes():
+      yield line.decode('utf-8')
+  else:
+    yield from as_bytes()
+
+
+def pageviews_for_lang(lang):
+  needle = f'{lang}.wikipedia'
+  for line in raw_pageviews():
+    if needle in line:
+      yield line

--- a/wp1/scores.py
+++ b/wp1/scores.py
@@ -88,8 +88,8 @@ def download_pageviews():
     r.raise_for_status()
     try:
       with open(cur_filepath, 'wb') as f:
-        # Read data in 8 KB chunks
-        for chunk in r.iter_content(chunk_size=8 * 1024):
+        # Read data in 8 MB chunks
+        for chunk in r.iter_content(chunk_size=8 * 1024 * 1024):
           f.write(chunk)
     except Exception as e:
       logger.exception('Error downloading pageviews')

--- a/wp1/scores.py
+++ b/wp1/scores.py
@@ -1,0 +1,20 @@
+import csv
+import requests
+
+from wp1.exceptions import Wp1ScoreProcessingError
+
+
+def wiki_languages():
+  r = requests.get(
+      'https://wikistats.wmcloud.org/api.php?action=dump&table=wikipedias&format=csv'
+  )
+  try:
+    r.raise_for_status()
+  except requests.exceptions.HTTPError as e:
+    raise Wp1ScoreProcessingError('Could not retrieve wiki list') from e
+
+  reader = csv.reader(r.text.splitlines())
+  # Skip the header row
+  next(reader, None)
+  for row in reader:
+    yield row[2]

--- a/wp1/scores_test.py
+++ b/wp1/scores_test.py
@@ -1,13 +1,45 @@
+import bz2
+from datetime import datetime
 import unittest
 from unittest.mock import patch, MagicMock
 
 import requests
 
+from wp1.base_db_test import BaseWpOneDbTest
+from wp1.constants import WP1_USER_AGENT
 from wp1.exceptions import Wp1ScoreProcessingError
-from wp1.scores import wiki_languages
+from wp1 import scores
 
 
-class ScoresTest(unittest.TestCase):
+class ScoresTest(BaseWpOneDbTest):
+  pageview_text = b'''af.wikipedia 1701 1402 desktop 4 F1
+af.wikipedia 1701 1402 mobile-web 3 O2T1
+af.wikipedia 1702 1404 mobile-web 3 L1O2
+af.wikipedia 1702 1404 desktop 1 P1
+af.wikipedia 1703 1405 mobile-web 3 C1O2
+af.wikipedia 1703 1405 desktop 1 ^1
+af.wikipedia 1704 1406 mobile-web 4 A1O2T1
+af.wikipedia 1704 1406 desktop 2 F1
+af.wikipedia 1705 1407 mobile-web 3 O3
+af.wikipedia 1705 1407 desktop 1 F1
+af.wikipedia 1706 1408 desktop 8 H8
+af.wikipedia 1706 1408 mobile-web 4 C1O2Y1
+af.wikipedia 1707 1409 mobile-web 2 O2
+af.wikipedia 1707 1409 desktop 3 H1J1
+af.wikipedia 1708 1410 desktop 4 V1]1
+af.wikipedia 1708 1410 mobile-web 1 O1
+af.wikipedia 1709 1411 desktop 2 F1
+af.wikipedia 1709 1411 mobile-web 2 O2
+af.wikipedia \xc3\xa9\xc3\xa1\xc3\xb8 3774 mobile-web 1 A1
+af.wikipedia \xc3\xa9\xc3\xa1\xc3\xb8 3774 mobile-web 2 F2
+af.wikipedia 1711 752 mobile-web 4 C1O2U1
+af.wikipedia 1711 752 desktop 1 K1
+af.wikipedia 1712 753 mobile-web 2 O2
+af.wikipedia 1712 753 desktop 20 E12J7U1'''
+
+  @property
+  def pageview_bz2(self):
+    return bz2.compress(self.pageview_text)
 
   @patch('wp1.scores.requests')
   def test_wiki_languages(self, mock_requests):
@@ -33,7 +65,7 @@ class ScoresTest(unittest.TestCase):
         ',,,,,,,,,,,,,8,200,a,0.2001\n')
     mock_requests.get.return_value = mock_response
 
-    actual = list(wiki_languages())
+    actual = list(scores.wiki_languages())
     self.assertEqual(['en', 'ceb', 'de', 'fr'], actual)
 
   @patch('wp1.scores.requests')
@@ -44,4 +76,128 @@ class ScoresTest(unittest.TestCase):
     mock_requests.get.return_value = mock_response
 
     with self.assertRaises(Wp1ScoreProcessingError):
-      list(wiki_languages())
+      list(scores.wiki_languages())
+
+  @patch('wp1.scores.get_current_datetime', return_value=datetime(2024, 5, 25))
+  def test_get_pageview_url(self, mock_datetime):
+    actual = scores.get_pageview_url()
+    self.assertEqual(
+        'https://dumps.wikimedia.org/other/pageview_complete/monthly/'
+        '2024/2024-04/pageviews-202404-user.bz2', actual)
+
+  @patch('wp1.scores.requests.get')
+  def test_get_pageview_response(self, mock_get):
+    context = MagicMock()
+    expected = MagicMock()
+    context.__enter__.return_value = expected
+    mock_get.return_value = context
+    with scores.get_pageview_response() as actual:
+      self.assertEqual(expected, actual)
+
+  @patch('wp1.scores.requests.get')
+  def test_get_pageview_response_non_success(self, mock_get):
+    context = MagicMock()
+    resp = MagicMock()
+    resp.raise_for_status.side_effect = requests.exceptions.HTTPError
+    context.__enter__.return_value = resp
+    mock_get.return_value = context
+    with self.assertRaises(
+        Wp1ScoreProcessingError), scores.get_pageview_response() as actual:
+      pass
+
+  @patch('wp1.scores.get_current_datetime', return_value=datetime(2024, 5, 25))
+  @patch('wp1.scores.get_pageview_response')
+  def test_raw_pageviews(self, mock_get_response, mock_datetime):
+    context = MagicMock()
+    resp = MagicMock()
+    resp.iter_content.return_value = (self.pageview_bz2,)
+    context.__enter__.return_value = resp
+    mock_get_response.return_value = context
+
+    actual = b'\n'.join(scores.raw_pageviews())
+
+    self.assertEqual(self.pageview_text, actual)
+
+  @patch('wp1.scores.get_current_datetime', return_value=datetime(2024, 5, 25))
+  @patch('wp1.scores.get_pageview_response')
+  def test_raw_pageviews(self, mock_get_response, mock_datetime):
+    context = MagicMock()
+    resp = MagicMock()
+    resp.iter_content.return_value = (self.pageview_bz2,)
+    context.__enter__.return_value = resp
+    mock_get_response.return_value = context
+
+    actual = b'\n'.join(scores.raw_pageviews())
+
+    self.assertEqual(self.pageview_text, actual)
+
+  @patch('wp1.scores.get_current_datetime', return_value=datetime(2024, 5, 25))
+  @patch('wp1.scores.get_pageview_response')
+  def test_raw_pageviews_decode(self, mock_get_response, mock_datetime):
+    context = MagicMock()
+    resp = MagicMock()
+    resp.iter_content.return_value = (self.pageview_bz2,)
+    context.__enter__.return_value = resp
+    mock_get_response.return_value = context
+
+    actual = '\n'.join(scores.raw_pageviews(decode=True))
+
+    self.assertEqual(self.pageview_text.decode('utf-8'), actual)
+
+  @patch('wp1.scores.get_pageview_response')
+  def test_pageview_components(self, mock_get_response):
+    context = MagicMock()
+    resp = MagicMock()
+    resp.iter_content.return_value = (self.pageview_bz2,)
+    context.__enter__.return_value = resp
+    mock_get_response.return_value = context
+
+    expected = [
+        (b'af', b'1701', b'1402', 7),
+        (b'af', b'1702', b'1404', 4),
+        (b'af', b'1703', b'1405', 4),
+        (b'af', b'1704', b'1406', 6),
+        (b'af', b'1705', b'1407', 4),
+        (b'af', b'1706', b'1408', 12),
+        (b'af', b'1707', b'1409', 5),
+        (b'af', b'1708', b'1410', 5),
+        (b'af', b'1709', b'1411', 4),
+        (b'af', b'\xc3\xa9\xc3\xa1\xc3\xb8', b'3774', 3),
+        (b'af', b'1711', b'752', 5),
+        (b'af', b'1712', b'753', 22),
+    ]
+
+    actual = list(scores.pageview_components())
+
+    self.assertEqual(expected, actual)
+
+  def test_update_db_pageviews(self):
+    scores.update_db_pageviews(self.wp10db, 'en', 'Statue_of_Liberty', 1234,
+                               100)
+
+    with self.wp10db.cursor() as cursor:
+      cursor.execute('SELECT * FROM page_scores WHERE ps_page_id = 1234')
+      result = cursor.fetchone()
+      self.assertIsNotNone(result)
+      self.assertEqual(result['ps_lang'], b'en')
+      self.assertEqual(result['ps_article'], b'Statue_of_Liberty')
+      self.assertEqual(result['ps_page_id'], 1234)
+      self.assertEqual(result['ps_views'], 100)
+
+  def test_update_db_pageviews_existing(self):
+    with self.wp10db.cursor() as cursor:
+      cursor.execute(
+          'INSERT INTO page_scores VALUES ("en", "Statue_of_Liberty", 1234, 100'
+      )
+
+    scores.update_db_pageviews(self.wp10db, 'en', 'Statue_of_Liberty', 1234,
+                               200)
+
+    with self.wp10db.cursor() as cursor:
+      cursor.execute('SELECT * FROM page_scores WHERE ps_page_id = 1234')
+      result = cursor.fetchone()
+      self.assertIsNotNone(result)
+      self.assertEqual(result['ps_lang'], b'en')
+      self.assertEqual(result['ps_article'], b'Statue_of_Liberty')
+      self.assertEqual(result['ps_page_id'], 1234)
+      self.assertEqual(result['ps_views'], 200)

--- a/wp1/scores_test.py
+++ b/wp1/scores_test.py
@@ -1,0 +1,47 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+import requests
+
+from wp1.exceptions import Wp1ScoreProcessingError
+from wp1.scores import wiki_languages
+
+
+class ScoresTest(unittest.TestCase):
+
+  @patch('wp1.scores.requests')
+  def test_wiki_languages(self, mock_requests):
+    mock_response = MagicMock()
+    mock_response.text = (
+        'id,lang,prefix,total,good,views,edits,users,admins,ts,loclang,images,'
+        'loclanglink,activeusers,version,si_mainpage,si_base,si_sitename,si_generator,'
+        'si_phpversion,si_phpsapi,si_dbtype,si_dbversion,si_rev,si_case,si_rights,'
+        'si_lang,si_fallback8bitEncoding,si_writeapi,si_timezone,si_timeoffset,'
+        'si_articlepath,si_scriptpath,si_script,si_variantarticlepath,si_server,'
+        'si_wikiid,si_time,method,http,status,ratio\n'
+        '2,English,en,60556624,6818615,63208806,1216695232,47328206,861,"2024-04-30 00:06:16",'
+        'English,916605,English_language,122676,1.28.0-wmf.13,,,,"MediaWiki 1.43.0-wmf.2",,,,,'
+        ',,,,,,,,,,,,,,,8,200,a,0.1126\n'
+        '153,Cebuano,ceb,11228672,6118766,0,35037562,115188,5,"2024-04-30 00:01:34"'
+        ',"Sinugboanong Binisaya",1,Sinugboanon,149,1.28.0-wmf.13,,,,"MediaWiki 1.43.0-wmf.2",,'
+        ',,,,,,,,,,,,,,,,,,8,200,a,0.5449\n'
+        '10,German,de,8007675,2905495,8543798,242922549,4359000,174,"2024-04-30 00:08:06",'
+        'Deutsch,129233,Deutsch,17684,1.28.0-wmf.13,,,,"MediaWiki 1.43.0-wmf.2",,,,,,,,,,,,,,,,,'
+        ',,,8,200,a,0.3628\n'
+        '1,French,fr,13037937,2608568,2234272,214217598,4914029,146,"2024-04-30 00:08:24",'
+        'Fran&#231;ais,71651,Fran&#231;ais,16929,1.28.0-wmf.13,,,,"MediaWiki 1.43.0-wmf.2",,,,,,,'
+        ',,,,,,,,,,,,,8,200,a,0.2001\n')
+    mock_requests.get.return_value = mock_response
+
+    actual = list(wiki_languages())
+    self.assertEqual(['en', 'ceb', 'de', 'fr'], actual)
+
+  @patch('wp1.scores.requests')
+  def test_wiki_languages_raises_on_http_error(self, mock_requests):
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError
+    mock_requests.exceptions.HTTPError = requests.exceptions.HTTPError
+    mock_requests.get.return_value = mock_response
+
+    with self.assertRaises(Wp1ScoreProcessingError):
+      list(wiki_languages())

--- a/wp10_test.down.sql
+++ b/wp10_test.down.sql
@@ -12,3 +12,4 @@ DROP TABLE IF EXISTS `builders`;
 DROP TABLE IF EXISTS `selections`;
 DROP TABLE IF EXISTS `custom`;
 DROP TABLE IF EXISTS `zim_files`;
+DROP TABLE IF EXISTS `page_scores`;

--- a/wp10_test.up.sql
+++ b/wp10_test.up.sql
@@ -138,6 +138,18 @@ CREATE TABLE zim_files (
   z_description tinyblob
 );
 
+CREATE TABLE `page_scores` (
+  `ps_lang` varbinary(255) NOT NULL,
+  `ps_page_id` int(11) NOT NULL,
+  `ps_article` varbinary(1024) DEFAULT NULL,
+  `ps_views` int(11) DEFAULT 0,
+  `ps_links` int(11) DEFAULT 0,
+  `ps_lang_links` int(11) DEFAULT 0,
+  `ps_score` int(11) DEFAULT 0,
+  PRIMARY KEY (`ps_lang`,`ps_page_id`),
+  KEY `lang_article` (`ps_lang`,`ps_article`)
+);
+
 INSERT INTO `global_rankings` (gr_type, gr_rating, gr_ranking) VALUES ('importance', 'Unknown-Class', 0);
 INSERT INTO `global_rankings` (gr_type, gr_rating, gr_ranking) VALUES ('importance', 'NA-Class', 50);
 INSERT INTO `global_rankings` (gr_type, gr_rating, gr_ranking) VALUES ('importance', 'Low-Class', 100);


### PR DESCRIPTION
For #171 

Here we download the pageviews text file for the previous month and ingest it, storing the view counts for every article, across every wikipedia, that has a view count.

This PR includes the schema for the `page_scores` table, which will eventually include more than just the page views, also the links and lang_links that make up the components of the page score used in classic selection.

Previous attempts at this logic involved streaming the pageviews bz2 file over HTTP, however this was found to be unreliable because the remote server would close the connection after ~20 minutes. Instead, we create a tempfile location, which in production is mapped to /srv/, and download the entire file there. The BZ2 decompression and line by line processing is still streamed.

EDIT: There is currently no scheduling for this process because we need to run it manually a couple of times first to make sure it works. Scheduling will be added in a future PR.