### PR TITLE
WIP: Add ZIM file scheduling functionality and update builder logic

### DIFF
--- a/supervisord-dev.conf
+++ b/supervisord-dev.conf
@@ -68,6 +68,30 @@ stopsignal=TERM
 autostart=true
 autorestart=true
 
+[program:wp1-zimfile-scheduling]
+; In the docker-compose world, the redis host is just 'redis'
+command=/usr/local/bin/rq worker -u redis://redis zimfile-scheduling
+; process_num is required if you specify >1 numprocs
+process_name=zimfile-scheduling-%(process_num)s
+
+; If you want to run more than one zimfile-scheduling worker, increase this
+numprocs=1
+
+; This is the directory from which RQ is run. Be sure to point this to the
+; directory where your source code is importable from
+directory=/usr/src/app
+
+redirect_stderr=true
+stdout_logfile=/var/log/wp1bot/%(program_name)s-%(process_num)s.log
+stdout_logfile_maxbytes=100MB
+stdout_logfile_backups=5
+
+; RQ requires the TERM signal to perform a warm shutdown. If RQ does not die
+; within 10 seconds, supervisor will forcefully kill it
+stopsignal=TERM
+autostart=true
+autorestart=true
+
 [program:scheduler]
 ; In the docker-compose world, the redis host is just 'redis'
 command=/usr/local/bin/rqscheduler --host redis -i 20

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -222,6 +222,30 @@ stopsignal=TERM
 autostart=true
 autorestart=true
 
+[program:wp1-zimfile-scheduling]
+; In the docker-compose world, the redis host is just 'redis'
+command=/usr/local/bin/rq worker -u redis://redis zimfile-scheduling
+; process_num is required if you specify >1 numprocs
+process_name=zimfile-scheduling-%(process_num)s
+
+; If you want to run more than one zimfile-scheduling worker, increase this
+numprocs=1
+
+; This is the directory from which RQ is run. Be sure to point this to the
+; directory where your source code is importable from
+directory=/usr/src/app
+
+redirect_stderr=true
+stdout_logfile=/var/log/wp1bot/%(program_name)s-%(process_num)s.log
+stdout_logfile_maxbytes=100MB
+stdout_logfile_backups=5
+
+; RQ requires the TERM signal to perform a warm shutdown. If RQ does not die
+; within 10 seconds, supervisor will forcefully kill it
+stopsignal=TERM
+autostart=true
+autorestart=true
+
 [program:scheduler]
 ; In the docker-compose world, the redis host is just 'redis'
 command=/usr/local/bin/rqscheduler --host redis -i 20

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -197,6 +197,7 @@ def create_zim_file_for_builder(builder_id):
     return flask.jsonify({'error_messages': error_messages}), 400
 
   long_desc = data.get('long_description')
+  scheduled_repetitions = data.get('scheduled_repetitions')
 
   try:
     logic_builder.schedule_zim_file(s3,
@@ -206,7 +207,9 @@ def create_zim_file_for_builder(builder_id):
                                     user_id=user_id,
                                     title=title,
                                     description=desc,
-                                    long_description=long_desc)
+                                    long_description=long_desc,
+                                    scheduled_repetitions=scheduled_repetitions
+                                    )
   except ObjectNotFoundError:
     return flask.jsonify(
         {'error_messages': ['No builder found with id = %s' % builder_id]}), 404


### PR DESCRIPTION
- Introduced a new worker for ZIM file scheduling in supervisord configuration.
- Refactored the request_zim_file function to handle ZIM file creation requests.
- Enhanced schedule_zim_file function to support scheduled repetitions.
- Updated the create_zim_file_for_builder endpoint to accept scheduled repetitions.
- Added necessary queue management for ZIM file scheduling in queues.py.


TODO:
- run create_or_update_builder for scheduled job
- add db queries
- handle zim creations using hook (+ notify)
- other CRUD api endpoints
- frontend