### PR TITLE
add `wp1-zimfile-scheduling` program configuration to supervisord

### DIFF
--- a/supervisord-dev.conf
+++ b/supervisord-dev.conf
@@ -68,6 +68,30 @@ stopsignal=TERM
 autostart=true
 autorestart=true
 
+[program:wp1-zimfile-scheduling]
+; In the docker-compose world, the redis host is just 'redis'
+command=/usr/local/bin/rq worker -u redis://redis zimfile-scheduling
+; process_num is required if you specify >1 numprocs
+process_name=zimfile-scheduling-%(process_num)s
+
+; If you want to run more than one zimfile-scheduling worker, increase this
+numprocs=1
+
+; This is the directory from which RQ is run. Be sure to point this to the
+; directory where your source code is importable from
+directory=/usr/src/app
+
+redirect_stderr=true
+stdout_logfile=/var/log/wp1bot/%(program_name)s-%(process_num)s.log
+stdout_logfile_maxbytes=100MB
+stdout_logfile_backups=5
+
+; RQ requires the TERM signal to perform a warm shutdown. If RQ does not die
+; within 10 seconds, supervisor will forcefully kill it
+stopsignal=TERM
+autostart=true
+autorestart=true
+
 [program:scheduler]
 ; In the docker-compose world, the redis host is just 'redis'
 command=/usr/local/bin/rqscheduler --host redis -i 20

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -222,6 +222,30 @@ stopsignal=TERM
 autostart=true
 autorestart=true
 
+[program:wp1-zimfile-scheduling]
+; In the docker-compose world, the redis host is just 'redis'
+command=/usr/local/bin/rq worker -u redis://redis zimfile-scheduling
+; process_num is required if you specify >1 numprocs
+process_name=zimfile-scheduling-%(process_num)s
+
+; If you want to run more than one zimfile-scheduling worker, increase this
+numprocs=1
+
+; This is the directory from which RQ is run. Be sure to point this to the
+; directory where your source code is importable from
+directory=/usr/src/app
+
+redirect_stderr=true
+stdout_logfile=/var/log/wp1bot/%(program_name)s-%(process_num)s.log
+stdout_logfile_maxbytes=100MB
+stdout_logfile_backups=5
+
+; RQ requires the TERM signal to perform a warm shutdown. If RQ does not die
+; within 10 seconds, supervisor will forcefully kill it
+stopsignal=TERM
+autostart=true
+autorestart=true
+
 [program:scheduler]
 ; In the docker-compose world, the redis host is just 'redis'
 command=/usr/local/bin/rqscheduler --host redis -i 20


### PR DESCRIPTION
**add `wp1-zimfile-scheduling` program configuration to supervisord**

This commit introduces a new supervisord program entry for the `wp1-zimfile-scheduling` RQ worker. The configuration is added to both `supervisord-dev.conf` and `supervisord.conf`.
This change is needed to execute scheduled tasks for zim-file generations.

Fixes #901