### PR TITLE
Delete logging table

### DIFF
--- a/db/migrations/20250426_01_i656U-drop-logging-table.py
+++ b/db/migrations/20250426_01_i656U-drop-logging-table.py
@@ -1,0 +1,12 @@
+"""
+Drop logging table
+"""
+
+from yoyo import step
+
+__depends__ = {
+    '20250325_01_sFddz-add-article-count-to-selection-table',
+    '20250330_01_zaRQa-migrate-last-7-days-of-logs'
+}
+
+steps = [step('DROP TABLE IF EXISTS logging')]

--- a/wp1/logic/rating_test.py
+++ b/wp1/logic/rating_test.py
@@ -1,8 +1,7 @@
 from wp1.base_db_test import BaseWpOneDbTest
 from wp1.constants import AssessmentKind
-from wp1.logic import rating as logic_rating
 from wp1.logic import log as logic_log
-from wp1.models.wp10.log import Log
+from wp1.logic import rating as logic_rating
 from wp1.models.wp10.rating import Rating
 
 

--- a/wp10_test.down.sql
+++ b/wp10_test.down.sql
@@ -1,5 +1,4 @@
 DROP TABLE IF EXISTS `ratings`;
-DROP TABLE IF EXISTS `logging`;
 DROP TABLE IF EXISTS `categories`;
 DROP TABLE IF EXISTS `moves`;
 DROP TABLE IF EXISTS `projects`;

--- a/wp10_test.up.sql
+++ b/wp10_test.up.sql
@@ -10,18 +10,6 @@ CREATE TABLE `ratings` (
   PRIMARY KEY (`r_project`,`r_namespace`,`r_article`)
 );
 
-CREATE TABLE `logging` (
-  `l_project` varbinary(63) NOT NULL,
-  `l_namespace` int(10) unsigned NOT NULL,
-  `l_article` varbinary(255) NOT NULL,
-  `l_action` varbinary(20) NOT NULL,
-  `l_timestamp` binary(14) NOT NULL,
-  `l_old` varbinary(63) DEFAULT NULL,
-  `l_new` varbinary(63) DEFAULT NULL,
-  `l_revision_timestamp` binary(20) NOT NULL,
-  PRIMARY KEY (`l_project`,`l_namespace`,`l_article`,`l_action`,`l_timestamp`)
-);
-
 CREATE TABLE `categories` (
   `c_project` varbinary(63) NOT NULL,
   `c_type` varbinary(16) NOT NULL,


### PR DESCRIPTION
Fixes #828 

We have simply added a migration to drop the logging table, and updated the test schemas.

This will save 6 GB in the database and the corresponding amount for every database backup:

```
MariaDB [enwp10_prod]> SELECT      table_name AS `Table`,      round(((data_length + index_length) / 1024 / 1024), 2) `Size in MB`  FROM information_schema.TABLES  WHERE table_schema = "enwp10_prod"
   AND table_name = "logging";
+---------+------------+
| Table   | Size in MB |
+---------+------------+
| logging |    5929.91 |
+---------+------------+
1 row in set (0.020 sec)
```

The `Log` model is retained, because it is still used in the Redis version of the code.

I have confirmed that logs have been successfully running off Redis for several weeks now.

Thank you again @elfkuzco!