### PR TITLE
Limit the number of articles that can be made into a ZIM file

### DIFF
--- a/wp1-frontend/cypress/e2e/zimFile.cy.js
+++ b/wp1-frontend/cypress/e2e/zimFile.cy.js
@@ -4,7 +4,7 @@ describe('the zim file creation page', () => {
   describe('when the user is logged in', () => {
     beforeEach(() => {
       cy.intercept('v1/oauth/identify', { fixture: 'identity.json' }).as(
-        'identity'
+        'identity',
       );
     });
 
@@ -15,209 +15,256 @@ describe('the zim file creation page', () => {
         }).as('builder');
       });
 
-      describe('when the zim file has not been requested yet', () => {
+      describe('and the selection is under the article limit', () => {
         beforeEach(() => {
+          cy.intercept('GET', 'v1/builders/1/selection/latest/article_count', {
+            selection: {
+              id: '1',
+              aricle_count: 1000,
+              max_article_count: 50000,
+            },
+          }).as('article_count');
+        });
+
+        describe('when the zim file has not been requested yet', () => {
+          beforeEach(() => {
+            cy.intercept('v1/builders/1/zim/status', {
+              fixture: 'zim_status_not_requested.json',
+            }).as('status');
+            cy.visit('/#/selections/1/zim');
+            cy.wait('@identity');
+            cy.wait('@builder');
+            cy.wait('@status');
+          });
+
+          it('displays the form for entering descriptions', () => {
+            cy.get('#desc').should('be.visible');
+            cy.get('#longdesc').should('be.visible');
+          });
+
+          it('validates the title input on losing focus', () => {
+            cy.get('#zimtitle').click();
+            cy.get('#zimtitle').clear();
+            cy.get('#longdesc').click();
+            cy.get('#zimtitle-group > .invalid-feedback').should('be.visible');
+          });
+
+          it('validates the title input to have max 30 graphemes', () => {
+            const longTitle = 'A'.repeat(31);
+            cy.get('#zimtitle').click();
+            cy.get('#zimtitle').clear();
+            cy.get('#zimtitle').type(longTitle);
+            cy.get('#zimtitle').should(
+              'have.value',
+              longTitle.substring(0, 30),
+            );
+          });
+
+          it('handles graphems correctly', () => {
+            const longTitle = 'में'.repeat(30);
+            cy.get('#zimtitle').click();
+            cy.get('#zimtitle').clear();
+            cy.get('#zimtitle').type(longTitle);
+            cy.get('#zimtitle').should('have.value', 'में'.repeat(30));
+          });
+
+          it('validates the description input on losing focus', () => {
+            cy.get('#desc').click();
+            cy.get('#longdesc').click();
+            cy.get('#desc-group > .invalid-feedback').should('be.visible');
+          });
+
+          it('disables the submit button when the description is missing', () => {
+            cy.get('#zimtitle').click();
+            cy.get('#zimtitle').type('Title from user');
+            cy.get('#request').should('be.visible');
+            cy.get('#request').should('have.attr', 'disabled');
+          });
+
+          it('disables the submit button when the title is missing', () => {
+            cy.get('#zimtitle').click();
+            cy.get('#zimtitle').clear();
+            cy.get('#desc').click();
+            cy.get('#desc').type('Description from user');
+            cy.get('#request').should('be.visible');
+            cy.get('#request').should('have.attr', 'disabled');
+          });
+
+          it('does not allow submission if the long desc is shorter than the desc', () => {
+            cy.get('#zimtitle').click();
+            cy.get('#zimtitle').clear();
+            cy.get('#zimtitle').type('Title from user');
+            cy.get('#desc').click();
+            cy.get('#desc').clear();
+            cy.get('#desc').type('The description, which is longer');
+            cy.get('#longdesc').click();
+            cy.get('#longdesc').type('Shorter desc');
+            cy.get('#request').should('be.visible');
+            cy.get('#request').should('have.attr', 'disabled');
+          });
+
+          it('does not allow submission if the long desc equals the desc', () => {
+            cy.get('#zimtitle').click();
+            cy.get('#zimtitle').clear();
+            cy.get('#zimtitle').type('Title from user');
+            cy.get('#desc').click();
+            cy.get('#desc').clear();
+            cy.get('#desc').type('The description');
+            cy.get('#longdesc').click();
+            cy.get('#longdesc').type('The description');
+            cy.get('#request').should('be.visible');
+            cy.get('#request').should('have.attr', 'disabled');
+          });
+        });
+
+        describe('when the zim file has been requested but is not ready', () => {
+          beforeEach(() => {
+            cy.intercept('v1/builders/1/zim/status', {
+              fixture: 'zim_status_not_ready.json',
+            }).as('status');
+            cy.visit('/#/selections/1/zim');
+            cy.wait('@identity');
+            cy.wait('@builder');
+            cy.wait('@status');
+          });
+
+          it('does not display the form for descriptions', () => {
+            cy.get('#desc').should('not.exist');
+            cy.get('#longdesc').should('not.exist');
+          });
+
+          it('shows the Download ZIM button disabled', () => {
+            cy.get('#download').should('be.visible');
+            cy.get('#download').should('have.attr', 'disabled');
+          });
+
+          it('shows the spinner', () => {
+            cy.get('#loader').should('be.visible');
+          });
+        });
+
+        describe('when the zim file is ready', () => {
+          beforeEach(() => {
+            cy.intercept('v1/builders/1/zim/status', {
+              fixture: 'zim_status_ready.json',
+            }).as('status');
+            cy.visit('/#/selections/1/zim');
+            cy.wait('@identity');
+            cy.wait('@builder');
+            cy.wait('@status');
+          });
+
+          it('does not display the form for descriptions', () => {
+            cy.get('#desc').should('not.exist');
+            cy.get('#longdesc').should('not.exist');
+          });
+
+          it('shows the Download ZIM button enabled', () => {
+            cy.get('#download').should('be.visible');
+            cy.get('#download').should('not.have.attr', 'disabled');
+          });
+
+          it('does not show the spinner', () => {
+            cy.get('#loader').should('not.be.visible');
+          });
+        });
+
+        describe('when the zim file has failed', () => {
+          beforeEach(() => {
+            cy.intercept('v1/builders/1/zim/status', {
+              fixture: 'zim_status_failed.json',
+            }).as('status');
+            cy.visit('/#/selections/1/zim');
+            cy.wait('@identity');
+            cy.wait('@builder');
+            cy.wait('@status');
+          });
+
+          it('displays the form for entering descriptions', () => {
+            cy.get('#desc').should('be.visible');
+            cy.get('#longdesc').should('be.visible');
+          });
+
+          it('does not show the spinner', () => {
+            cy.get('#loader').should('not.be.visible');
+          });
+
+          it('displays the Request ZIM file button', () => {
+            cy.get('#zimtitle').click();
+            cy.get('#zimtitle').type('Title from user');
+            cy.get('#desc').click();
+            cy.get('#desc').type('Description from user');
+            cy.get('#request').should('be.visible');
+            cy.get('#request').should('not.have.attr', 'disabled');
+          });
+
+          describe('when the Request ZIM file button is clicked', () => {
+            beforeEach(() => {
+              cy.intercept('POST', 'v1/builders/1/zim', {
+                statusCode: 204,
+              }).as('request');
+
+              cy.get('#desc').click();
+              cy.get('#desc').type('Description from user');
+              cy.get('#request').click();
+            });
+
+            it('makes the ZIM file request', () => {
+              cy.wait('@request');
+            });
+          });
+        });
+
+        describe('when the zim file is expired', () => {
+          beforeEach(() => {
+            cy.intercept('v1/builders/1/zim/status', {
+              fixture: 'zim_status_deleted.json',
+            }).as('status');
+            cy.visit('/#/selections/1/zim');
+            cy.wait('@identity');
+            cy.wait('@builder');
+            cy.wait('@status');
+          });
+
+          it('displays the form for entering descriptions', () => {
+            cy.get('#desc').should('be.visible');
+            cy.get('#longdesc').should('be.visible');
+          });
+
+          it('does not show the spinner', () => {
+            cy.get('#loader').should('not.be.visible');
+          });
+
+          it('displays the Request ZIM file button', () => {
+            cy.get('#zimtitle').click();
+            cy.get('#zimtitle').type('Title from user');
+            cy.get('#desc').click();
+            cy.get('#desc').type('Description from user');
+            cy.get('#request').should('be.visible');
+            cy.get('#request').should('not.have.attr', 'disabled');
+          });
+        });
+      });
+
+      describe('and the selection is over the article limit', () => {
+        beforeEach(() => {
+          cy.intercept('GET', 'v1/builders/1/selection/latest/article_count', {
+            selection: {
+              id: '1',
+              article_count: 100000,
+              max_article_count: 50000,
+            },
+          }).as('article_count');
           cy.intercept('v1/builders/1/zim/status', {
             fixture: 'zim_status_not_requested.json',
           }).as('status');
+        });
+
+        it('displays the article error message', () => {
           cy.visit('/#/selections/1/zim');
           cy.wait('@identity');
           cy.wait('@builder');
           cy.wait('@status');
-        });
-
-        it('displays the form for entering descriptions', () => {
-          cy.get('#desc').should('be.visible');
-          cy.get('#longdesc').should('be.visible');
-        });
-
-        it('validates the title input on losing focus', () => {
-          cy.get('#zimtitle').click();
-          cy.get('#zimtitle').clear();
-          cy.get('#longdesc').click();
-          cy.get('#zimtitle-group > .invalid-feedback').should('be.visible');
-        });
-
-        it('validates the title input to have max 30 graphemes', () => {
-          const longTitle = 'A'.repeat(31);
-          cy.get('#zimtitle').click();
-          cy.get('#zimtitle').clear();
-          cy.get('#zimtitle').type(longTitle);
-          cy.get('#zimtitle').should('have.value', longTitle.substring(0, 30));
-        });
-
-        it('handles graphems correctly', () => {
-          const longTitle = "में".repeat(30);
-          cy.get('#zimtitle').click();
-          cy.get('#zimtitle').clear();
-          cy.get('#zimtitle').type(longTitle);
-          cy.get('#zimtitle').should('have.value', "में".repeat(30));
-        });
-
-        it('validates the description input on losing focus', () => {
-          cy.get('#desc').click();
-          cy.get('#longdesc').click();
-          cy.get('#desc-group > .invalid-feedback').should('be.visible');
-        });
-
-        it('displays the Request ZIM file button', () => {
-          cy.get('#request').should('be.visible');
-          cy.get('#request').should('have.attr', 'disabled');
-        });
-
-        describe('when the description is missing', () => {
-          beforeEach(() => {
-            cy.intercept('POST', 'v1/builders/1/zim', () => {
-              throw new Error(
-                'POST to create ZIM should not have been requested'
-              );
-            }).as('request');
-          });
-
-            it('disables the submit button', () => {
-            cy.get('#request').should('have.attr', 'disabled');
-            });
-
-            it('shows the error message', () => {
-            cy.get('#request').click({ force: true });
-            cy.get('#desc-group > .invalid-feedback').should('be.visible');
-            });
-        });
-
-        describe('when the Request ZIM file button is clicked', () => {
-          beforeEach(() => {
-            cy.intercept('POST', 'v1/builders/1/zim', {
-              statusCode: 204,
-            }).as('request');
-
-            cy.get('#desc').click();
-            cy.get('#desc').type('Description from user');
-            cy.get('#request').click();
-          });
-
-          it('makes the ZIM file request', () => {
-            cy.wait('@request');
-          });
-        });
-      });
-
-      describe('when the zim file has been requested but is not ready', () => {
-        beforeEach(() => {
-          cy.intercept('v1/builders/1/zim/status', {
-            fixture: 'zim_status_not_ready.json',
-          }).as('status');
-          cy.visit('/#/selections/1/zim');
-          cy.wait('@identity');
-          cy.wait('@builder');
-          cy.wait('@status');
-        });
-
-        it('does not display the form for descriptions', () => {
-          cy.get('#desc').should('not.exist');
-          cy.get('#longdesc').should('not.exist');
-        });
-
-        it('shows the Download ZIM button disabled', () => {
-          cy.get('#download').should('be.visible');
-          cy.get('#download').should('have.attr', 'disabled');
-        });
-
-        it('shows the spinner', () => {
-          cy.get('#loader').should('be.visible');
-        });
-      });
-
-      describe('when the zim file is ready', () => {
-        beforeEach(() => {
-          cy.intercept('v1/builders/1/zim/status', {
-            fixture: 'zim_status_ready.json',
-          }).as('status');
-          cy.visit('/#/selections/1/zim');
-          cy.wait('@identity');
-          cy.wait('@builder');
-          cy.wait('@status');
-        });
-
-        it('does not display the form for descriptions', () => {
-          cy.get('#desc').should('not.exist');
-          cy.get('#longdesc').should('not.exist');
-        });
-
-        it('shows the Download ZIM button enabled', () => {
-          cy.get('#download').should('be.visible');
-          cy.get('#download').should('not.have.attr', 'disabled');
-        });
-
-        it('does not show the spinner', () => {
-          cy.get('#loader').should('not.be.visible');
-        });
-      });
-
-      describe('when the zim file has failed', () => {
-        beforeEach(() => {
-          cy.intercept('v1/builders/1/zim/status', {
-            fixture: 'zim_status_failed.json',
-          }).as('status');
-          cy.visit('/#/selections/1/zim');
-          cy.wait('@identity');
-          cy.wait('@builder');
-          cy.wait('@status');
-        });
-
-        it('displays the form for entering descriptions', () => {
-          cy.get('#desc').should('be.visible');
-          cy.get('#longdesc').should('be.visible');
-        });
-
-        it('does not show the spinner', () => {
-          cy.get('#loader').should('not.be.visible');
-        });
-
-        it('displays the Request ZIM file button', () => {
-          cy.get('#request').should('be.visible');
-          cy.get('#request').should('have.attr', 'disabled');
-        });
-
-        describe('when the Request ZIM file button is clicked', () => {
-          beforeEach(() => {
-            cy.intercept('POST', 'v1/builders/1/zim', {
-              statusCode: 204,
-            }).as('request');
-
-            cy.get('#desc').click();
-            cy.get('#desc').type('Description from user');
-            cy.get('#request').click();
-          });
-
-          it('makes the ZIM file request', () => {
-            cy.wait('@request');
-          });
-        });
-      });
-
-      describe('when the zim file is expired', () => {
-        beforeEach(() => {
-          cy.intercept('v1/builders/1/zim/status', {
-            fixture: 'zim_status_deleted.json',
-          }).as('status');
-          cy.visit('/#/selections/1/zim');
-          cy.wait('@identity');
-          cy.wait('@builder');
-          cy.wait('@status');
-        });
-
-        it('displays the form for entering descriptions', () => {
-          cy.get('#desc').should('be.visible');
-          cy.get('#longdesc').should('be.visible');
-        });
-
-        it('does not show the spinner', () => {
-          cy.get('#loader').should('not.be.visible');
-        });
-
-        it('displays the Request ZIM file button', () => {
-          cy.get('#request').should('be.visible');
-          cy.get('#request').should('have.attr', 'disabled');
         });
       });
     });

--- a/wp1-frontend/src/components/ZimFile.vue
+++ b/wp1-frontend/src/components/ZimFile.vue
@@ -26,7 +26,7 @@
               are required, but generic defaults will be used if they're not
               provided.
             </p>
-            <div v-if="tooManyArticles()" class="errors">
+            <div v-if="tooManyArticles()" class="article-limit-exceeded errors">
               <h2>Too many articles</h2>
               <p>
                 Oh no! It seems that you have hit the limit for the maximum

--- a/wp1/exceptions.py
+++ b/wp1/exceptions.py
@@ -30,6 +30,12 @@ class InvalidZimLongDescriptionError(ZimFarmError):
   pass
 
 
+class ZimFarmTooManyArticlesError(ZimFarmError):
+
+  def user_message(self):
+    return str(self)
+
+
 class ObjectNotFoundError(Wp1Error):
   pass
 

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -6,15 +6,12 @@ import attr
 import wp1.logic.selection as logic_selection
 import wp1.logic.util as logic_util
 from wp1 import queues, zimfarm
-from wp1.constants import (
-    CONTENT_TYPE_TO_EXT,
-    EXT_TO_CONTENT_TYPE,
-    MAX_ZIM_FILE_POLL_TIME,
-    TS_FORMAT_WP10,
-)
+from wp1.constants import (CONTENT_TYPE_TO_EXT, EXT_TO_CONTENT_TYPE,
+                           MAX_ZIM_FILE_POLL_TIME, TS_FORMAT_WP10)
 from wp1.credentials import CREDENTIALS, ENV
 from wp1.environment import Environment
-from wp1.exceptions import ObjectNotFoundError, UserNotAuthorizedError, ZimFarmError
+from wp1.exceptions import (ObjectNotFoundError, UserNotAuthorizedError,
+                            ZimFarmError)
 from wp1.models.wp10.builder import Builder
 from wp1.models.wp10.selection import Selection
 from wp1.models.wp10.zim_file import ZimFile

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -145,8 +145,14 @@ def latest_selection_for_builder(builder_id, ext):
 
 
 @builders.route('/<builder_id>/selection/latest/article_count')
+@authenticate
 def latest_selection_article_count_for_builder(builder_id):
   wp10db = get_db('wp10db')
+
+  user_id = flask.session['user']['identity']['sub']
+  builder = logic_builder.get_builder(wp10db, builder_id)
+  if builder.b_user_id.decode('utf-8') != user_id:
+    flask.abort(403)
 
   selection = logic_builder.latest_selection_for(wp10db, builder_id,
                                                  EXT_TO_CONTENT_TYPE['tsv'])

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -6,6 +6,7 @@ import flask
 import wp1.logic.builder as logic_builder
 import wp1.logic.selection as logic_selection
 from wp1 import queues
+from wp1.constants import EXT_TO_CONTENT_TYPE
 from wp1.credentials import CREDENTIALS, ENV
 from wp1.exceptions import (
     ObjectNotFoundError,
@@ -141,6 +142,24 @@ def latest_selection_for_builder(builder_id, ext):
     flask.abort(404)
 
   return flask.redirect(url, code=302)
+
+
+@builders.route('/<builder_id>/selection/latest/article_count')
+def latest_selection_article_count_for_builder(builder_id):
+  wp10db = get_db('wp10db')
+
+  selection = logic_builder.latest_selection_for(wp10db, builder_id,
+                                                 EXT_TO_CONTENT_TYPE['tsv'])
+  if not selection:
+    flask.abort(404)
+
+  return flask.jsonify({
+      'selection': {
+          'id': selection.s_id.decode('utf-8'),
+          'article_count': selection.s_article_count,
+          'max_article_count': MAX_ZIMFARM_ARTICLE_COUNT,
+      }
+  })
 
 
 @builders.route('/<builder_id>/zim', methods=['POST'])

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -695,6 +695,8 @@ class BuildersTest(BaseWebTestcase):
     self._insert_selections(builder_id)
     self.app = create_app()
     with self.app.test_client() as client:
+      with client.session_transaction() as sess:
+        sess['user'] = self.USER
       rv = client.get('/v1/builders/%s/selection/latest/article_count' %
                       builder_id)
     self.assertEqual('200 OK', rv.status)
@@ -706,3 +708,12 @@ class BuildersTest(BaseWebTestcase):
                 'max_article_count': MAX_ZIMFARM_ARTICLE_COUNT
             }
         }, rv.get_json())
+
+  def test_latest_selection_article_count_for_builder_wrong_user(self):
+    builder_id = self._insert_builder()
+    self._insert_selections(builder_id)
+    self.app = create_app()
+    with self.app.test_client() as client:
+      rv = client.get('/v1/builders/%s/selection/latest/article_count' %
+                      builder_id)
+    self.assertEqual('401 UNAUTHORIZED', rv.status)

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -689,3 +689,20 @@ class BuildersTest(BaseWebTestcase):
     with self.app.test_client() as client:
       rv = client.get('/v1/builders/abcd-1234/zim/latest')
     self.assertEqual('404 NOT FOUND', rv.status)
+
+  def test_latest_selection_article_count_for_builder(self):
+    builder_id = self._insert_builder()
+    self._insert_selections(builder_id)
+    self.app = create_app()
+    with self.app.test_client() as client:
+      rv = client.get('/v1/builders/%s/selection/latest/article_count' %
+                      builder_id)
+    self.assertEqual('200 OK', rv.status)
+    self.assertEqual(
+        {
+            'selection': {
+                'id': '3',
+                'article_count': 1000,
+                'max_article_count': MAX_ZIMFARM_ARTICLE_COUNT
+            }
+        }, rv.get_json())

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -7,10 +7,21 @@ import requests
 from wp1 import zimfarm
 from wp1.base_db_test import BaseWpOneDbTest
 from wp1.environment import Environment
-from wp1.exceptions import (ObjectNotFoundError, ZimFarmError,
-                            ZimFarmTooManyArticlesError)
+from wp1.exceptions import (
+    InvalidZimDescriptionError,
+    InvalidZimLongDescriptionError,
+    InvalidZimTitleError,
+    ObjectNotFoundError,
+    ZimFarmError,
+    ZimFarmTooManyArticlesError,
+)
 from wp1.models.wp10.builder import Builder
 from wp1.models.wp10.selection import Selection
+from wp1.zimfarm import (
+    ZIM_DESCRIPTION_MAX_LENGTH,
+    ZIM_LONG_DESCRIPTION_MAX_LENGTH,
+    ZIM_TITLE_MAX_LENGTH,
+)
 
 
 class ZimFarmTest(BaseWpOneDbTest):
@@ -119,7 +130,7 @@ class ZimFarmTest(BaseWpOneDbTest):
                 },
                 'resources': {
                     'cpu': 3,
-                    'memory': 2147483648,
+                    'memory': 2242586827,
                     'disk': 21474836480,
                 },
                 'platform': 'wikimedia',
@@ -343,11 +354,12 @@ class ZimFarmTest(BaseWpOneDbTest):
     mock_response.json.return_value = {'requested': ['9876']}
     mock_requests.post.side_effect = (MagicMock(), mock_response)
 
-<<<<<<< HEAD
-    actual = zimfarm.schedule_zim_file(s3, redis, self.wp10db, self.builder, title='a', description='b')
-=======
-    zimfarm.schedule_zim_file(s3, redis, self.wp10db, self.builder)
->>>>>>> c419127 (Implement max article count of 50k for ZIM file creation)
+    zimfarm.schedule_zim_file(s3,
+                              redis,
+                              self.wp10db,
+                              self.builder,
+                              title='a',
+                              description='b')
 
     schedule_create_call = call(
         'https://fake.farm/v1/schedules/',
@@ -389,11 +401,12 @@ class ZimFarmTest(BaseWpOneDbTest):
     mock_requests.post.side_effect = (create_schedule_response, mock_response)
 
     with self.assertRaises(ZimFarmError):
-<<<<<<< HEAD
-      zimfarm.schedule_zim_file(s3, redis, self.wp10db, self.builder, title='a', description='b')
-=======
-      zimfarm.schedule_zim_file(s3, redis, self.wp10db, self.builder)
->>>>>>> c419127 (Implement max article count of 50k for ZIM file creation)
+      zimfarm.schedule_zim_file(s3,
+                                redis,
+                                self.wp10db,
+                                self.builder,
+                                title='a',
+                                description='b')
 
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
@@ -417,7 +430,7 @@ class ZimFarmTest(BaseWpOneDbTest):
   @patch('wp1.zimfarm.get_zimfarm_token')
   @patch('wp1.zimfarm._get_params')
   def test_schedule_zim_valid_graphemes(self, get_params_mock, get_token_mock,
-                             mock_requests):
+                                        mock_requests):
     redis = MagicMock()
     s3 = MagicMock()
     mock_response = MagicMock()
@@ -425,80 +438,117 @@ class ZimFarmTest(BaseWpOneDbTest):
     mock_requests.post.side_effect = (MagicMock(), mock_response, MagicMock())
 
     valid_title = "में" * (ZIM_TITLE_MAX_LENGTH)
-    actual = zimfarm.schedule_zim_file(s3, redis, self.wp10db, self.builder, title=valid_title, description='b')
+    actual = zimfarm.schedule_zim_file(s3,
+                                       redis,
+                                       self.wp10db,
+                                       self.builder,
+                                       title=valid_title,
+                                       description='b')
     self.assertEqual('9876', actual)
-  
+
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   @patch('wp1.zimfarm._get_params')
-  def test_schedule_zim_file_too_long_title(self, get_params_mock, get_token_mock,
-                             mock_requests):
+  def test_schedule_zim_file_too_long_title(self, get_params_mock,
+                                            get_token_mock, mock_requests):
     redis = MagicMock()
     s3 = MagicMock()
 
-    wrong_title = "a" * (ZIM_TITLE_MAX_LENGTH+1)
+    wrong_title = "a" * (ZIM_TITLE_MAX_LENGTH + 1)
     with self.assertRaises(InvalidZimTitleError):
-        zimfarm.schedule_zim_file(s3, redis, self.wp10db, self.builder, title=wrong_title)
+      zimfarm.schedule_zim_file(s3,
+                                redis,
+                                self.wp10db,
+                                self.builder,
+                                title=wrong_title)
 
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   @patch('wp1.zimfarm._get_params')
-  def test_schedule_zim_file_too_long_title(self, get_params_mock, get_token_mock,
-                             mock_requests):
+  def test_schedule_zim_file_too_long_title(self, get_params_mock,
+                                            get_token_mock, mock_requests):
     redis = MagicMock()
     s3 = MagicMock()
 
-    wrong_title = "a" * (ZIM_TITLE_MAX_LENGTH+1)
+    wrong_title = "a" * (ZIM_TITLE_MAX_LENGTH + 1)
     with self.assertRaises(InvalidZimTitleError):
-        zimfarm.schedule_zim_file(s3, redis, self.wp10db, self.builder, title=wrong_title)
+      zimfarm.schedule_zim_file(s3,
+                                redis,
+                                self.wp10db,
+                                self.builder,
+                                title=wrong_title)
 
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   @patch('wp1.zimfarm._get_params')
-  def test_schedule_zim_file_too_long_description(self, get_params_mock, get_token_mock,
-                             mock_requests):
+  def test_schedule_zim_file_too_long_description(self, get_params_mock,
+                                                  get_token_mock,
+                                                  mock_requests):
     redis = MagicMock()
     s3 = MagicMock()
 
-    too_long_description = "z" * (ZIM_DESCRIPTION_MAX_LENGTH+1)
+    too_long_description = "z" * (ZIM_DESCRIPTION_MAX_LENGTH + 1)
     with self.assertRaises(InvalidZimDescriptionError):
-        zimfarm.schedule_zim_file(s3, redis, self.wp10db, self.builder, title='a', description=too_long_description)
-
-
-  @patch('wp1.zimfarm.requests')
-  @patch('wp1.zimfarm.get_zimfarm_token')
-  @patch('wp1.zimfarm._get_params')
-  def test_schedule_zim_file_too_long_long_description(self, get_params_mock, get_token_mock,
-                             mock_requests):
-    redis = MagicMock()
-    s3 = MagicMock()
-
-    too_long_long_description = "z" * (ZIM_LONG_DESCRIPTION_MAX_LENGTH+1)
-    with self.assertRaises(InvalidZimLongDescriptionError):
-        zimfarm.schedule_zim_file(s3, redis, self.wp10db, self.builder, title='a', description='zz', long_description=too_long_long_description)
+      zimfarm.schedule_zim_file(s3,
+                                redis,
+                                self.wp10db,
+                                self.builder,
+                                title='a',
+                                description=too_long_description)
 
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   @patch('wp1.zimfarm._get_params')
-  def test_schedule_zim_file_too_short_long_description(self, get_params_mock, get_token_mock,
-                             mock_requests):
+  def test_schedule_zim_file_too_long_long_description(self, get_params_mock,
+                                                       get_token_mock,
+                                                       mock_requests):
     redis = MagicMock()
     s3 = MagicMock()
 
+    too_long_long_description = "z" * (ZIM_LONG_DESCRIPTION_MAX_LENGTH + 1)
     with self.assertRaises(InvalidZimLongDescriptionError):
-        zimfarm.schedule_zim_file(s3, redis, self.wp10db, self.builder, title='a', description='bb', long_description='z')
+      zimfarm.schedule_zim_file(s3,
+                                redis,
+                                self.wp10db,
+                                self.builder,
+                                title='a',
+                                description='zz',
+                                long_description=too_long_long_description)
 
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   @patch('wp1.zimfarm._get_params')
-  def test_schedule_zim_file_equal_descriptions(self, get_params_mock, get_token_mock,
-                             mock_requests):
+  def test_schedule_zim_file_too_short_long_description(self, get_params_mock,
+                                                        get_token_mock,
+                                                        mock_requests):
     redis = MagicMock()
     s3 = MagicMock()
 
     with self.assertRaises(InvalidZimLongDescriptionError):
-        zimfarm.schedule_zim_file(s3, redis, self.wp10db, self.builder, title='a', description='bb', long_description='bb')
+      zimfarm.schedule_zim_file(s3,
+                                redis,
+                                self.wp10db,
+                                self.builder,
+                                title='a',
+                                description='bb',
+                                long_description='z')
 
+  @patch('wp1.zimfarm.requests')
+  @patch('wp1.zimfarm.get_zimfarm_token')
+  @patch('wp1.zimfarm._get_params')
+  def test_schedule_zim_file_equal_descriptions(self, get_params_mock,
+                                                get_token_mock, mock_requests):
+    redis = MagicMock()
+    s3 = MagicMock()
+
+    with self.assertRaises(InvalidZimLongDescriptionError):
+      zimfarm.schedule_zim_file(s3,
+                                redis,
+                                self.wp10db,
+                                self.builder,
+                                title='a',
+                                description='bb',
+                                long_description='bb')
 
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')


### PR DESCRIPTION
Fixes #816 

This PR includes both backend limits as well as frontend validation and messaging. The article limit is configured in a single place and passed to the frontend in the same request that provides the number of articles to the ZIM request page. Even if this request is tampered with, or if a request is made through the WP1 API, the backend zimfarm module checks the limits before requesting a ZIM.