### PR TITLE
fix(logs): add Automatically generated template to log pages

### DIFF
--- a/wp1/logs.py
+++ b/wp1/logs.py
@@ -201,7 +201,7 @@ def update_log_page_for_project(project_name):
 
     p = api.get_page(log_page_name(project_name))
 
-    header = ('<noinclude>{{Log}}</noinclude>\n')
+    header = ('<noinclude>{{Log}}\n{{Automatically generated}}</noinclude>\n')
 
     if len(edits) == 0:
       today = get_current_datetime()


### PR DESCRIPTION
Add {{Automatically generated}} template to log pages to prevent manual renaming and editing. 