### PR TITLE
Fix routing bug in links for articles with slash in the name

### DIFF
--- a/wp1/web/articles.py
+++ b/wp1/web/articles.py
@@ -1,18 +1,30 @@
+import logging
+import urllib.parse
+
 import flask
 
 from wp1.api import get_page, get_revision_id_by_timestamp
 from wp1.constants import FRONTEND_WIKI_BASE
 
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
 articles = flask.Blueprint('articles', __name__)
 
 
-@articles.route('<name>/<timestamp>/redirect')
+@articles.route('<path:name>/<timestamp>/redirect')
 def redirect(name, timestamp):
-  page = get_page(name)
-  revid = get_revision_id_by_timestamp(page, timestamp)
+    logger.debug(f"Redirect route called with raw name: {name}")
+    logger.debug(f"Redirect route called with raw timestamp: {timestamp}")
+    # Decode the URL-encoded name
+    decoded_name = urllib.parse.unquote(name)
+    page = get_page(decoded_name)
+    logger.debug(f"Got page: {page}")
+    revid = get_revision_id_by_timestamp(page, timestamp)
+    logger.debug(f"Got revid: {revid}")
+    if revid:
+        return flask.redirect(
+            '%sindex.php?title=%s&oldid=%s' % (FRONTEND_WIKI_BASE, decoded_name, revid)
+        )
 
-  if revid:
-    return flask.redirect('%sindex.php?title=%s&oldid=%s' %
-                          (FRONTEND_WIKI_BASE, name, revid))
-
-  return flask.abort(404)
+    return flask.abort(404)

--- a/wp1/web/articles.py
+++ b/wp1/web/articles.py
@@ -13,18 +13,18 @@ articles = flask.Blueprint('articles', __name__)
 
 
 @articles.route('<path:name>/<timestamp>/redirect')
-def redirect(name, timestamp):
-    logger.debug(f"Redirect route called with raw name: {name}")
-    logger.debug(f"Redirect route called with raw timestamp: {timestamp}")
-    # Decode the URL-encoded name
-    decoded_name = urllib.parse.unquote(name)
-    page = get_page(decoded_name)
-    logger.debug(f"Got page: {page}")
-    revid = get_revision_id_by_timestamp(page, timestamp)
-    logger.debug(f"Got revid: {revid}")
-    if revid:
-        return flask.redirect(
-            '%sindex.php?title=%s&oldid=%s' % (FRONTEND_WIKI_BASE, decoded_name, revid)
-        )
+def redirect(name, timestamp): 
+  logger.debug(f"Redirect route called with raw name: {name}")
+  logger.debug(f"Redirect route called with raw timestamp: {timestamp}")
+  # Decode the URL-encoded name
+  decoded_name = urllib.parse.unquote(name)
+  page = get_page(decoded_name)
+  logger.debug(f"Got page: {page}")
+  revid = get_revision_id_by_timestamp(page, timestamp)
+  logger.debug(f"Got revid: {revid}")
+  if revid:
+      return flask.redirect(
+          '%sindex.php?title=%s&oldid=%s' % (FRONTEND_WIKI_BASE, decoded_name, revid)
+      )
 
-    return flask.abort(404)
+  return flask.abort(404)


### PR DESCRIPTION
### Rationale
This change should resolve the bug where articles with forward slashes in their names were not routed correctly, ensuring both proper URL parsing and successful page retrieval.

### Changes
- Route Parameter Update
- Decoding the URL-Encoded Name
- Additional Logging for Debugging

### Why It Works
- The Flask route parameter <<path:name>> allows the captured variable to include slashes. This directly addresses the routing issue by expanding the accepted URL pattern.
-  URL-encoded names (with characters like %2F for /) are properly decoded, ensuring that the lookup function (get_page) receives the intended article name. This prevents mismatches and lookup failures due to encoding issues.

### Tested on many articles including these:
http://localhost:5000/v1/articles/WP%3AWikiProject%20Aviation%2FAerospace%20biography%20task%20force/2009-04-23T15%3A36%3A30Z/redirect (original issue link)
http://localhost:5000/v1/articles/Al-Anon%2FAlateen/2016-12-11T20%3A56%3A38Z/redirect
http://localhost:5000/v1/articles/Portal%3AAviation%2FSelected%20biography/2009-03-05T14%3A25%3A50Z/redirect
http://localhost:5000/v1/articles/WP%253AVersion%25201.0%2520Editorial%2520Team%252FAesthetics%2520articles%2520by%2520quality%2520log/2010-06-21T18%3A12%3A55Z/redirect

### Fixes
This fixes https://github.com/openzim/wp1/issues/817