### PR TITLE
feat: add zim_schedules table, migration script and update dump

### DIFF
--- a/db/migrations/20250610_01_kNsXy-add-email-to-users-table.py
+++ b/db/migrations/20250610_01_kNsXy-add-email-to-users-table.py
@@ -1,0 +1,14 @@
+"""
+Add email column to users table
+"""
+
+from yoyo import step
+
+__depends__ = {'20250426_01_i656U-drop-logging-table'}
+
+steps = [
+    step(
+        "ALTER TABLE users ADD COLUMN u_email VARCHAR(255) NULL",
+        "ALTER TABLE users DROP COLUMN u_email"
+    )
+]

--- a/db/migrations/20250610_02_FHB8A-create-zim-schedules-table.py
+++ b/db/migrations/20250610_02_FHB8A-create-zim-schedules-table.py
@@ -1,0 +1,20 @@
+"""
+This migration creates the zim_schedules table.
+"""
+
+from yoyo import step
+
+__depends__ = {'20250610_01_kNsXy-add-email-to-users-table'}
+
+steps = [
+    step(
+        'CREATE TABLE zim_schedules ('
+        '  s_id VARCHAR(36) NOT NULL PRIMARY KEY,' 
+        '  s_builder_id VARCHAR(255) NOT NULL,' # ID in the builders table
+        '  s_zim_file_id INTEGER NULL,' # Last ZIM file related to the schedule, can be NULL
+        '  s_rq_job_id INTEGER NOT NULL,' # ID of the job in the rq-scheduler
+        '  s_last_updated_at BINARY(14) NOT NULL' # Last update to the schedule
+        ')', 
+        'DROP TABLE zim_schedules'
+    )
+]

--- a/docker/dev-db/enwp10_dev.dump.sql
+++ b/docker/dev-db/enwp10_dev.dump.sql
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:af02d51a6a38b202280f0890fced63545df48373fb4916a1edbf855fd1b8ee80
-size 7528485
+oid sha256:3daecbde0277b947607426ce194edeb178fc0ba062b0446e761a770b794677c5
+size 10411422

--- a/wp10_test.down.sql
+++ b/wp10_test.down.sql
@@ -11,5 +11,6 @@ DROP TABLE IF EXISTS `builders`;
 DROP TABLE IF EXISTS `selections`;
 DROP TABLE IF EXISTS `custom`;
 DROP TABLE IF EXISTS `zim_files`;
+DROP TABLE IF EXISTS `zim_schedules`;
 DROP TABLE IF EXISTS `page_scores`;
 DROP TABLE IF EXISTS `temp_pageviews`;

--- a/wp10_test.up.sql
+++ b/wp10_test.up.sql
@@ -127,6 +127,14 @@ CREATE TABLE zim_files (
   z_description tinyblob
 );
 
+CREATE TABLE zim_schedules (
+  s_id VARCHAR(36) NOT NULL PRIMARY KEY,
+  s_builder_id VARCHAR(255) NOT NULL,
+  s_zim_file_id INTEGER NULL,
+  s_rq_job_id INTEGER NOT NULL,
+  s_last_updated_at BINARY(14) NOT NULL
+);
+
 CREATE TABLE `temp_pageviews` (
   `tp_lang` varbinary(255) NOT NULL,
   `tp_page_id` int(11) NOT NULL,


### PR DESCRIPTION
This PR introduces the new `zim_schedules` table to support scheduled ZIM generation. Changes include:

- A new migration (`20250610_02_FHB8A-create-zim-schedules-table.py`) that creates the `zim_schedules` table with the following fields:
  - `s_id`: Primary key (UUID)
  - `s_builder_id`: References a builder
  - `s_zim_file_id`: Optionally links to the latest ZIM file
  - `s_rq_job_id`: Scheduler job ID (from rq-scheduler)
  - `s_last_updated_at`: Binary timestamp of last update
- A preceding migration (`20250610_01_kNsXy-add-email-to-users-table.py`) that adds a nullable `u_email` column to the users table.
- Updates to the dev/test SQL dump files (`enwp10_dev.dump.sql`, `wp10_test.up.sql`, `wp10_test.down.sql`) to reflect the schema changes.

These changes prepare the database for handling scheduled recurring ZIM generation tasks and associating them with existing builders and job scheduling infrastructure.

todo: apply schema changes in production