### PR TITLE
wait for redisdb to start

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -8,6 +8,12 @@ services:
     networks:
       - wp1bot-dev
     restart: always
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      start_period: 1m30s
+      interval: 1m
+      timeout: 15s
+      retries: 10
 
   dev-database:
     build: docker/dev-db/
@@ -43,7 +49,7 @@ services:
       - wp1bot-dev
     volumes:
       - ./docker/minio/setup-buckets.sh:/setup-buckets.sh
-    entrypoint: [ "/bin/sh", "/setup-buckets.sh" ]
+    entrypoint: ['/bin/sh', '/setup-buckets.sh']
 
   dev-workers:
     build:
@@ -58,13 +64,15 @@ services:
       - wp1bot-dev
     restart: always
     depends_on:
-      - redis
-      - dev-database
-      - minio
+      redis:
+        condition: service_healthy
+      dev-database:
+        condition: service_started
+      minio:
+        condition: service_started
 
 networks:
   wp1bot-dev:
-
 
 volumes:
   minio-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,12 @@ services:
     expose:
       - 6379
     restart: always
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      start_period: 1m30s
+      interval: 1m
+      timeout: 15s
+      retries: 10
 
   workers:
     image: ghcr.io/openzim/wp1-workers:release
@@ -24,7 +30,8 @@ services:
         max-size: '10m'
     restart: always
     depends_on:
-      - redis
+      redis:
+        condition: service_healthy
 
   web:
     image: ghcr.io/openzim/wp1-web:release
@@ -47,7 +54,8 @@ services:
         max-size: '10m'
     restart: always
     depends_on:
-      - redis
+      redis:
+        condition: service_healthy
 
   frontend:
     image: ghcr.io/openzim/wp1-frontend:release


### PR DESCRIPTION
## Rationale
By defining a healthcheck for the redis db and ensuring the services that depend on it wait for the healthchek to pass, services that rely on it can avoid crashing on startup as redis might not be ready.

This fixes #836 