### PR TITLE
Disable cron jobs for automatic update

### DIFF
--- a/docker/workers/Dockerfile
+++ b/docker/workers/Dockerfile
@@ -18,9 +18,10 @@ RUN pipenv install --system --deploy --ignore-pipfile
 RUN chmod -R a+x /usr/src/app/cron/
 
 # Schedule tasks through cron
-RUN echo "0 0 * * * root /usr/src/app/cron/enqueue-all.sh > /var/log/wp1bot/enqueue-all.cron.log 2>&1" > /etc/cron.d/enqueue-all
-RUN echo "0 4 * * * root /usr/src/app/cron/update-global-articles.sh > /var/log/wp1bot/update-global-articles.cron.log 2>&1" > /etc/cron.d/update-global-articles
-RUN echo "0 5 * * * root /usr/src/app/cron/enqueue-global.sh > /var/log/wp1bot/enqueue-global.cron.log 2>&1" > /etc/cron.d/enqueue-global
+# Currently disabled: https://github.com/openzim/wp1/issues/875
+# RUN echo "0 0 * * * root /usr/src/app/cron/enqueue-all.sh > /var/log/wp1bot/enqueue-all.cron.log 2>&1" > /etc/cron.d/enqueue-all
+# RUN echo "0 4 * * * root /usr/src/app/cron/update-global-articles.sh > /var/log/wp1bot/update-global-articles.cron.log 2>&1" > /etc/cron.d/update-global-articles
+# RUN echo "0 5 * * * root /usr/src/app/cron/enqueue-global.sh > /var/log/wp1bot/enqueue-global.cron.log 2>&1" > /etc/cron.d/enqueue-global
 
 # Start
 CMD cron && supervisord -c /usr/src/app/supervisord.conf -n


### PR DESCRIPTION
Based on the bug in #875 and the discussion [on English Wikipedia](https://en.wikipedia.org/wiki/Wikipedia_talk:Version_1.0_Editorial_Team/Index#Bot_is_gutting_many_of_the_tables), we are disabling the cron jobs that automatically run WP 1.0, so that we can manually run it at a convenient time and monitor the output.