### PR TITLE
fix: URL generation by stripping trailing slashes from S3_PUBLIC_URL

### DIFF
--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -63,7 +63,8 @@ def url_for(object_key):
     raise ValueError('Cannot get url for empty object_key')
   path = urllib.parse.quote(
       object_key if isinstance(object_key, str) else object_key.decode('utf-8'))
-  return '%s/%s' % (S3_PUBLIC_URL, path)
+  s3_public_url = S3_PUBLIC_URL.rstrip("/") #strip any trailing slashes
+  return f"{s3_public_url}/{path}"
 
 
 def zim_file_requested_at_for(wp10db, task_id):


### PR DESCRIPTION
Fix that solves problems reaching s3 when there is a '/' at the end of the S3_PUBLIC_URL.

While working on #834 I found a bug: If there's a '/' at the end of the s3 endpoint url the generated file url will be something like this: https://example.com//path/to/file which will of course result in files not found or errors on the s3 endpoints.

This small change fixes it. :)