### PR TITLE
Restore VITE_API_URL to localhost to fix auth issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,12 @@ Using pipenv, you can start the API server with:
 pipenv run flask --app wp1.web.app --debug run
 ```
 
+If you're having difficulties connecting to the backend server from the
+frontend, especially in cypress e2e tests, and espcially on macOS, it might have
+something to do with IPv4 versus IPv6 networking stacks. You can try adding the
+option `--host 127.0.0.1` to the command line above (see
+https://github.com/openzim/wp1/pull/859).
+
 ## Starting the web frontend
 
 Assuming you've installed the frontend deps (`yarn install`), the web frontend

--- a/wp1-frontend/.env.development
+++ b/wp1-frontend/.env.development
@@ -1,1 +1,1 @@
-VITE_API_URL=http://127.0.0.1:5000/v1
+VITE_API_URL=http://localhost:5000/v1


### PR DESCRIPTION
In #843, the VITE_API_URL was changed from `localhost` to `127.0.0.1`. This causes problems with auth in the development environment, since the frontend loads `http://127.0.0.1/v1/oauth/initiate` but the callback from the Wikimedia OAuth API is `http://localhost:5000/v1/oauth/complete`. Because of the mismatch, the session cookies don't match up, the browser sees `127.0.0.1` and `localhost` as different hosts, and as such sends different cookies (which then corresponds to different Flask sessions).

It's not completely clear what the actual issue is that causes cypress to be unable to contact the Flask backend in e2e tests. It's likely something to do with the networking config on the host machine, and has nothing to do with any application code. I've had similar issues with my mac, and launching the backend with the following command helped fix it:

```
$ pipenv run flask --app wp1.web.app --debug run --host 127.0.0.1
```

Alternately, developers facing this issue (@nicolapace) can create an `.env.development.local` file in the wp1-frontend directory that is git ignored (`.gitignore`) and that file will take precedence over `.env.development`.