### PR TITLE
remove redundant ImportErrors

### DIFF
--- a/enqueue-all.py
+++ b/enqueue-all.py
@@ -8,13 +8,6 @@ from wp1.redis_db import connect as redis_connect
 
 logger = logging.getLogger(__name__)
 
-try:
-  from wp1.credentials import ENV, CREDENTIALS
-except ImportError:
-  logger.exception('The file credentials.py must be populated manually in '
-                   'order to connect to Redis')
-  raise
-
 
 def main():
   logging.basicConfig(level=logging.INFO)

--- a/enqueue-global.py
+++ b/enqueue-global.py
@@ -4,19 +4,12 @@ from redis import Redis
 from rq import Queue
 
 from wp1.environment import Environment
+from wp1.credentials import ENV, CREDENTIALS
 from wp1 import constants
 from wp1 import tables
 import wp1.logic.project as logic_project
 
 logger = logging.getLogger(__name__)
-
-try:
-  from wp1.credentials import ENV, CREDENTIALS
-except ImportError:
-  logger.exception('The file credentials.py must be populated manually in '
-                   'order to connect to Redis')
-  CREDENTIALS = None
-  ENV = None
 
 
 def main():

--- a/wp1/api.py
+++ b/wp1/api.py
@@ -5,15 +5,15 @@ import os
 import mwclient
 import requests
 
+from wp1.credentials import ENV, CREDENTIALS
 logger = logging.getLogger(__name__)
 MW_USER_AGENT = 'WP1.0Bot/3.0. Run by User:Audiodude. Using mwclient/0.9.1'
 
 
 def get_credentials():
   try:
-    from wp1.credentials import ENV, CREDENTIALS
     return CREDENTIALS[ENV]['API']
-  except (ImportError, KeyError):
+  except KeyError:
     # No credentials, probably in development environment.
     pass
 

--- a/wp1/base_db_test.py
+++ b/wp1/base_db_test.py
@@ -5,6 +5,7 @@ import sys
 
 import pymysql
 
+from wp1.credentials import CREDENTIALS, ENV
 from wp1.environment import Environment
 from wp1.models.wp10.selection import Selection
 
@@ -13,13 +14,6 @@ from wp1.redis_db import connect as redis_connect
 from wp1.models.wp10.rating import Rating
 
 logger = logging.getLogger(__name__)
-
-try:
-  from wp1.credentials import CREDENTIALS, ENV
-except ImportError:
-  logger.exception('The credentials.py file must be populated to run tests.')
-  CREDENTIALS = None
-  ENV = None
 
 
 def parse_sql(filename):

--- a/wp1/conf.py
+++ b/wp1/conf.py
@@ -2,11 +2,7 @@ import os
 
 import json
 
-try:
-  from wp1.credentials import CONF_LANG
-except ImportError:
-  # Default to English for unit tests.
-  CONF_LANG = 'en'
+from wp1.credentials import CONF_LANG
 
 
 def _get_conf_path():

--- a/wp1/credentials.py.e2e
+++ b/wp1/credentials.py.e2e
@@ -8,6 +8,8 @@ from wp1.environment import Environment
 ENV = Environment.TEST if 'pytest' in sys.modules else Environment.DEVELOPMENT
 # yapf: enable
 
+CONF_LANG = 'en'
+
 CREDENTIALS = {
     Environment.DEVELOPMENT: {
         'WIKIDB': {},

--- a/wp1/db.py
+++ b/wp1/db.py
@@ -7,15 +7,9 @@ import pymysql.cursors
 import pymysql.err
 import socks
 
-logger = logging.getLogger(__name__)
+from wp1.credentials import CREDENTIALS, ENV
 
-try:
-  from wp1.credentials import CREDENTIALS, ENV
-except ImportError:
-  logger.exception('The file credentials.py must be populated manually in '
-                   'order to connect to the required databases')
-  CREDENTIALS = None
-  ENV = None
+logger = logging.getLogger(__name__)
 
 RETRY_TIME_SECONDS = 5
 

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -12,13 +12,10 @@ from wp1.storage import connect_storage
 from wp1.logic import util
 from wp1.timestamp import utcnow
 from wp1 import zimfarm
+from wp1.credentials import ENV, CREDENTIALS
 
-try:
-  from wp1.credentials import ENV, CREDENTIALS
-  S3_PUBLIC_URL = CREDENTIALS.get(ENV, {}).get('CLIENT_URL', {}).get(
-      's3', 'http://credentials.not.found.fake')
-except ImportError:
-  S3_PUBLIC_URL = 'http://credentials.not.found.fake'
+S3_PUBLIC_URL = CREDENTIALS.get(ENV, {}).get('CLIENT_URL', {}).get(
+    's3', 'http://credentials.not.found.fake')
 
 DEFAULT_SELECTION_NAME = 'selection'
 

--- a/wp1/queues.py
+++ b/wp1/queues.py
@@ -13,18 +13,11 @@ import wp1.logic.builder as logic_builder
 import wp1.logic.project as logic_project
 from wp1.wiki_db import connect as wiki_connect
 from wp1 import logs
-from wp1 import redis_db
 from wp1 import tables
 from wp1.timestamp import utcnow
+from wp1.credentials import ENV
 
 logger = logging.getLogger(__name__)
-
-try:
-  from wp1.credentials import ENV
-except ImportError:
-  logger.exception('The file credentials.py must be populated manually in '
-                   'order to connect to Redis')
-  ENV = None
 
 
 def _get_queues(redis, manual=False):

--- a/wp1/redis_db.py
+++ b/wp1/redis_db.py
@@ -1,16 +1,9 @@
 import logging
 
 from redis import Redis
+from wp1.credentials import ENV, CREDENTIALS
 
 logger = logging.getLogger(__name__)
-
-try:
-  from wp1.credentials import ENV, CREDENTIALS
-except ImportError:
-  logger.exception('The file credentials.py must be populated manually in '
-                   'order to connect to Redis')
-  ENV = None
-  CREDENTIALS = None
 
 
 def connect():

--- a/wp1/scores.py
+++ b/wp1/scores.py
@@ -8,6 +8,7 @@ import csv
 from datetime import datetime, timedelta
 import requests
 
+from wp1.credentials import ENV, CREDENTIALS
 from wp1.constants import WP1_USER_AGENT
 from wp1.exceptions import Wp1ScoreProcessingError
 from wp1.time import get_current_datetime
@@ -17,14 +18,6 @@ PageviewRecord = namedtuple('PageviewRecord',
                             ['lang', 'name', 'page_id', 'views'])
 
 logger = logging.getLogger(__name__)
-
-try:
-  from wp1.credentials import ENV, CREDENTIALS
-except ImportError:
-  logger.exception('The file credentials.py must be populated manually in '
-                   'order to download pageviews')
-  CREDENTIALS = None
-  ENV = None
 
 
 def wiki_languages():

--- a/wp1/storage.py
+++ b/wp1/storage.py
@@ -7,8 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 def connect_storage():
-  if CREDENTIALS is None or ENV is None or CREDENTIALS[ENV].get(
-      'STORAGE') is None:
+  if CREDENTIALS[ENV].get('STORAGE') is None:
     raise ValueError('storage (s3) credentials in ENV=%s are None' % ENV)
   creds = CREDENTIALS[ENV]['STORAGE']
   connect_str = (

--- a/wp1/storage.py
+++ b/wp1/storage.py
@@ -1,16 +1,9 @@
 import logging
 
 from kiwixstorage import KiwixStorage
+from wp1.credentials import CREDENTIALS, ENV
 
 logger = logging.getLogger(__name__)
-
-try:
-  from wp1.credentials import CREDENTIALS, ENV
-except ImportError:
-  logger.exception('The file credentials.py must be populated manually in '
-                   'order to connect to the backend storage system.')
-  CREDENTIALS = None
-  ENV = None
 
 
 def connect_storage():

--- a/wp1/storage_test.py
+++ b/wp1/storage_test.py
@@ -7,11 +7,6 @@ from wp1.storage import connect_storage
 
 class StorageTest(unittest.TestCase):
 
-  @patch('wp1.storage.ENV', None)
-  def test_connect_storage_raises_if_no_env(self):
-    with self.assertRaises(ValueError):
-      actual = connect_storage()
-
   @patch('wp1.storage.CREDENTIALS', {Environment.TEST: {}})
   @patch('wp1.storage.ENV', Environment.TEST)
   def test_connect_storage_raises_if_no_credentials(self):

--- a/wp1/tables.py
+++ b/wp1/tables.py
@@ -9,20 +9,11 @@ from redis import Redis
 from wp1 import api
 from wp1.conf import get_conf
 from wp1.constants import LIST_URL, LIST_V2_URL, WIKI_BASE
-from wp1.models.wp10.category import Category
-from wp1.models.wp10.rating import Rating
 from wp1.templates import env as jinja_env
 from wp1.wp10_db import connect as wp10_connect
+from wp1.credentials import ENV, CREDENTIALS
 
 logger = logging.getLogger(__name__)
-
-try:
-  from wp1.credentials import ENV, CREDENTIALS
-except ImportError:
-  logger.exception('The file credentials.py must be populated manually in '
-                   'order to connect to Redis')
-  CREDENTIALS = None
-  ENV = None
 
 
 def get_redis():

--- a/wp1/web/__init__.py
+++ b/wp1/web/__init__.py
@@ -2,16 +2,6 @@ import flask
 from functools import wraps
 from flask import session
 
-try:
-  #  The credentials module isn't checked in and may be missing
-  from wp1.credentials import ENV, CREDENTIALS
-except ImportError:
-  print(
-      'No credentials.py file found, Please add your credentials in credentials.py'
-  )
-  ENV = None
-  CREDENTIALS = None
-
 
 def authenticate(f):
 

--- a/wp1/web/app.py
+++ b/wp1/web/app.py
@@ -14,33 +14,23 @@ from wp1.web.articles import articles
 from wp1.web.builders import builders
 from wp1.web.projects import projects
 from wp1.web.selection import selection
+from wp1.credentials import ENV, CREDENTIALS
 from wp1.web.sites import sites
 from wp1.web.dev.projects import dev_projects
-
-try:
-  # The credentials module isn't checked in and may be missing
-  from wp1.credentials import ENV, CREDENTIALS
-except ImportError:
-  print('No credentials.py file found. Development overlay will '
-        'not be enabled.')
-  ENV = None
-  CREDENTIALS = None
 
 
 def get_redis_creds():
   try:
-    from wp1.credentials import ENV, CREDENTIALS
     return CREDENTIALS[ENV]['REDIS']
-  except (ImportError, KeyError):
+  except KeyError:
     print('No REDIS_CREDS found, using defaults.')
     return None
 
 
 def get_secret_key():
   try:
-    from wp1.credentials import ENV, CREDENTIALS
     return CREDENTIALS[ENV]['SESSION']['secret_key']
-  except (ImportError, KeyError):
+  except KeyError:
     print('No secret_key found, using defaults.')
     return 'WP1'
 

--- a/wp1/web/dev/projects.py
+++ b/wp1/web/dev/projects.py
@@ -16,13 +16,13 @@ import flask
 from wp1.environment import Environment
 from wp1.timestamp import utcnow
 from wp1.web.redis import get_redis
+from wp1.credentials import CREDENTIALS
 
 UPDATE_DURATION_SECS = 5 * 30
 ELAPSED_TIME_SECS = 30
 BI_DURATION_SECS = UPDATE_DURATION_SECS + ELAPSED_TIME_SECS // 2
 
 try:
-  from wp1.credentials import CREDENTIALS
   overlay_settings = CREDENTIALS[Environment.DEVELOPMENT]['OVERLAY']
   UPDATE_DURATION_SECS = overlay_settings.get('update_wait_time_seconds',
                                               UPDATE_DURATION_SECS)
@@ -30,7 +30,7 @@ try:
                                            ELAPSED_TIME_SECS)
   BI_DURATION_SECS = overlay_settings.get('basic_income_total_time_seconds',
                                           BI_DURATION_SECS)
-except (ImportError, KeyError):
+except KeyError:
   # The default values were already set before the attempted import so nothing to do
   pass
 

--- a/wp1/web/oauth.py
+++ b/wp1/web/oauth.py
@@ -3,24 +3,21 @@ import flask
 from flask import jsonify, session
 from mwoauth import ConsumerToken, Handshaker
 from wp1.web.db import get_db
+from wp1.credentials import ENV, CREDENTIALS
 from wp1.models.wp10.user import User
 
 oauth = flask.Blueprint('oauth', __name__)
 
 try:
   # The credentials module isn't checked in and may be missing
-  from wp1.credentials import ENV, CREDENTIALS
   consumer_token = ConsumerToken(CREDENTIALS[ENV]['MWOAUTH']['consumer_key'],
                                  CREDENTIALS[ENV]['MWOAUTH']['consumer_secret'])
   handshaker = Handshaker("https://en.wikipedia.org/w/index.php",
                           consumer_token)
   homepage_url = CREDENTIALS[ENV]['CLIENT_URL']['homepage']
-except (ImportError, KeyError):
-  print(
-      'No credentials.py file found, or credentials malformed, Please add your '
-      'mwoauth credentials in credentials.py')
-  ENV = None
-  CREDENTIALS = None
+except KeyError:
+  print('Credentials malformed, Please add your '
+        'mwoauth credentials in credentials.py')
   handshaker = None
   homepage_url = None
 

--- a/wp1/web/redis.py
+++ b/wp1/web/redis.py
@@ -2,16 +2,9 @@ import logging
 
 import flask
 from redis import Redis
+from wp1.credentials import CREDENTIALS, ENV
 
 logger = logging.getLogger(__name__)
-
-try:
-  from wp1.credentials import CREDENTIALS, ENV
-except ImportError:
-  logger.exception('The file credentials.py must be populated manually in '
-                   'order to connect to the required databases')
-  CREDENTIALS = None
-  ENV = None
 
 
 def has_redis():


### PR DESCRIPTION
## Rationale
Remove redundant `ImportError` since there is always a `credentials.py`. This fixes #486 