### PR TITLE
Fix broken link bug for article's name that includes slash

### DIFF
--- a/wp1-frontend/src/components/ArticleTable.vue
+++ b/wp1-frontend/src/components/ArticleTable.vue
@@ -299,7 +299,9 @@ export default {
     },
     timestampLink: function (articleName, ts) {
       return `${import.meta.env.VITE_API_URL}/articles/${encodeURIComponent(
-        articleName
+        encodeURIComponent(
+          articleName // double encode article name
+        )
       )}/${encodeURIComponent(ts)}/redirect`;
     },
   },

--- a/wp1-frontend/src/components/ArticleTable.vue
+++ b/wp1-frontend/src/components/ArticleTable.vue
@@ -298,11 +298,11 @@ export default {
       return ts.split('T')[0];
     },
     timestampLink: function (articleName, ts) {
-      return `${import.meta.env.VITE_API_URL}/articles/${encodeURIComponent(
-        encodeURIComponent(
-          articleName // double encode article name
-        )
-      )}/${encodeURIComponent(ts)}/redirect`;
+      return `${
+        import.meta.env.VITE_API_URL
+      }/articles/redirect?name=${encodeURIComponent(
+        articleName
+      )}&timestamp=${encodeURIComponent(ts)}`;
     },
   },
 };

--- a/wp1/web/articles.py
+++ b/wp1/web/articles.py
@@ -1,4 +1,5 @@
 import flask
+import urllib.parse
 
 from wp1.api import get_page, get_revision_id_by_timestamp
 from wp1.constants import FRONTEND_WIKI_BASE
@@ -6,8 +7,9 @@ from wp1.constants import FRONTEND_WIKI_BASE
 articles = flask.Blueprint('articles', __name__)
 
 
-@articles.route('<name>/<timestamp>/redirect')
-def redirect(name, timestamp):
+@articles.route('<name_encoded>/<timestamp>/redirect')
+def redirect(name_encoded, timestamp):
+  name = urllib.parse.unquote(name_encoded)
   page = get_page(name)
   revid = get_revision_id_by_timestamp(page, timestamp)
 

--- a/wp1/web/articles.py
+++ b/wp1/web/articles.py
@@ -1,4 +1,5 @@
 import flask
+from flask import request
 import urllib.parse
 
 from wp1.api import get_page, get_revision_id_by_timestamp
@@ -7,9 +8,11 @@ from wp1.constants import FRONTEND_WIKI_BASE
 articles = flask.Blueprint('articles', __name__)
 
 
-@articles.route('<name_encoded>/<timestamp>/redirect')
-def redirect(name_encoded, timestamp):
-  name = urllib.parse.unquote(name_encoded)
+@articles.route('/redirect')
+def redirect():
+  name = request.args.get("name", None)
+  timestamp = request.args.get("timestamp", None)
+
   page = get_page(name)
   revid = get_revision_id_by_timestamp(page, timestamp)
 

--- a/wp1/web/articles.py
+++ b/wp1/web/articles.py
@@ -1,6 +1,5 @@
 import flask
 from flask import request
-import urllib.parse
 
 from wp1.api import get_page, get_revision_id_by_timestamp
 from wp1.constants import FRONTEND_WIKI_BASE

--- a/wp1/web/articles_test.py
+++ b/wp1/web/articles_test.py
@@ -13,7 +13,8 @@ class ArticlesTest(BaseWebTestcase):
 
     with self.override_db(self.app), self.app.test_client() as client:
       rv = client.get(
-          '/v1/articles/Web%20development/2020-01-13T10:00:00Z/redirect')
+          '/v1/articles/redirect?name=Web%20development&timestamp=2020-01-13T10:00:00Z'
+      )
       self.assertEqual('302 FOUND', rv.status)
 
       expected_url = ('%sindex.php?title=%s&oldid=%s' %
@@ -27,5 +28,6 @@ class ArticlesTest(BaseWebTestcase):
 
     with self.override_db(self.app), self.app.test_client() as client:
       rv = client.get(
-          '/v1/articles/Web%20development/2020-01-13T10:00:00Z/redirect')
+          '/v1/articles/redirect?name=Web%20development&timestamp=2020-01-13T10:00:00Z'
+      )
       self.assertEqual('404 NOT FOUND', rv.status)


### PR DESCRIPTION
## Issue: Broken Date Links in Articles having name that contains slash
Fixes #817 

## Changes
In frontend, double encode the article name.
In backend, decode the encoded article name (Flask decode the first time, and we decode it the second time to get original name).