### PR TITLE
chore: update dev db with new migrations

### DIFF
--- a/docker/dev-db/enwp10_dev.dump.sql
+++ b/docker/dev-db/enwp10_dev.dump.sql
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b7b2e1458f1c7ec397f0885e3823a5f86b9b3b190f807352cae9252e0b277c24
-size 21920793
+oid sha256:4716cbb9650d8e547df7f990dd1bb775f3985eda08a6f49f3c1cd58ec467b2ba
+size 31105032


### PR DESCRIPTION
The dev db was not up to date with the latest migrations, resulting in problems with the latest changes.

To fix the dev. env, I applied the following migrations that were missing:
 - [20250323_01_xyzAB-add-temp-pageviews-table]
 - [20250324_02_arj6b-add-ps-article-index-to-page-scores]
 - [20250330_01_zaRQa-migrate-last-7-days-of-logs]
 - [20250325_01_sFddz-add-article-count-to-selection-table]