### PR TITLE
Update custom RateLimitQueue rq class to take **kwargs for forward compatibility

### DIFF
--- a/rate_limit_queue.py
+++ b/rate_limit_queue.py
@@ -1,4 +1,5 @@
 import time
+
 from rq import Queue
 
 
@@ -7,17 +8,8 @@ class RateLimitQueue(Queue):
   wait_time_secs = 1
 
   @classmethod
-  def dequeue_any(cls,
-                  queues,
-                  timeout,
-                  connection=None,
-                  job_class=None,
-                  serializer=None):
-    job, queue = super().dequeue_any(queues,
-                                     timeout,
-                                     connection=connection,
-                                     job_class=job_class,
-                                     serializer=serializer)
+  def dequeue_any(cls, *args, **kwargs):
+    job, queue = super().dequeue_any(*args, **kwargs)
     if job and queue:
       cur_time = int(time.time())
       time_diff = 0


### PR DESCRIPTION
We recently upgraded to rq 2.2.0, however this introduced API changes. The worker jobs broke in production and it was difficult to tell why.

The root cause was that `dequeue_any` method is now expected to take an additional `death_penalty_class` keyword argument.

We've tried to future proof the RateLimitQueue in this class a bit by using `*args` and `**kwargs`, because we don't need to operate on any of them and just want to pass them to the `super().dequeue_any()` method.