### PR TITLE
feat: extend URL stripping to support non-EN Wikipedia projects

### DIFF
--- a/wp1/selection/models/simple.py
+++ b/wp1/selection/models/simple.py
@@ -69,28 +69,15 @@ class Builder(AbstractBuilder):
         invalid_article_names.append(decoded_item)
         is_valid = False
       if is_valid:
-        article_name = self.extract_article_name(decoded_item)
-        if not article_name:
-          invalid_article_names.append(decoded_item)
-        else:
-          valid_article_names.append(article_name)
+        project_domain = 'en.wikipedia.org'
+        if 'project' in params:
+          project_domain = params['project']
+        wiki_prefix = f"https://{project_domain}/wiki/"
+        index_prefix = f"https://{project_domain}/w/index.php?title="
+        article_name = decoded_item.replace(wiki_prefix,
+                                            "").replace(index_prefix, "")
+        valid_article_names.append(article_name)
     if forbidden_chars:
       errors.append('The list contained the following invalid characters: ' +
                     ', '.join(forbidden_chars))
     return (valid_article_names, invalid_article_names, errors)
-
-  def extract_article_name(self, url):
-    if not url:
-      return None
-
-    parsed_url = urllib.parse.urlparse(url)
-    domain = parsed_url.netloc
-    if not domain:
-      return url
-    if not domain.endswith("wikipedia.org"):
-      return None
-
-    wiki_prefix = f"https://{domain}/wiki/"
-    index_prefix = f"https://{domain}/w/index.php?title="
-    article_name = url.replace(wiki_prefix, "").replace(index_prefix, "")
-    return article_name

--- a/wp1/selection/models/simple_test.py
+++ b/wp1/selection/models/simple_test.py
@@ -196,31 +196,14 @@ of text than an actual article name.',
 
   def test_non_en_url_stripping(self):
     simple_builder_test = SimpleBuilder()
-    expected = (['Statue_of_Liberty', 'Indonésie', 'Marie_Curie'], [], [])
+    expected = (['Portugal', 'Europa', 'Marie_Curie'], [], [])
     params = {
         'list': [
-            'https://en.wikipedia.org/wiki/Statue_of_Liberty',
-            'https://fr.wikipedia.org/wiki/Indon%C3%A9sie',
+            'https://de.wikipedia.org/wiki/Portugal',
+            'https://de.wikipedia.org/wiki/Europa',
             'https://de.wikipedia.org/w/index.php?title=Marie_Curie'
         ],
-        'project': 'project_name'
-    }
-    actual = simple_builder_test.validate(**params)
-    self.assertEqual(expected, actual)
-
-  def test_non_wikipedia_domain_invalid(self):
-    simple_builder_test = SimpleBuilder()
-    expected = (['Marie_Curie'], [
-        'https://en.wiki.org/wiki/Statue_of_Liberty',
-        'https://fr.wiktionary.org/wiki/Indonésie',
-    ], [])
-    params = {
-        'list': [
-            'https://en.wiki.org/wiki/Statue_of_Liberty',
-            'https://fr.wiktionary.org/wiki/Indon%C3%A9sie',
-            'https://de.wikipedia.org/w/index.php?title=Marie_Curie'
-        ],
-        'project': 'project_name'
+        'project': 'de.wikipedia.org'
     }
     actual = simple_builder_test.validate(**params)
     self.assertEqual(expected, actual)

--- a/wp1/selection/models/simple_test.py
+++ b/wp1/selection/models/simple_test.py
@@ -193,3 +193,34 @@ of text than an actual article name.',
     }
     actual = simple_builder_test.validate(**params)
     self.assertEqual(expected, actual)
+
+  def test_non_en_url_stripping(self):
+    simple_builder_test = SimpleBuilder()
+    expected = (['Statue_of_Liberty', 'Indonésie', 'Marie_Curie'], [], [])
+    params = {
+        'list': [
+            'https://en.wikipedia.org/wiki/Statue_of_Liberty',
+            'https://fr.wikipedia.org/wiki/Indon%C3%A9sie',
+            'https://de.wikipedia.org/w/index.php?title=Marie_Curie'
+        ],
+        'project': 'project_name'
+    }
+    actual = simple_builder_test.validate(**params)
+    self.assertEqual(expected, actual)
+
+  def test_non_wikipedia_domain_invalid(self):
+    simple_builder_test = SimpleBuilder()
+    expected = (['Marie_Curie'], [
+        'https://en.wiki.org/wiki/Statue_of_Liberty',
+        'https://fr.wiktionary.org/wiki/Indonésie',
+    ], [])
+    params = {
+        'list': [
+            'https://en.wiki.org/wiki/Statue_of_Liberty',
+            'https://fr.wiktionary.org/wiki/Indon%C3%A9sie',
+            'https://de.wikipedia.org/w/index.php?title=Marie_Curie'
+        ],
+        'project': 'project_name'
+    }
+    actual = simple_builder_test.validate(**params)
+    self.assertEqual(expected, actual)


### PR DESCRIPTION
Fixes: #721 

This PR updates the Simple Selection validator to dynamically strip Wikipedia article URLs based on the project name instead of hardcoding `en.wikipedia.org`. This allows the validator to support non-English Wikipedia projects (e.g., `fr.wikipedia.org`, `de.wikipedia.org`, etc.).
Related Issues

- [X] Code follows project coding standards
- [X] Changes have been tested

 
