### PR TITLE
refactor: store logs as Redis hashes

### DIFF
--- a/wp1/logic/log.py
+++ b/wp1/logic/log.py
@@ -1,17 +1,59 @@
-import attr
+import datetime
 
+import attr
+from redis import Redis
+from wp1.redis_db import gen_redis_log_key
 from wp1.models.wp10.log import Log
 
+# Redis does not allow None types. However if a log to be stored has a None
+# we convert it to this value while storing on Redis and back to None
+# when converting from Redis to python object
+REDIS_NULL = b"__redis__none__"
 
-def insert_or_update(wp10db, log):
-  with wp10db.cursor() as cursor:
-    cursor.execute(
-        '''
-        INSERT INTO logging
-          (l_project, l_namespace, l_article, l_action, l_timestamp, l_old,
-           l_new, l_revision_timestamp)
-        VALUES
-          (%(l_project)s, %(l_namespace)s, %(l_article)s, %(l_action)s,
-           %(l_timestamp)s, %(l_old)s, %(l_new)s, %(l_revision_timestamp)s)
-        ON DUPLICATE KEY UPDATE l_article = l_article
-    ''', attr.asdict(log))
+
+def insert_or_update(redis: Redis, log: Log):
+  log_key = gen_redis_log_key(project=log.l_project,
+                              namespace=log.l_namespace,
+                              action=log.l_action,
+                              article=log.l_article)
+  with redis.pipeline() as pipe:
+    mapping = {
+        k: REDIS_NULL if v is None else v for k, v in attr.asdict(log).items()
+    }
+    pipe.hset(log_key, mapping=mapping)
+    pipe.expire(log_key, datetime.timedelta(days=7))
+    pipe.execute()
+
+
+def get_logs(
+    redis: Redis,
+    *,
+    project: str | bytes = "*",
+    namespace: str | bytes = "*",
+    action: str | bytes = "*",
+    article: str | bytes = "*",
+    start_dt: datetime.datetime | None = None,
+) -> list[Log]:
+  """Retrieve logs from Redis matching the given filters."""
+  key = gen_redis_log_key(project=project,
+                          namespace=namespace,
+                          action=action,
+                          article=article)
+  logs: list[Log] = []
+  for log_key in redis.scan_iter(match=key, _type="HASH"):
+    data = redis.hgetall(log_key)
+    # convert the data according to the field types of the Log object
+    log_dict = {
+        k.decode("utf-8"): v if v != REDIS_NULL else None
+        for k, v in data.items()
+    }
+    if log_dict["l_namespace"] is not None:
+      log_dict["l_namespace"] = int(log_dict["l_namespace"])
+
+    log = Log(**log_dict)
+    # skip logs that are not newer than start_dt
+    if start_dt is not None and log.timestamp_dt < start_dt:
+      continue
+    logs.append(log)
+
+  return logs

--- a/wp1/logic/page.py
+++ b/wp1/logic/page.py
@@ -37,8 +37,8 @@ def get_pages_by_category(wikidb, category, ns=None):
       yield Page(**result)
 
 
-def update_page_moved(wp10db, project, old_ns, old_title, new_ns, new_title,
-                      move_timestamp_dt):
+def update_page_moved(wp10db, redis, project, old_ns, old_title, new_ns,
+                      new_title, move_timestamp_dt):
   logger.debug('Updating moves table for %s -> %s', old_title.decode('utf-8'),
                new_title.decode('utf-8'))
   db_timestamp = move_timestamp_dt.strftime(TS_FORMAT).encode('utf-8')
@@ -62,7 +62,7 @@ def update_page_moved(wp10db, project, old_ns, old_title, new_ns, new_title,
                 l_old=b'',
                 l_new=b'',
                 l_revision_timestamp=db_timestamp)
-  logic_log.insert_or_update(wp10db, new_log)
+  logic_log.insert_or_update(redis, new_log)
 
 
 def _get_redirects_from_db(wikidb, namespace, title, timestamp_dt):

--- a/wp1/logic/rating.py
+++ b/wp1/logic/rating.py
@@ -341,7 +341,7 @@ def count_unassessed_importance_for_project(wp10db, project):
     return cursor.fetchone()['cnt']
 
 
-def add_log_for_rating(wp10db, new_rating, kind, old_rating_value):
+def add_log_for_rating(redis, new_rating, kind, old_rating_value):
   if kind == AssessmentKind.QUALITY:
     action = b'quality'
     timestamp = new_rating.r_quality_timestamp
@@ -361,4 +361,4 @@ def add_log_for_rating(wp10db, new_rating, kind, old_rating_value):
             l_old=old_rating_value,
             l_new=new,
             l_revision_timestamp=timestamp)
-  logic_log.insert_or_update(wp10db, log)
+  logic_log.insert_or_update(redis, log)

--- a/wp1/models/wp10/log_test.py
+++ b/wp1/models/wp10/log_test.py
@@ -20,7 +20,7 @@ class ModelsLogTest(BaseWpOneDbTest):
                    l_old=b'NotA-Class',
                    l_new=b'Mid-Class',
                    l_revision_timestamp=b'2018-01-01T12:00:00Z')
-    logic_log.insert_or_update(self.wp10db, self.log)
+    logic_log.insert_or_update(self.redis, self.log)
 
   def test_timestamp_dt(self):
     dt = self.log.timestamp_dt

--- a/wp1/queues_test.py
+++ b/wp1/queues_test.py
@@ -14,11 +14,9 @@ class QueuesTest(BaseWpOneDbTest):
 
   def setUp(self):
     super().setUp()
-    self.redis = fakeredis.FakeStrictRedis()
 
   def tearDown(self):
     super().tearDown()
-    self.redis = None
 
   @patch('wp1.queues.ENV', Environment.DEVELOPMENT)
   @patch('wp1.queues.logic_project.update_project_by_name')

--- a/wp1/redis_db.py
+++ b/wp1/redis_db.py
@@ -16,3 +16,9 @@ except ImportError:
 def connect():
   creds = CREDENTIALS[ENV]['REDIS']
   return Redis(**creds)
+
+
+def gen_redis_log_key(*, project: str | bytes, namespace: str | bytes,
+                      action: str | bytes, article: str | bytes) -> str:
+  to_str = lambda x: x.decode("utf-8") if isinstance(x, bytes) else x
+  return f"wp1:logs:{to_str(project)}:{to_str(namespace)}:{to_str(action)}:{to_str(article)}"


### PR DESCRIPTION
# Rationale
This PR implements the functionality to save logs to Redis. By setting expiry on the logs while saving, we can be sure that logs are not saved for years and there is no need for reliance on a cron job to delete old logs.

## Changes
- set up connection to Redis in `BaseWPOneDbTest`
- save logs to Redis as hashes instead of SQL DB
- use a key naming pattern which allows us to filter logs that match the pattern. This emulates SQL-like `AND` queries for logs
- update tests to use appropriate `self.redis` 

## Fixes
This fixes #778 
This fixes #49 