### PR TITLE
chore: Add ZIM Farm setup instructions and improve MinIO setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,22 @@ If you wish to connect to a wiki replica database on toolforge, you will need
 to fill out your credentials in WIKIDB section. This is not required for
 developing the frontend.
 
+## Running a ZIM Farm
+
+If you wish to run a ZIM Farm instance for testing purposes, the easiest way is to 
+clone the zimfarm repository and then setup a development instance of it:
+
+```bash
+git clone https://github.com/openzim/zimfarm.git
+cd zimfarm/dev
+docker compose -p zimfarm up -d
+```
+
+For detailed setup instructions, refer to `dev/README.md` in the zimfarm repository.
+The `ZIMFARM` section in your `credentials.py` file contains pre-configured default
+values for the development instance. If you encounter connection issues, verify
+these credentials match your local setup.
+
 ## Development overlay
 
 The API server has a built-in development overlay, currently used for manual

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -39,12 +39,19 @@ services:
     networks:
       - wp1bot-dev
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      start_period: 30s
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
   createbuckets:
     image: minio/mc
     container_name: wp1bot-minio-setup
     depends_on:
-      - minio
+      minio:
+        condition: service_healthy
     networks:
       - wp1bot-dev
     volumes:

--- a/docker/minio/setup-buckets.sh
+++ b/docker/minio/setup-buckets.sh
@@ -1,8 +1,21 @@
 #!/bin/sh
 
-# Configure MinIO client and create bucket
-/usr/bin/mc config host add dev_minio http://minio:9000 minio_key minio_secret #configure client
-/usr/bin/mc mb dev_minio/org-kiwix-dev-wp1 --ignore-existing #create bucket
-/usr/bin/mc policy set public dev_minio/org-kiwix-dev-wp1 #set policy
+MINIO_ALIAS="dev_minio"
+MINIO_URL="http://minio:9000"
+MINIO_USER="minio_key"
+MINIO_PASSWORD="minio_secret"
+BUCKET_NAME="org-kiwix-dev-wp1"
 
-exit 0
+# Wait for MinIO
+echo "Waiting for MinIO to be ready..."
+for i in $(seq 1 30); do
+    # Set up MinIO alias if it's ready
+    /usr/bin/mc alias set $MINIO_ALIAS $MINIO_URL $MINIO_USER $MINIO_PASSWORD && echo "MinIO is ready!" && break
+    sleep 2
+    [ $i -eq 30 ] && { echo "ERROR: MinIO timeout"; exit 1; }
+done
+
+# Setup bucket
+/usr/bin/mc mb $MINIO_ALIAS/$BUCKET_NAME --ignore-existing # Create bucket if it doesn't exist
+/usr/bin/mc anonymous set public $MINIO_ALIAS/$BUCKET_NAME # Set bucket to public
+echo "MinIO setup complete"

--- a/wp1/credentials.py.dev.example
+++ b/wp1/credentials.py.dev.example
@@ -89,12 +89,16 @@ CREDENTIALS = {
         # Server URL and credentials for the Zim Farm that will be used to create
         # ZIM files from materialized selections.
         'ZIMFARM': {
-            'url': 'https://api.farm.youzim.it/v1',
-            's3_url': 'https://fake.wasabisys.com/org-kiwix-zimit',
-            'user': 'wp1',
-            'password': '', # EDIT this line
-            'hook_token': '', # EDIT this line
-            'cache_url': '', # EDIT this line
+            # Use 'host.docker.internal' to connect to zimfarm from within the docker container.
+            # This works on Mac/Windows. On Linux, try '172.17.0.1' instead.
+            'url': 'http://host.docker.internal:8000/v1',
+            's3_url': 'http://host.docker.internal:9000/', # if using minio
+            'user': 'admin',
+            'password': 'admin',
+            # A simple token secret exchanged between the WP1 server and the zimfarm
+            # server, to ensure requests to the webhook endpoint are valid.
+            'hook_token': '',
+            'cache_url': 'http://host.docker.internal:9000/',  # if using minio
         },
 
         # Logging directives. Keys are the names of the loggers, values are dictionaries

--- a/wp1/credentials.py.example
+++ b/wp1/credentials.py.example
@@ -121,14 +121,16 @@ CREDENTIALS = {
         # Server URL and credentials for the Zim Farm that will be used to create
         # ZIM files from materialized selections.
         'ZIMFARM': {
-            'url': 'https://api.farm.youzim.it/v1',
-            's3_url': 'https://s3.us-west-1.wasabisys.com/org-kiwix-zimit',
-            'user': '', # EDIT this line
-            'password': '', # EDIT this line
+            # Use 'host.docker.internal' to connect to zimfarm from within the docker container.
+            # This works on Mac/Windows. On Linux, try '172.17.0.1' instead.
+            'url': 'http://host.docker.internal:8000/v1',
+            's3_url': 'http://host.docker.internal:9000/', # if using minio
+            'user': 'admin',
+            'password': 'admin',
             # A simple token secret exchanged between the WP1 server and the zimfarm
             # server, to ensure requests to the webhook endpoint are valid.
-            'hook_token': '', # EDIT this line
-            'cache_url': '', # EDIT this line
+            'hook_token': '',
+            'cache_url': 'http://host.docker.internal:9000/', # if using minio
         },
 
         'FILE_PATH': {


### PR DESCRIPTION
This pull request improves the local development setup by adding ZIM Farm integration documentation and defaults and enhancing MinIO configuration.

Key Changes:
- *ZIM Farm Setup*: Added README instructions for running a local ZIM Farm development instance with pre-configured credentials
  -  *Docker Integration*: Updated credential templates to use `host.docker.internal` (optional) for container-to-container communication between zimfarm-wp1
- *MinIO Improvements*: Added health checks and logs in bucket setup script and docker-compose, and fixed commands

tldr: Enable developers to easily test ZIM file generation locally with a complete development environment.