### PR TITLE
Limit WikiProject selection to article namespace

### DIFF
--- a/wp1/selection/models/wikiproject.py
+++ b/wp1/selection/models/wikiproject.py
@@ -4,8 +4,9 @@ from wp1.selection.abstract_builder import AbstractBuilder
 
 def _get_articles_for_project(wp10db, project):
   with wp10db.cursor() as cursor:
-    cursor.execute('SELECT r_article FROM ratings WHERE r_project = %s',
-                   (project.strip().replace(' ', '_'),))
+    cursor.execute(
+        'SELECT r_article FROM ratings WHERE r_namespace = 0 AND r_project = %s',
+        (project.strip().replace(' ', '_'),))
     return [row['r_article'].decode('utf-8') for row in cursor.fetchall()]
 
 

--- a/wp1/selection/models/wikiproject_test.py
+++ b/wp1/selection/models/wikiproject_test.py
@@ -33,6 +33,12 @@ class WikiProjectTest(BaseWpOneDbTest):
           'INSERT INTO projects (p_project, p_timestamp) VALUES (%s, 0)',
           projects)
 
+      # Add a few category pages that should be excluded from the materialized article lists
+      cursor.executemany(
+          'INSERT INTO ratings (r_project, r_namespace, r_article) VALUES (%s, 14, %s)',
+          [('Water_Elements', 'Famous_bodies_of_water'),
+           ('Wind', 'Coastal_breezes')])
+
   def test_validate(self):
     params = {
         'include': ['Water Elements', 'Fire', 'Lava'],


### PR DESCRIPTION
Fixes #788

Originally, WikiProject selection grabbed every `r_article` from the ratings table for the project. However, many items in the table are not proper articles (namespace == 0) but rather things like categories etc. This caused problems for mwoffliner because it couldn't download those, which led to failed ZIMs.