### PR TITLE
Use static resource profile for requesting ZIM creation

### DIFF
--- a/wp1/logic/selection_test.py
+++ b/wp1/logic/selection_test.py
@@ -1,9 +1,9 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import attr
 
-from wp1.base_db_test import BaseWpOneDbTest
 import wp1.logic.selection as logic_selection
+from wp1.base_db_test import BaseWpOneDbTest
 from wp1.models.wp10.selection import Selection
 from wp1.models.wp10.zim_file import ZimFile
 
@@ -336,17 +336,3 @@ class SelectionTest(BaseWpOneDbTest):
     self._insert_selections()
     actual = logic_selection.zim_file_requested_at_for(self.wp10db, 'xyz1')
     self.assertEqual(1672538522, actual)
-
-  def test_get_resource_profile(self):
-    s3 = MagicMock()
-    s3.client.head_object.return_value = {'ContentLength': 20000000}
-    selection = Selection(s_builder_id=b'abcd',
-                          s_content_type=b'text/tab-separated-values',
-                          s_version=1,
-                          s_object_key=b'foo/bar/1234.tsv')
-    actual = logic_selection.get_resource_profile(s3, selection)
-    self.assertEqual({
-        'cpu': 3,
-        'disk': 42949672960,
-        'memory': 6442450944
-    }, actual)

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -1,13 +1,13 @@
 import datetime
-from unittest.mock import call, patch, MagicMock
+from unittest.mock import MagicMock, call, patch
 
 import attr
 import requests
 
-from wp1.environment import Environment
-from wp1.exceptions import ObjectNotFoundError, ZimFarmError
 from wp1 import zimfarm
 from wp1.base_db_test import BaseWpOneDbTest
+from wp1.environment import Environment
+from wp1.exceptions import ObjectNotFoundError, ZimFarmError
 from wp1.models.wp10.builder import Builder
 
 
@@ -107,9 +107,9 @@ class ZimFarmTest(BaseWpOneDbTest):
                     'tag': 'latest'
                 },
                 'resources': {
-                    'cpu': 3,
-                    'memory': 6442450944,
-                    'disk': 42949672960,
+                    'cpu': 6,
+                    'memory': 16106127360,
+                    'disk': 214748364800,
                 },
                 'platform': 'wikimedia',
                 'monitor': False,


### PR DESCRIPTION
Fixes #794.

Originally, we were trying to estimate how many resources we would need on Zimfarm based on the size of the selection. It seems the estimates were based on the idea that the max resource allocation of, say, 15 GB of memory would be enough to scrape almost all of English Wikipedia, so 3 GB would be enough to scrape 1M articles, or about 1/5 of that. This is obviously not right, and #790 makes it clear that there should be a certain maximum limit on the number of articles that can be requested through WP1.

Instead of doing any kind of heuristic calculation, we now just statically request the maximum amount of resources that we happen to know (from outside channels) the Zimfarm is able to support.