### PR TITLE
Add `zim_schedule` model class

### DIFF
--- a/wp1/models/wp10/zim_schedule.py
+++ b/wp1/models/wp10/zim_schedule.py
@@ -1,0 +1,43 @@
+import datetime
+import logging
+import uuid
+
+import attr
+
+from wp1.constants import TS_FORMAT_WP10
+from wp1.timestamp import utcnow
+
+logger = logging.getLogger(__name__)
+
+
+@attr.s
+class ZimSchedule:
+  table_name = 'zim_schedules'
+
+  s_id: str = attr.ib(default=None)
+  s_builder_id: str = attr.ib()
+  s_zim_file_id: int = attr.ib(default=None)
+  s_rq_job_id: str = attr.ib()
+  s_interval: int = attr.ib(default=None)  # in months
+  s_remaining_generations: int = attr.ib(default=None)  # how many more ZIMs to generate
+  s_last_updated_at: bytes = attr.ib()
+
+  def set_id(self):
+    self.s_id = str(uuid.uuid4())
+
+  @property
+  def last_updated_at_dt(self):
+    """The timestamp parsed into a datetime.datetime object."""
+    return datetime.datetime.strptime(self.s_last_updated_at.decode('utf-8'),
+                                      TS_FORMAT_WP10)
+
+  def set_last_updated_at_dt(self, dt):
+    """Sets the last_updated_at field using a datetime.datetime object"""
+    if dt is None:
+      logger.warning('Attempt to set zim schedule last_updated_at to None ignored')
+      return
+    self.s_last_updated_at = dt.strftime(TS_FORMAT_WP10).encode('utf-8')
+
+  def set_last_updated_at_now(self):
+    """Sets the last_updated_at field to a timestamp that is equal to now"""
+    self.set_last_updated_at_dt(utcnow())

--- a/wp1/models/wp10/zim_schedule.py
+++ b/wp1/models/wp10/zim_schedule.py
@@ -14,16 +14,16 @@ logger = logging.getLogger(__name__)
 class ZimSchedule:
   table_name = 'zim_schedules'
 
-  s_id: str = attr.ib()
-  s_builder_id: str = attr.ib()
-  s_rq_job_id: str = attr.ib()
+  s_id: bytes = attr.ib()
+  s_builder_id: bytes = attr.ib()
+  s_rq_job_id: bytes = attr.ib()
   s_last_updated_at: bytes = attr.ib()
   s_zim_file_id: int = attr.ib(default=None)
   s_interval: int = attr.ib(default=None)  # in months
   s_remaining_generations: int = attr.ib(default=None)  # how many more ZIMs to generate
 
   def set_id(self):
-    self.s_id = str(uuid.uuid4())
+    self.s_id = str(uuid.uuid4()).encode('utf-8')
 
   @property
   def last_updated_at_dt(self):

--- a/wp1/models/wp10/zim_schedule.py
+++ b/wp1/models/wp10/zim_schedule.py
@@ -14,13 +14,13 @@ logger = logging.getLogger(__name__)
 class ZimSchedule:
   table_name = 'zim_schedules'
 
-  s_id: str = attr.ib(default=None)
+  s_id: str = attr.ib()
   s_builder_id: str = attr.ib()
-  s_zim_file_id: int = attr.ib(default=None)
   s_rq_job_id: str = attr.ib()
+  s_last_updated_at: bytes = attr.ib()
+  s_zim_file_id: int = attr.ib(default=None)
   s_interval: int = attr.ib(default=None)  # in months
   s_remaining_generations: int = attr.ib(default=None)  # how many more ZIMs to generate
-  s_last_updated_at: bytes = attr.ib()
 
   def set_id(self):
     self.s_id = str(uuid.uuid4())

--- a/wp1/models/wp10/zim_schedule_test.py
+++ b/wp1/models/wp10/zim_schedule_test.py
@@ -1,0 +1,38 @@
+import datetime
+from unittest.mock import patch
+import uuid
+
+from wp1.base_db_test import BaseWpOneDbTest
+from wp1.models.wp10.zim_schedule import ZimSchedule
+
+
+class ModelsZimScheduleTest(BaseWpOneDbTest):
+
+  def setUp(self):
+    super().setUp()
+    self.zim_schedule = ZimSchedule(s_id=str(uuid.uuid4()),
+                   s_builder_id=str(uuid.uuid4()),
+                   s_rq_job_id=str(uuid.uuid4()),
+                   s_last_updated_at=b'20190830112844')
+
+  def test_last_updated_at_dt(self):
+    dt = self.zim_schedule.last_updated_at_dt
+    self.assertEqual(2019, dt.year)
+    self.assertEqual(8, dt.month)
+    self.assertEqual(30, dt.day)
+    self.assertEqual(11, dt.hour)
+    self.assertEqual(28, dt.minute)
+    self.assertEqual(44, dt.second)
+
+  def test_set_last_updated_at_dt(self):
+    dt = datetime.datetime(2020, 12, 15, 9, 30, 55)
+    self.zim_schedule.set_last_updated_at_dt(dt)
+
+    self.assertEqual(b'20201215093055', self.zim_schedule.s_last_updated_at)
+
+  @patch('wp1.models.wp10.zim_schedule.utcnow',
+         return_value=datetime.datetime(2019, 12, 25, 4, 44, 44))
+  def test_set_last_updated_at_now(self, patched_now):
+    self.zim_schedule.set_last_updated_at_now()
+
+    self.assertEqual(b'20191225044444', self.zim_schedule.s_last_updated_at)


### PR DESCRIPTION
This PR introduces the `ZimSchedule` model, representing entries in the `zim_schedules` database table. 
It includes unit tests (`wp1/models/wp10/zim_schedule_test.py`).
Typing added for clarity and improved development experience (e.g., IDE support, static analysis)

Fixes #906 