### PR TITLE
fix: update VITE_API_URL to use 127.0.0.1 instead of localhost in .env.development

### DIFF
--- a/wp1-frontend/.env.development
+++ b/wp1-frontend/.env.development
@@ -1,1 +1,1 @@
-VITE_API_URL=http://localhost:5000/v1
+VITE_API_URL=http://127.0.0.1:5000/v1


### PR DESCRIPTION
As described in #841, unit tests are not working properly in the local development environment. 

In particular, I was not able to use the autocomplete component properly during test with cypress. 
Debugging I found out that inside cypress test environment I was not able to reach `localhost:5000/v1`.

Changing from the `VITE_API_URL` to use `127.0.0.1` instead of `localhost` in file `.env.development` solves the issue.