### PR TITLE
Rename zimfile generation related functions

### DIFF
--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -158,7 +158,7 @@ def materialize_builder(builder_cls, builder_id, content_type):
       # be automatically created. We don't need to do this if the ZIM
       # version was updated, because that indicates that the ZIM file
       # was never requested or errored and should remain in that state.
-      auto_schedule_zim_file(s3, redis, wp10db, builder_id)
+      auto_handle_zim_generation(s3, redis, wp10db, builder_id)
   finally:
     wp10db.close()
 
@@ -179,7 +179,7 @@ def maybe_update_selection_zim_version(wp10db, builder, selection_version):
   return True
 
 
-def auto_schedule_zim_file(s3, redis, wp10db, builder_id):
+def auto_handle_zim_generation(s3, redis, wp10db, builder_id):
   # First, cancel any pending auto-scheduled tasks.
   for task_id in pending_zim_tasks_for(wp10db, builder_id):
     try:
@@ -193,7 +193,7 @@ def auto_schedule_zim_file(s3, redis, wp10db, builder_id):
       'utf-8') if zim_file.z_description is not None else None
   long_description = zim_file.z_long_description.decode(
       'utf-8') if zim_file.z_long_description is not None else None
-  schedule_zim_file(s3,
+  handle_zim_generation(s3,
                     redis,
                     wp10db,
                     builder_id,
@@ -385,7 +385,7 @@ def latest_selections_with_errors(wp10db, builder_id):
   return res
 
 
-def schedule_zim_file(s3,
+def handle_zim_generation(s3,
                       redis,
                       wp10db,
                       builder_id,
@@ -408,7 +408,7 @@ def schedule_zim_file(s3,
           'Could not use builder id = %s for user id = %s' %
           (builder_id, user_id))
 
-  task_id = zimfarm.schedule_zim_file(s3,
+  task_id = zimfarm.handle_zim_generation(s3,
                                       redis,
                                       wp10db,
                                       builder,

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -825,13 +825,13 @@ class BuilderTest(BaseWpOneDbTest):
 
     self.assertEqual(0, len(actual))
 
-  @patch('wp1.logic.builder.zimfarm.schedule_zim_file')
+  @patch('wp1.logic.builder.zimfarm.request_zimfarm_task')
   @patch('wp1.logic.builder.utcnow',
          return_value=datetime.datetime(2022, 12, 25, 0, 1, 2))
-  def test_handle_zim_generation(self, patched_utcnow, patched_schedule_zim_file):
+  def test_handle_zim_generation(self, patched_utcnow, patched_request_zimfarm_task):
     redis = MagicMock()
     s3 = MagicMock()
-    patched_schedule_zim_file.return_value = '1234-a'
+    patched_request_zimfarm_task.return_value = '1234-a'
 
     builder_id = self._insert_builder()
     self._insert_selection(1,
@@ -848,7 +848,7 @@ class BuilderTest(BaseWpOneDbTest):
                                     description='a',
                                     long_description='z')
 
-    patched_schedule_zim_file.assert_called_once_with(s3,
+    patched_request_zimfarm_task.assert_called_once_with(s3,
                                                       redis,
                                                       self.wp10db,
                                                       self.builder,
@@ -887,11 +887,11 @@ class BuilderTest(BaseWpOneDbTest):
                                       description='a',
                                       long_description='z')
 
-  @patch('wp1.logic.builder.zimfarm.schedule_zim_file')
-  def test_handle_zim_generation_404(self, patched_schedule_zim_file):
+  @patch('wp1.logic.builder.zimfarm.request_zimfarm_task')
+  def test_handle_zim_generation_404(self, patched_request_zimfarm_task):
     redis = MagicMock()
     s3 = MagicMock()
-    patched_schedule_zim_file.return_value = '1234-a'
+    patched_request_zimfarm_task.return_value = '1234-a'
 
     with self.assertRaises(ObjectNotFoundError):
       logic_builder.handle_zim_generation(s3,
@@ -900,11 +900,11 @@ class BuilderTest(BaseWpOneDbTest):
                                       '404builder',
                                       user_id=1234)
 
-  @patch('wp1.logic.builder.zimfarm.schedule_zim_file')
-  def test_handle_zim_generation_not_authorized(self, patched_schedule_zim_file):
+  @patch('wp1.logic.builder.zimfarm.request_zimfarm_task')
+  def test_handle_zim_generation_not_authorized(self, patched_request_zimfarm_task):
     redis = MagicMock()
     s3 = MagicMock()
-    patched_schedule_zim_file.return_value = '1234-a'
+    patched_request_zimfarm_task.return_value = '1234-a'
 
     builder_id = self._insert_builder()
     self._insert_selection(1,

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -199,7 +199,7 @@ def create_zim_file_for_builder(builder_id):
   long_desc = data.get('long_description')
 
   try:
-    logic_builder.schedule_zim_file(s3,
+    logic_builder.handle_zim_generation(s3,
                                     redis,
                                     wp10db,
                                     builder_id,

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -433,12 +433,12 @@ class BuildersTest(BaseWebTestcase):
       rv = client.post('/v1/builders/-1/delete')
       self.assertEqual('404 NOT FOUND', rv.status)
 
-  @patch('wp1.zimfarm.schedule_zim_file')
-  def test_create_zim_file_for_builder(self, patched_schedule_zim_file):
+  @patch('wp1.zimfarm.request_zimfarm_task')
+  def test_create_zim_file_for_builder(self, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
-    patched_schedule_zim_file.return_value = '1234-a'
+    patched_request_zimfarm_task.return_value = '1234-a'
 
     self.app = create_app()
     with self.override_db(self.app), self.app.test_client() as client:
@@ -451,7 +451,7 @@ class BuildersTest(BaseWebTestcase):
                        })
       self.assertEqual('204 NO CONTENT', rv.status)
 
-    patched_schedule_zim_file.assert_called_once()
+    patched_request_zimfarm_task.assert_called_once()
     with self.wp10db.cursor() as cursor:
       cursor.execute('SELECT z_task_id, z_status FROM zim_files '
                      'WHERE z_selection_id = 3')
@@ -460,9 +460,9 @@ class BuildersTest(BaseWebTestcase):
     self.assertEqual(b'1234-a', data['z_task_id'])
     self.assertEqual(b'REQUESTED', data['z_status'])
 
-  @patch('wp1.zimfarm.schedule_zim_file')
+  @patch('wp1.zimfarm.request_zimfarm_task')
   def test_create_zim_file_for_builder_not_found(self,
-                                                 patched_schedule_zim_file):
+                                                 patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -477,9 +477,9 @@ class BuildersTest(BaseWebTestcase):
                        })
       self.assertEqual('404 NOT FOUND', rv.status)
 
-  @patch('wp1.zimfarm.schedule_zim_file')
+  @patch('wp1.zimfarm.request_zimfarm_task')
   def test_create_zim_file_for_builder_unauthorized(self,
-                                                    patched_schedule_zim_file):
+                                                    patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -494,12 +494,12 @@ class BuildersTest(BaseWebTestcase):
                        })
       self.assertEqual('403 FORBIDDEN', rv.status)
 
-  @patch('wp1.zimfarm.schedule_zim_file')
-  def test_create_zim_file_for_builder_500(self, patched_schedule_zim_file):
+  @patch('wp1.zimfarm.request_zimfarm_task')
+  def test_create_zim_file_for_builder_500(self, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
-    patched_schedule_zim_file.side_effect = ZimFarmError
+    patched_request_zimfarm_task.side_effect = ZimFarmError
 
     self.app = create_app()
     with self.override_db(self.app), self.app.test_client() as client:
@@ -512,8 +512,8 @@ class BuildersTest(BaseWebTestcase):
                        })
       self.assertEqual('500 INTERNAL SERVER ERROR', rv.status)
 
-  @patch('wp1.zimfarm.schedule_zim_file')
-  def test_create_zim_file_for_builder_400(self, patched_schedule_zim_file):
+  @patch('wp1.zimfarm.request_zimfarm_task')
+  def test_create_zim_file_for_builder_400(self, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -524,9 +524,9 @@ class BuildersTest(BaseWebTestcase):
       rv = client.post('/v1/builders/%s/zim' % builder_id, json={})
       self.assertEqual('400 BAD REQUEST', rv.status)
 
-  @patch('wp1.zimfarm.schedule_zim_file')
+  @patch('wp1.zimfarm.request_zimfarm_task')
   def test_create_zim_file_for_builder_no_title(self,
-                                                patched_schedule_zim_file):
+                                                patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -254,7 +254,7 @@ def _get_zimfarm_headers(token):
   return {"Authorization": "Token %s" % token, 'User-Agent': WP1_USER_AGENT}
 
 
-def schedule_zim_file(s3,
+def request_zimfarm_task(s3,
                       redis,
                       wp10db,
                       builder,

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -347,7 +347,7 @@ class ZimFarmTest(BaseWpOneDbTest):
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   @patch('wp1.zimfarm._get_params')
-  def test_schedule_zim_file(self, get_params_mock, get_token_mock,
+  def test_request_zimfarm_task(self, get_params_mock, get_token_mock,
                              mock_requests):
     redis = MagicMock()
     s3 = MagicMock()
@@ -357,24 +357,24 @@ class ZimFarmTest(BaseWpOneDbTest):
     mock_response.json.return_value = {'requested': ['9876']}
     mock_requests.post.side_effect = (MagicMock(), mock_response, MagicMock())
 
-    actual = zimfarm.schedule_zim_file(s3, redis, self.wp10db, self.builder)
+    actual = zimfarm.request_zimfarm_task(s3, redis, self.wp10db, self.builder)
 
     self.assertEqual('9876', actual)
 
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
-  def test_schedule_zim_file_missing_builder(self, get_token_mock,
+  def test_request_zimfarm_task_missing_builder(self, get_token_mock,
                                              mock_requests):
     redis = MagicMock()
     s3 = MagicMock()
 
     with self.assertRaises(ObjectNotFoundError):
-      zimfarm.schedule_zim_file(s3, redis, self.wp10db, None)
+      zimfarm.request_zimfarm_task(s3, redis, self.wp10db, None)
 
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   @patch('wp1.zimfarm._get_params')
-  def test_schedule_zim_file_post_requests(self, get_params_mock,
+  def test_request_zimfarm_task_post_requests(self, get_params_mock,
                                            get_token_mock, mock_requests):
     redis = MagicMock()
     s3 = MagicMock()
@@ -384,7 +384,7 @@ class ZimFarmTest(BaseWpOneDbTest):
     mock_response.json.return_value = {'requested': ['9876']}
     mock_requests.post.side_effect = (MagicMock(), mock_response)
 
-    zimfarm.schedule_zim_file(s3,
+    zimfarm.request_zimfarm_task(s3,
                               redis,
                               self.wp10db,
                               self.builder,
@@ -419,7 +419,7 @@ class ZimFarmTest(BaseWpOneDbTest):
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   @patch('wp1.zimfarm._get_params')
-  def test_schedule_zim_file_schedule_create_raises(self, get_params_mock,
+  def test_request_zimfarm_task_schedule_create_raises(self, get_params_mock,
                                                     get_token_mock,
                                                     mock_requests):
     redis = MagicMock()
@@ -431,7 +431,7 @@ class ZimFarmTest(BaseWpOneDbTest):
     mock_requests.post.side_effect = (create_schedule_response, mock_response)
 
     with self.assertRaises(ZimFarmError):
-      zimfarm.schedule_zim_file(s3,
+      zimfarm.request_zimfarm_task(s3,
                                 redis,
                                 self.wp10db,
                                 self.builder,
@@ -441,7 +441,7 @@ class ZimFarmTest(BaseWpOneDbTest):
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   @patch('wp1.zimfarm._get_params')
-  def test_schedule_zim_file_task_create_raises(self, get_params_mock,
+  def test_request_zimfarm_task_task_create_raises(self, get_params_mock,
                                                 get_token_mock, mock_requests):
     redis = MagicMock()
     s3 = MagicMock()
@@ -454,7 +454,7 @@ class ZimFarmTest(BaseWpOneDbTest):
     )
 
     with self.assertRaises(ZimFarmError):
-      zimfarm.schedule_zim_file(s3, redis, self.wp10db, self.builder)
+      zimfarm.request_zimfarm_task(s3, redis, self.wp10db, self.builder)
 
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
@@ -468,7 +468,7 @@ class ZimFarmTest(BaseWpOneDbTest):
     mock_requests.post.side_effect = (MagicMock(), mock_response, MagicMock())
 
     valid_title = "में" * (ZIM_TITLE_MAX_LENGTH)
-    actual = zimfarm.schedule_zim_file(s3,
+    actual = zimfarm.request_zimfarm_task(s3,
                                        redis,
                                        self.wp10db,
                                        self.builder,
@@ -479,14 +479,14 @@ class ZimFarmTest(BaseWpOneDbTest):
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   @patch('wp1.zimfarm._get_params')
-  def test_schedule_zim_file_too_long_title(self, get_params_mock,
+  def test_request_zimfarm_task_too_long_title(self, get_params_mock,
                                             get_token_mock, mock_requests):
     redis = MagicMock()
     s3 = MagicMock()
 
     wrong_title = "a" * (ZIM_TITLE_MAX_LENGTH + 1)
     with self.assertRaises(InvalidZimTitleError):
-      zimfarm.schedule_zim_file(s3,
+      zimfarm.request_zimfarm_task(s3,
                                 redis,
                                 self.wp10db,
                                 self.builder,
@@ -495,14 +495,14 @@ class ZimFarmTest(BaseWpOneDbTest):
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   @patch('wp1.zimfarm._get_params')
-  def test_schedule_zim_file_too_long_title(self, get_params_mock,
+  def test_request_zimfarm_task_too_long_title(self, get_params_mock,
                                             get_token_mock, mock_requests):
     redis = MagicMock()
     s3 = MagicMock()
 
     wrong_title = "a" * (ZIM_TITLE_MAX_LENGTH + 1)
     with self.assertRaises(InvalidZimTitleError):
-      zimfarm.schedule_zim_file(s3,
+      zimfarm.request_zimfarm_task(s3,
                                 redis,
                                 self.wp10db,
                                 self.builder,
@@ -511,7 +511,7 @@ class ZimFarmTest(BaseWpOneDbTest):
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   @patch('wp1.zimfarm._get_params')
-  def test_schedule_zim_file_too_long_description(self, get_params_mock,
+  def test_request_zimfarm_task_too_long_description(self, get_params_mock,
                                                   get_token_mock,
                                                   mock_requests):
     redis = MagicMock()
@@ -519,7 +519,7 @@ class ZimFarmTest(BaseWpOneDbTest):
 
     too_long_description = "z" * (ZIM_DESCRIPTION_MAX_LENGTH + 1)
     with self.assertRaises(InvalidZimDescriptionError):
-      zimfarm.schedule_zim_file(s3,
+      zimfarm.request_zimfarm_task(s3,
                                 redis,
                                 self.wp10db,
                                 self.builder,
@@ -529,7 +529,7 @@ class ZimFarmTest(BaseWpOneDbTest):
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   @patch('wp1.zimfarm._get_params')
-  def test_schedule_zim_file_too_long_long_description(self, get_params_mock,
+  def test_request_zimfarm_task_too_long_long_description(self, get_params_mock,
                                                        get_token_mock,
                                                        mock_requests):
     redis = MagicMock()
@@ -537,7 +537,7 @@ class ZimFarmTest(BaseWpOneDbTest):
 
     too_long_long_description = "z" * (ZIM_LONG_DESCRIPTION_MAX_LENGTH + 1)
     with self.assertRaises(InvalidZimLongDescriptionError):
-      zimfarm.schedule_zim_file(s3,
+      zimfarm.request_zimfarm_task(s3,
                                 redis,
                                 self.wp10db,
                                 self.builder,
@@ -548,14 +548,14 @@ class ZimFarmTest(BaseWpOneDbTest):
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   @patch('wp1.zimfarm._get_params')
-  def test_schedule_zim_file_too_short_long_description(self, get_params_mock,
+  def test_request_zimfarm_task_too_short_long_description(self, get_params_mock,
                                                         get_token_mock,
                                                         mock_requests):
     redis = MagicMock()
     s3 = MagicMock()
 
     with self.assertRaises(InvalidZimLongDescriptionError):
-      zimfarm.schedule_zim_file(s3,
+      zimfarm.request_zimfarm_task(s3,
                                 redis,
                                 self.wp10db,
                                 self.builder,
@@ -566,13 +566,13 @@ class ZimFarmTest(BaseWpOneDbTest):
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   @patch('wp1.zimfarm._get_params')
-  def test_schedule_zim_file_equal_descriptions(self, get_params_mock,
+  def test_request_zimfarm_task_equal_descriptions(self, get_params_mock,
                                                 get_token_mock, mock_requests):
     redis = MagicMock()
     s3 = MagicMock()
 
     with self.assertRaises(InvalidZimLongDescriptionError):
-      zimfarm.schedule_zim_file(s3,
+      zimfarm.request_zimfarm_task(s3,
                                 redis,
                                 self.wp10db,
                                 self.builder,
@@ -583,7 +583,7 @@ class ZimFarmTest(BaseWpOneDbTest):
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   @patch('wp1.zimfarm._get_params')
-  def test_schedule_zim_file_delete_schedule_even_if_task_create_raises(
+  def test_request_zimfarm_task_delete_schedule_even_if_task_create_raises(
       self, get_params_mock, get_token_mock, mock_requests):
     redis = MagicMock()
     s3 = MagicMock()
@@ -596,14 +596,14 @@ class ZimFarmTest(BaseWpOneDbTest):
     mock_requests.exceptions.HTTPError = requests.exceptions.HTTPError
 
     with self.assertRaises(ZimFarmError):
-      zimfarm.schedule_zim_file(s3, redis, self.wp10db, self.builder)
+      zimfarm.request_zimfarm_task(s3, redis, self.wp10db, self.builder)
 
     mock_requests.delete.assert_called_once()
 
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   @patch('wp1.zimfarm._get_params')
-  def test_schedule_zim_file_missing_task_id(self, get_params_mock,
+  def test_request_zimfarm_task_missing_task_id(self, get_params_mock,
                                              get_token_mock, mock_requests):
     redis = MagicMock()
     s3 = MagicMock()
@@ -613,12 +613,12 @@ class ZimFarmTest(BaseWpOneDbTest):
     mock_requests.post.side_effect = (MagicMock(), mock_response, MagicMock())
 
     with self.assertRaises(ZimFarmError):
-      zimfarm.schedule_zim_file(s3, redis, self.wp10db, self.builder)
+      zimfarm.request_zimfarm_task(s3, redis, self.wp10db, self.builder)
 
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   @patch('wp1.zimfarm._get_params')
-  def test_schedule_zim_file_missing_article_count(self, get_params_mock,
+  def test_request_zimfarm_task_missing_article_count(self, get_params_mock,
                                                    get_token_mock,
                                                    mock_requests):
     redis = MagicMock()
@@ -629,12 +629,12 @@ class ZimFarmTest(BaseWpOneDbTest):
     self.wp10db.commit()
 
     with self.assertRaises(ZimFarmTooManyArticlesError):
-      zimfarm.schedule_zim_file(s3, redis, self.wp10db, self.builder)
+      zimfarm.request_zimfarm_task(s3, redis, self.wp10db, self.builder)
 
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   @patch('wp1.zimfarm._get_params')
-  def test_schedule_zim_file_too_many_articles(self, get_params_mock,
+  def test_request_zimfarm_task_too_many_articles(self, get_params_mock,
                                                get_token_mock, mock_requests):
     redis = MagicMock()
     s3 = MagicMock()
@@ -645,7 +645,7 @@ class ZimFarmTest(BaseWpOneDbTest):
     self.wp10db.commit()
 
     with self.assertRaises(ZimFarmTooManyArticlesError):
-      zimfarm.schedule_zim_file(s3, redis, self.wp10db, self.builder)
+      zimfarm.request_zimfarm_task(s3, redis, self.wp10db, self.builder)
 
   @patch('wp1.zimfarm.requests.get')
   def test_is_zim_file_ready(self, patched_get):


### PR DESCRIPTION
**Renamed `schedule_zim_file()` to clarify purpose and avoid confusion.**

The function `schedule_zim_file()` was renamed in two steps for better clarity:
 - First commit: Renamed `wp1/logic/builder.py:schedule_zim_file()`to `handle_zim_generation()`
 - Second commit: Renamed to `wp1/zimfarm.py:schedule_zim_file()` to `request_zimfarm_task()` 

The original name was misleading, especially with the upcoming scheduled ZIM generation feature. The final name avoids confusion and better reflects the function’s actual behavior.