### PR TITLE
refactor: update request token handling in OAuth flow

### DIFF
--- a/wp1/web/oauth.py
+++ b/wp1/web/oauth.py
@@ -1,7 +1,7 @@
 import attr
 import flask
 from flask import jsonify, session
-from mwoauth import ConsumerToken, Handshaker
+from mwoauth import ConsumerToken, Handshaker, RequestToken
 from wp1.web.db import get_db
 from wp1.models.wp10.user import User
 
@@ -33,7 +33,7 @@ def initiate():
       return flask.redirect(f"{homepage_url}{str(session['next_path'])}")
     return flask.redirect(homepage_url)
   redirect, request_token = handshaker.initiate()
-  session['request_token'] = request_token
+  session['request_token'] = { 'key': request_token.key, 'secret': request_token.secret }
   return flask.redirect(redirect)
 
 
@@ -43,7 +43,8 @@ def complete():
     flask.abort(404, 'User does not exist')
 
   query_string = str(flask.request.query_string.decode('utf-8'))
-  access_token = handshaker.complete(session['request_token'], query_string)
+  request_token = RequestToken(key = session['request_token']['key'], secret = session['request_token']['secret'])
+  access_token = handshaker.complete(request_token, query_string)
   session.pop('request_token')
   identity = handshaker.identify(access_token)
 


### PR DESCRIPTION
After cloning the repo and setting up a dev. environment, I couldn't log in. While debugging, I found out that the OAuth `RequestToken` object wasn't working properly when stored in the Flask session.

Turns out Flask sessions store data as JSON (in Redis), which somehow converts the namedtuple into a plain list. When the app later tries to use this token object, it fails because the structured data got lost in the conversion:
```
127.0.0.1 - - [02/Apr/2025 00:09:04] "GET /v1/oauth/complete?oauth_verifier=XXXXXXXXXXXXXXXXXXXXXXXX&oauth_token=XXXXXXXXXXXXXXXXXXXXXXXX HTTP/1.1" 500 -
Traceback (most recent call last):
  File "/Users/npace/.pyenv/versions/3.12.0/lib/python3.12/site-packages/flask/app.py", line 1536, in __call__
    return self.wsgi_app(environ, start_response)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/npace/.pyenv/versions/3.12.0/lib/python3.12/site-packages/flask/app.py", line 1514, in wsgi_app
    response = self.handle_exception(e)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/npace/.pyenv/versions/3.12.0/lib/python3.12/site-packages/flask_cors/extension.py", line 176, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
                                                ^^^^^^^^^^^^^^^^^^^^
  File "/Users/npace/.pyenv/versions/3.12.0/lib/python3.12/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/npace/.pyenv/versions/3.12.0/lib/python3.12/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/npace/.pyenv/versions/3.12.0/lib/python3.12/site-packages/flask_cors/extension.py", line 176, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
                                                ^^^^^^^^^^^^^^^^^^^^
  File "/Users/npace/.pyenv/versions/3.12.0/lib/python3.12/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/npace/.pyenv/versions/3.12.0/lib/python3.12/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/npace/repos/wp1/wp1/web/oauth.py", line 46, in complete
    access_token = handshaker.complete(session['request_token'], query_string)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/npace/.pyenv/versions/3.12.0/lib/python3.12/site-packages/mwoauth/handshaker.py", line 106, in complete
    return complete(
           ^^^^^^^^^
  File "/Users/npace/.pyenv/versions/3.12.0/lib/python3.12/site-packages/mwoauth/functions.py", line 160, in complete
    if not request_token.key == request_token_key:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'list' object has no attribute 'key'
```

My fix is pretty simple: instead of storing the whole token object directly, I save the key and secret as a dictionary, then rebuild the proper `RequestToken` when needed. 