### PR TITLE
Fix bug in migration to handle NULL/empty object ids

### DIFF
--- a/db/migrations/20250325_01_sFddz-add-article-count-to-selection-table.py
+++ b/db/migrations/20250325_01_sFddz-add-article-count-to-selection-table.py
@@ -17,6 +17,9 @@ def update_article_counts(conn):
         'SELECT s_id, s_object_key FROM selections WHERE s_article_count IS NULL'
     )
     for s_id, s_object_key in cursor.fetchall():
+      if not s_object_key:
+        continue
+
       buffer = BytesIO()
       s3.download_fileobj(s_object_key.decode('utf-8'), buffer)
       data = buffer.getvalue()


### PR DESCRIPTION
There was a bug in the original migration that shipped with #818, in that we didn't expect `NULL` values for `s_object_key` in the `selections` table, but some values existed. This caused the migration to fail.

To continue the deployment, we temporarily edited the migration file in the running container in order to add these lines. The migration completed successfully and now we are retroactively adding this line to the repo for historical reasons.