### PR TITLE
Migrate database user IDs to strings, and compare as strings

### DIFF
--- a/db/migrations/20250120_01_4GEMs-convert-user-id-to-str.py
+++ b/db/migrations/20250120_01_4GEMs-convert-user-id-to-str.py
@@ -1,0 +1,14 @@
+"""
+Convert user_id to VARCHAR
+"""
+
+from yoyo import step
+
+__depends__ = {'20240429_01_qtSms-add-scores-table'}
+
+steps = [
+    step('ALTER TABLE users MODIFY u_id VARCHAR(255);',
+         'ALTER TABLE users MODIFY u_id INT;'),
+    step('ALTER TABLE builders MODIFY b_user_id VARCHAR(255);',
+         'ALTER TABLE builders MODIFY b_user_id INT;'),
+]

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -402,10 +402,13 @@ def schedule_zim_file(s3,
     raise ObjectNotFoundError('Could not find builder with id = %s' %
                               builder_id)
 
-  if user_id is not None and builder.b_user_id != user_id:
-    raise UserNotAuthorizedError(
-        'Could not use builder id = %s for user id = %s' %
-        (builder_id, user_id))
+  if user_id is not None:
+    user_id = str(user_id)
+    builder_user_id = builder.b_user_id.decode('utf-8')
+    if user_id != builder_user_id:
+      raise UserNotAuthorizedError(
+          'Could not use builder id = %s for user id = %s' %
+          (builder_id, user_id))
 
   task_id = zimfarm.schedule_zim_file(s3,
                                       redis,

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -1,5 +1,5 @@
 import datetime
-from unittest.mock import call, patch, MagicMock, ANY
+from unittest.mock import ANY, MagicMock, call, patch
 
 import attr
 
@@ -14,7 +14,7 @@ class BuilderTest(BaseWpOneDbTest):
   expected_builder = {
       'b_id': b'1a-2b-3c-4d',
       'b_name': b'My Builder',
-      'b_user_id': 1234,
+      'b_user_id': b'1234',
       'b_project': b'en.wikipedia.fake',
       'b_model': b'wp1.selection.models.simple',
       'b_params': b'{"list": ["a", "b", "c"]}',
@@ -269,7 +269,7 @@ class BuilderTest(BaseWpOneDbTest):
   def _get_builder_by_user_id(self):
     with self.wp10db.cursor() as cursor:
       cursor.execute('SELECT * FROM builders WHERE b_user_id=%(b_user_id)s',
-                     {'b_user_id': '1234'})
+                     {'b_user_id': b'1234'})
       db_lists = cursor.fetchone()
       return db_lists
 
@@ -278,7 +278,7 @@ class BuilderTest(BaseWpOneDbTest):
     self.builder = Builder(
         b_id=b'1a-2b-3c-4d',
         b_name=b'My Builder',
-        b_user_id=1234,
+        b_user_id=b'1234',
         b_project=b'en.wikipedia.fake',
         b_model=b'wp1.selection.models.simple',
         b_params=b'{"list": ["a", "b", "c"]}',
@@ -535,7 +535,7 @@ class BuilderTest(BaseWpOneDbTest):
     builder = Builder(
         b_id=b'1a-2b-3c-4d',
         b_name=b'My Builder',
-        b_user_id=5555,  # Different user_id
+        b_user_id=b'5555',  # Different user_id
         b_project=b'en.wikipedia.fake',
         b_model=b'wp1.selection.models.simple',
         b_params=b'{"list": ["a", "b", "c"]}',
@@ -548,7 +548,7 @@ class BuilderTest(BaseWpOneDbTest):
     builder = Builder(
         b_id=b'100',  # Wrong ID
         b_name=b'My Builder',
-        b_user_id=1234,
+        b_user_id=b'1234',
         b_project=b'en.wikipedia.fake',
         b_model=b'wp1.selection.models.simple',
         b_params=b'{"list": ["a", "b", "c"]}',
@@ -561,7 +561,7 @@ class BuilderTest(BaseWpOneDbTest):
     builder = Builder(
         b_id=b'1a-2b-3c-4d',
         b_name=b'My Builder',
-        b_user_id=1234,
+        b_user_id=b'1234',
         b_project=b'en.wikipedia.fake',
         b_model=b'wp1.selection.models.simple',
         b_params=b'{"list": ["a", "b", "c"]}',
@@ -573,7 +573,7 @@ class BuilderTest(BaseWpOneDbTest):
     self._insert_builder()
     builder = Builder(b_id=b'1a-2b-3c-4d',
                       b_name=b'Builder 2',
-                      b_user_id=1234,
+                      b_user_id=b'1234',
                       b_project=b'zz.wikipedia.fake',
                       b_model=b'wp1.selection.models.complex',
                       b_params=b'{"list": ["1", "b", "c"]}',

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -14,7 +14,7 @@ class BuildersTest(BaseWebTestcase):
       'access_token': 'access_token',
       'identity': {
           'username': 'WP1_user',
-          'sub': 1234,
+          'sub': '1234',
       },
   }
   UNAUTHORIZED_USER = {
@@ -46,7 +46,7 @@ class BuildersTest(BaseWebTestcase):
 
   builder = Builder(b_id=b'1a-2b-3c-4d',
                     b_name=b'My Builder',
-                    b_user_id=1234,
+                    b_user_id='1234',
                     b_project=b'en.wikipedia.fake',
                     b_model=b'wp1.selection.models.simple',
                     b_params=b'{"list": ["a", "b", "c"]}',

--- a/wp10_test.up.sql
+++ b/wp10_test.up.sql
@@ -88,14 +88,14 @@ CREATE TABLE `global_rankings` (
 );
 
 CREATE TABLE `users` (
-  `u_id` int(8) unsigned NOT NULL,
+  `u_id` VARCHAR(255) NOT NULL,
   `u_username` varchar(255) DEFAULT NULL
 );
 
 CREATE TABLE `builders` (
   b_id VARBINARY(255) NOT NULL PRIMARY KEY,
   b_name VARBINARY(255) NOT NULL,
-  b_user_id INTEGER NOT NULL,
+  b_user_id VARCHAR(255) NOT NULL,
   b_project VARBINARY(255) NOT NULL,
   b_model VARBINARY(255) NOT NULL,
   b_current_version int(11) NOT NULL DEFAULT 0,


### PR DESCRIPTION
Fixes #784. Related to #783. Related to #780.

Fix an additional place in the codebase where we compare user IDs for access control. User IDs from wikimedia OAuth endpoints are now strings instead of ints.

To accommodate this change and hopefully avoid this issue in the future, we now map the user IDs to VARCHAR (strings) in the database.

However there is still a small issue in that user_ids coming from the database will be bytes (`b'1234'`) and ones from the session will be str (`'1234'`), so care still has to be taken when comparing them.