### PR TITLE
fix: correct Redis port and improve example instructions in credentials files

### DIFF
--- a/wp1/credentials.py.dev.example
+++ b/wp1/credentials.py.dev.example
@@ -44,7 +44,7 @@ CREDENTIALS = {
         # prepopulated to use the dev Redis, and should not have to be edited.
         'REDIS': {
             'host': 'redis',
-            'port': 9736,
+            'port': 6379,
         },
 
         # These don't exist in development.

--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -1,9 +1,9 @@
 # Copy this file to credentials.py (in the same directory). Your application
 # database should work immediately after you run:
-# $ docker-compose -f docker-compose-dev.yml -d
+# $ docker-compose -f docker-compose-dev.yml up -d
 # in the root directory. The Wiki replica database requires actual toolforge
 # credentials to be accessible. The test database will be available when you run:
-# $ docker-compose -f docker-compose-test.yml -d
+# $ docker-compose -f docker-compose-test.yml up -d
 # in the root directory.
 import sys
 


### PR DESCRIPTION
Small changes to the credentials example files:
- Fixed docker-compose command in `credentials.py.example`
- Added a missing comma  in `credentials.py.dev.example`
- Corrected redis port in `credentials.py.dev.example`

I've tested the change of the redis port by opening a connection inside the container and it works correctly.
(it also makes sense give the docker-compose):
```yaml
  redis:
    image: redis
    container_name: wp1bot-redis-dev
    ports:
      - '9736:6379'
    networks:
      - wp1bot-dev
    restart: always
```