### PR TITLE
#832: Include Minio in docker-compose-dev.yml

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -18,6 +18,33 @@ services:
       - wp1bot-dev
     restart: always
 
+  minio:
+    image: minio/minio
+    container_name: wp1bot-minio-dev
+    ports:
+      - '9000:9000' #api
+      - '9001:9001' #web console
+    environment:
+      - MINIO_ROOT_USER=minio_key
+      - MINIO_ROOT_PASSWORD=minio_secret
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio-data:/data
+    networks:
+      - wp1bot-dev
+    restart: always
+
+  createbuckets:
+    image: minio/mc
+    container_name: wp1bot-minio-setup
+    depends_on:
+      - minio
+    networks:
+      - wp1bot-dev
+    volumes:
+      - ./docker/minio/setup-buckets.sh:/setup-buckets.sh
+    entrypoint: [ "/bin/sh", "/setup-buckets.sh" ]
+
   dev-workers:
     build:
       context: .
@@ -33,6 +60,11 @@ services:
     depends_on:
       - redis
       - dev-database
+      - minio
 
 networks:
   wp1bot-dev:
+
+
+volumes:
+  minio-data:

--- a/docker/minio/setup-buckets.sh
+++ b/docker/minio/setup-buckets.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Configure MinIO client and create bucket
+/usr/bin/mc config host add dev_minio http://minio:9000 minio_key minio_secret #configure client
+/usr/bin/mc mb dev_minio/org-kiwix-dev-wp1 --ignore-existing #create bucket
+/usr/bin/mc policy set public dev_minio/org-kiwix-dev-wp1 #set policy
+
+exit 0

--- a/wp1/credentials.py.dev.example
+++ b/wp1/credentials.py.dev.example
@@ -67,22 +67,24 @@ CREDENTIALS = {
         'CLIENT_URL': {
             'domains': ['http://localhost:5173'],
             'homepage': 'http://localhost:5173/#/',
+            's3': 'http://localhost:9000/org-kiwix-dev-wp1',
             'api': 'http://localhost:5000',
         },
 
-        # Configuration for the storage backend for storing selection lists. You MUST
-        # edit this line for your selections to be stored in a S3-like storage backend.
-        # You have two options for this setting:
+        # Configuration for the storage backend for storing selection lists.
+        # For development, you can use the local MinIO instance that's included in 
+        # the docker-compose setup (settings below are pre-configured for this).
+        # If you need to use an external service instead, you have two options:
         # 1. Use the Kiwix S3 backend on Wasabi. You will need to request dev or prod
         #    credentials. See https://github.com/openzim/zimfarm/wiki/S3-Cache-Policy
         #    for how.
-        # 2. Run your own S3-like storage system (MinIO, etc), or connect to one set
-        #    up as a service (actual AWS S3 or similar).
+        # 2. Use another S3-compatible storage service (AWS S3 or similar).
+        # In either external case, you'll need to edit the settings below.
         'STORAGE': {
-            'url': 'https://fake.s3.us-west-1.wasabisys.com/' # EDIT this line
-            'key': '', # EDIT this line
-            'secret': '', # EDIT this line
-            'bucket': 'org-kiwix-dev-wp1', # EDIT this line
+            'url': 'http://minio:9000/',
+            'key': 'minio_key', #username
+            'secret': 'minio_secret', #password
+            'bucket': 'org-kiwix-dev-wp1',
         },
 
         # Server URL and credentials for the Zim Farm that will be used to create

--- a/wp1/credentials.py.dev.example
+++ b/wp1/credentials.py.dev.example
@@ -67,7 +67,6 @@ CREDENTIALS = {
         'CLIENT_URL': {
             'domains': ['http://localhost:5173'],
             'homepage': 'http://localhost:5173/#/',
-            's3': 'http://localhost:9000/org-kiwix-dev-wp1',
             'api': 'http://localhost:5000',
         },
 

--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -98,22 +98,23 @@ CREDENTIALS = {
         'CLIENT_URL': {
             'domains': ['http://localhost:5173'],
             'homepage': 'http://localhost:5173/#/',
-            's3': 'https://org-kiwix-dev-wp1.s3.us-west-1.wasabisys.com',
+            's3': 'http://localhost:9000/org-kiwix-dev-wp1',
             'api': 'http://localhost:5000',
         },
 
-        # Configuration for the storage backend for storing selection lists. You MUST
-        # edit this line for your selections to be stored in a S3-like storage backend.
-        # You have two options for this setting:
+        # Configuration for the storage backend for storing selection lists.
+        # For development, you can use the local MinIO instance that's included in 
+        # the docker-compose setup (settings below are pre-configured for this).
+        # If you need to use an external service instead, you have two options:
         # 1. Use the Kiwix S3 backend on Wasabi. You will need to request dev or prod
         #    credentials. See https://github.com/openzim/zimfarm/wiki/S3-Cache-Policy
         #    for how.
-        # 2. Run your own S3-like storage system (MinIO, etc), or connect to one set
-        #    up as a service (actual AWS S3 or similar).
+        # 2. Use another S3-compatible storage service (AWS S3 or similar).
+        # In either external case, you'll need to edit the settings below.
         'STORAGE': {
-            'url': '', # EDIT this line
-            'key': '', # EDIT this line
-            'secret': '', # EDIT this line
+            'url': 'http://minio:9000/',
+            'key': 'minio_key', #username
+            'secret': 'minio_secret', #password
             'bucket': 'org-kiwix-dev-wp1',
         },
 


### PR DESCRIPTION
I added two new containers in docker-compose-dev.yml, one to run MinIO, and one to setup buckets in it.
I used the default docker images minio/minio to run MinIO and minio/mc to setup the buckets (with a script to do that in a clean way).
I create only a org-kiwix-dev-wp1 bucket in the script. 
On [localhost:9001](http://localhost:9001) there's also the MinIO web console available to easily check uploaded files in buckets.

I also added default credential for MinIO in credentials.* and updated comments on those files.

I tested it locally and it works: I am able to download the .tsv files.

Solves #832, and will make the setup for development of WP1 a bit easier. :)