### PR TITLE
feat: enhance WikiProject builder with autocomplete for project selection

### DIFF
--- a/wp1-frontend/cypress/e2e/createWikiProjectList.cy.js
+++ b/wp1-frontend/cypress/e2e/createWikiProjectList.cy.js
@@ -37,11 +37,13 @@ describe('the create WikiProject builder page', () => {
       cy.get('#listName > .form-control').click();
       cy.get('#listName > .form-control').type('List name');
       cy.get('#include-items').click();
+      cy.intercept('v1/builders/', (req) => {
+        req.reply({
+          statusCode: 200,
+          fixture: 'save_wikiproject_failure.json',
+        });
+    });
       cy.get('#include-items').type('Fake Project\n');
-      cy.intercept('v1/builders/', {
-        fixture: 'save_wikiproject_failure.json',
-      });
-
       cy.get('#include-projects').children().eq(0).should('contain.text', 'Fake Project');
       cy.get('#invalid_articles > .form-control').should(
         'have.value',
@@ -72,7 +74,6 @@ describe('the create WikiProject builder page', () => {
       cy.get('#include-items').click();
       cy.get('#include-items').type('Water\n');
       cy.get('#saveListButton').click();
-      cy.get('#saveListButton').click();
       cy.url().should('eq', 'http://localhost:5173/#/selections/user');
     });
 
@@ -93,8 +94,8 @@ describe('the create WikiProject builder page', () => {
         
         cy.get('#include-items').find('.search').type('Alien');
         cy.get('#include-items').find('.results').should('be.visible');
-        cy.get('#include-items').find('.results').children('li').eq(1).should('contain.text', 'Alien');
-        cy.get('#include-items').find('.results').children('li').eq(1).click();
+        cy.get('#include-items').find('.results').children('li').eq(0).should('contain.text', 'Alien');
+        cy.get('#include-items').find('.results').children('li').eq(0).click();
         
         cy.get('#saveListButton').click();
         cy.get('#saveLoader').should('be.visible');
@@ -106,8 +107,8 @@ describe('the create WikiProject builder page', () => {
         
         cy.get('#include-items').find('.search').type('Alien');
         cy.get('#include-items').find('.results').should('be.visible');
-        cy.get('#include-items').find('.results').children('li').eq(1).should('contain.text', 'Alien');
-        cy.get('#include-items').find('.results').children('li').eq(1).click();
+        cy.get('#include-items').find('.results').children('li').eq(0).should('contain.text', 'Alien');
+        cy.get('#include-items').find('.results').children('li').eq(0).click();
         
         cy.get('#saveListButton').click();
         cy.get('#saveListButton').should('have.attr', 'disabled');
@@ -120,8 +121,8 @@ describe('the create WikiProject builder page', () => {
       
       cy.get('#include-items').find('.search').type('Alien');
       cy.get('#include-items').find('.results').should('be.visible');
-      cy.get('#include-items').find('.results').children('li').eq(1).should('contain.text', 'Alien');
-      cy.get('#include-items').find('.results').children('li').eq(1).click();
+      cy.get('#include-items').find('.results').children('li').eq(0).should('contain.text', 'Alien');
+      cy.get('#include-items').find('.results').children('li').eq(0).click();
 
       cy.intercept('v1/builders/', { fixture: 'save_list_success.json' }).as(
         'createBuilderSuccess',
@@ -137,13 +138,13 @@ describe('the create WikiProject builder page', () => {
       
       cy.get('#include-items').find('.search').type('Alien');
       cy.get('#include-items').find('.results').should('be.visible');
-      cy.get('#include-items').find('.results').children('li').eq(1).should('contain.text', 'Alien');
-      cy.get('#include-items').find('.results').children('li').eq(1).click();
+      cy.get('#include-items').find('.results').children('li').eq(0).should('contain.text', 'Alien');
+      cy.get('#include-items').find('.results').children('li').eq(0).click();
 
       cy.get('#exclude-items').find('.search').type('Barbados');
       cy.get('#exclude-items').find('.results').should('be.visible');
-      cy.get('#exclude-items').find('.results').children('li').eq(1).should('contain.text', 'Barbados');
-      cy.get('#exclude-items').find('.results').children('li').eq(1).click();
+      cy.get('#exclude-items').find('.results').children('li').eq(0).should('contain.text', 'Barbados');
+      cy.get('#exclude-items').find('.results').children('li').eq(0).click();
 
       cy.intercept('v1/builders/', { fixture: 'save_list_success.json' }).as(
         'createBuilderSuccess',

--- a/wp1-frontend/cypress/e2e/createWikiProjectList.cy.js
+++ b/wp1-frontend/cypress/e2e/createWikiProjectList.cy.js
@@ -20,10 +20,11 @@ describe('the create WikiProject builder page', () => {
       cy.get('#listName').contains('Please provide a valid list name');
     });
 
-    it('validates textbox on clicking save', () => {
+    it('validates input on clicking save', () => {
       cy.get('#saveListButton').click();
       cy.get('#listName > .invalid-feedback').should('be.visible');
-      cy.get('#include-items ~ .invalid-feedback').should('be.visible');
+      cy.get('#lists .invalid-feedback').should('be.visible')
+      cy.get('#include-items').find('.invalid-feedback').should('be.visible');
     });
 
     it('validates list name on losing focus', () => {
@@ -36,19 +37,15 @@ describe('the create WikiProject builder page', () => {
       cy.get('#listName > .form-control').click();
       cy.get('#listName > .form-control').type('List name');
       cy.get('#include-items').click();
-      cy.get('#include-items').type('Fake Project 1\nAnother Fake');
+      cy.get('#include-items').type('Fake Project\n');
       cy.intercept('v1/builders/', {
         fixture: 'save_wikiproject_failure.json',
       });
-      cy.get('#saveListButton').click();
 
-      cy.get('#include-items').should(
-        'have.value',
-        'Fake Project 1\nAnother Fake',
-      );
+      cy.get('#include-projects').children().eq(0).should('contain.text', 'Fake Project');
       cy.get('#invalid_articles > .form-control').should(
         'have.value',
-        'Fake Project 1\nAnother Fake',
+        'Fake Project',
       );
     });
 
@@ -73,7 +70,7 @@ describe('the create WikiProject builder page', () => {
       cy.get('#listName > .form-control').click();
       cy.get('#listName > .form-control').type('List Name');
       cy.get('#include-items').click();
-      cy.get('#include-items').type('Fake Project 1\nAnother Fake');
+      cy.get('#include-items').type('Water\n');
       cy.get('#saveListButton').click();
       cy.get('#saveListButton').click();
       cy.url().should('eq', 'http://localhost:5173/#/selections/user');
@@ -93,8 +90,12 @@ describe('the create WikiProject builder page', () => {
       it('shows spinner', () => {
         cy.get('#listName > .form-control').click();
         cy.get('#listName > .form-control').type('List Name');
-        cy.get('#include-items').click();
-        cy.get('#include-items').type('Fake Project');
+        
+        cy.get('#include-items').find('.search').type('Alien');
+        cy.get('#include-items').find('.results').should('be.visible');
+        cy.get('#include-items').find('.results').children('li').eq(1).should('contain.text', 'Alien');
+        cy.get('#include-items').find('.results').children('li').eq(1).click();
+        
         cy.get('#saveListButton').click();
         cy.get('#saveLoader').should('be.visible');
       });
@@ -102,8 +103,12 @@ describe('the create WikiProject builder page', () => {
       it('disables save button', () => {
         cy.get('#listName > .form-control').click();
         cy.get('#listName > .form-control').type('List Name');
-        cy.get('#include-items').click();
-        cy.get('#include-items').type('Fake Project');
+        
+        cy.get('#include-items').find('.search').type('Alien');
+        cy.get('#include-items').find('.results').should('be.visible');
+        cy.get('#include-items').find('.results').children('li').eq(1).should('contain.text', 'Alien');
+        cy.get('#include-items').find('.results').children('li').eq(1).click();
+        
         cy.get('#saveListButton').click();
         cy.get('#saveListButton').should('have.attr', 'disabled');
       });
@@ -112,8 +117,12 @@ describe('the create WikiProject builder page', () => {
     it('redirects on saving valid project names', () => {
       cy.get('#listName > .form-control').click();
       cy.get('#listName > .form-control').type('List Name');
-      cy.get('#include-items').click();
-      cy.get('#include-items').type('Fake Project\nAnother Fake');
+      
+      cy.get('#include-items').find('.search').type('Alien');
+      cy.get('#include-items').find('.results').should('be.visible');
+      cy.get('#include-items').find('.results').children('li').eq(1).should('contain.text', 'Alien');
+      cy.get('#include-items').find('.results').children('li').eq(1).click();
+
       cy.intercept('v1/builders/', { fixture: 'save_list_success.json' }).as(
         'createBuilderSuccess',
       );
@@ -125,10 +134,16 @@ describe('the create WikiProject builder page', () => {
     it('sends correct data to API', () => {
       cy.get('#listName > .form-control').click();
       cy.get('#listName > .form-control').type('List Name');
-      cy.get('#include-items').click();
-      cy.get('#include-items').type('Fake Project\nAnother Fake Project');
-      cy.get('#exclude-items').click();
-      cy.get('#exclude-items').type('Even Faker Project\nMost Fake Project');
+      
+      cy.get('#include-items').find('.search').type('Alien');
+      cy.get('#include-items').find('.results').should('be.visible');
+      cy.get('#include-items').find('.results').children('li').eq(1).should('contain.text', 'Alien');
+      cy.get('#include-items').find('.results').children('li').eq(1).click();
+
+      cy.get('#exclude-items').find('.search').type('Barbados');
+      cy.get('#exclude-items').find('.results').should('be.visible');
+      cy.get('#exclude-items').find('.results').children('li').eq(1).should('contain.text', 'Barbados');
+      cy.get('#exclude-items').find('.results').children('li').eq(1).click();
 
       cy.intercept('v1/builders/', { fixture: 'save_list_success.json' }).as(
         'createBuilderSuccess',
@@ -136,12 +151,10 @@ describe('the create WikiProject builder page', () => {
       cy.get('#saveListButton').click();
       cy.wait('@createBuilderSuccess').then((interception) => {
         expect(interception.request.body.params.include).to.deep.equal([
-          'Fake Project',
-          'Another Fake Project',
+          'Alien',
         ]);
         expect(interception.request.body.params.exclude).to.deep.equal([
-          'Even Faker Project',
-          'Most Fake Project',
+          'Barbados',
         ]);
       });
     });

--- a/wp1-frontend/cypress/e2e/updateWikiProjectList.cy.js
+++ b/wp1-frontend/cypress/e2e/updateWikiProjectList.cy.js
@@ -49,7 +49,7 @@ describe('the update wikiproject list page', () => {
 
         cy.get('#invalid_articles > .form-control').should(
           'have.value',
-          'Fake Project 1\nAnother Fake',
+          'Fake Project',
         );
       });
 

--- a/wp1-frontend/cypress/e2e/updateWikiProjectList.cy.js
+++ b/wp1-frontend/cypress/e2e/updateWikiProjectList.cy.js
@@ -29,15 +29,12 @@ describe('the update wikiproject list page', () => {
 
       it('displays builder information', () => {
         cy.get('#listName > .form-control').should('have.value', 'Builder 3');
-        cy.get('#include-items').should(
-          'have.value',
-          'British Columbia road transport\nNew Brunswick road transport',
-        );
+        cy.get('#include-projects').children().should('have.length', 2);
+        cy.get('#include-projects').children().eq(0).should('contain.text', 'British Columbia road transport');
+        cy.get('#include-projects').children().eq(1).should('contain.text', 'New Brunswick road transport');
+        cy.get('#exclude-projects').children().should('have.length', 1);
+        cy.get('#exclude-projects').children().eq(0).should('contain.text', 'Countries');
         cy.get('#project > select').should('have.value', 'en.wikipedia.org');
-      });
-
-      it('does not show invalid list items', () => {
-        cy.get('#include-items ~ .invalid-feedback').should('not.be.visible');
       });
 
       it('does not show invalid list name', () => {

--- a/wp1-frontend/cypress/fixtures/save_wikiproject_failure.json
+++ b/wp1-frontend/cypress/fixtures/save_wikiproject_failure.json
@@ -2,7 +2,7 @@
   "success": false,
   "items": {
     "valid": [],
-    "invalid": ["Fake Project 1", "Another Fake"],
+    "invalid": ["Fake Project"],
     "errors": ["Not all given projects exist"]
   }
 }

--- a/wp1-frontend/src/components/Autocomplete.vue
+++ b/wp1-frontend/src/components/Autocomplete.vue
@@ -30,6 +30,9 @@
       <button v-on:click="onButtonClick()" class="btn btn-primary">
         Select Project
       </button>
+      <div class="invalid-feedback" >
+        Please provide projects
+      </div>
     </div>
     <ul tabindex="0" ref="list" class="results" v-show="isOpen">
       <li


### PR DESCRIPTION
Fixes #775

I tried implementing something like what is proposed in #775. I reused the Autocomplete component from the Project home page and did some modifications to make it work correctly (especially to get errors and so on).
I used bootstrap for the style.
I modified the unit tests (although I was not able to test them all correctly cause the Autocomplete is not working properly when I run tests locally (but it works in my local deployment)). I will for sure continue working on the unit tests part :)

Hope to have your feedback. :)

Here's a screenshot of the modified page:

![Screenshot](https://github.com/user-attachments/assets/e875289d-2473-4eb6-ac2c-fa2cfe2877ca)
