### PR TITLE
add email handling in OAuth complete flow and corresponding test

### DIFF
--- a/wp1/web/oauth.py
+++ b/wp1/web/oauth.py
@@ -44,22 +44,37 @@ def complete():
   session.pop('request_token')
   identity = handshaker.identify(access_token)
 
+  wp10db = get_db('wp10db')
+  
+  if identity.get('email') is None:
+    with wp10db.cursor() as cursor:
+      cursor.execute(
+          '''SELECT u_email FROM users WHERE u_id = %(u_id)s''',
+          {'u_id': identity['sub']}
+      )
+      result = cursor.fetchone()
+      email = result['u_email'] if result else None
+  else:
+    email = identity.get('email')
+
   session['user'] = {
       'access_token': access_token,
       'identity': {
           'username': identity['username'],
+          'email': email,
           'sub': identity['sub']
       }
   }
-  wp10db = get_db('wp10db')
+
   with wp10db.cursor() as cursor:
     cursor.execute(
-        '''INSERT INTO users (u_id, u_username)
-                      VALUES (%(u_id)s, %(u_username)s)
-                      ON DUPLICATE KEY UPDATE u_id= %(u_id)s, u_username= %(u_username)s''',
+        '''INSERT INTO users (u_id, u_username, u_email)
+                      VALUES (%(u_id)s, %(u_username)s, %(u_email)s)
+                      ON DUPLICATE KEY UPDATE u_id= %(u_id)s, u_username= %(u_username)s, u_email= %(u_email)s''',
         {
             'u_id': identity['sub'],
-            'u_username': identity['username']
+            'u_username': identity['username'],
+            'u_email': email
         })
     wp10db.commit()
   next_path = session.pop('next_path')

--- a/wp1/web/oauth.py
+++ b/wp1/web/oauth.py
@@ -61,7 +61,7 @@ def complete():
       VALUES (%(u_id)s, %(u_username)s, %(u_email)s)
       ON DUPLICATE KEY UPDATE
         u_username = VALUES(u_username),
-        u_email = COALESCE(VALUES(u_email), u_email)
+        u_email = IF(u_email IS NULL, VALUES(u_email), u_email)
       ''',
       {
         'u_id': identity['sub'],

--- a/wp1/web/oauth.py
+++ b/wp1/web/oauth.py
@@ -61,7 +61,7 @@ def complete():
       VALUES (%(u_id)s, %(u_username)s, %(u_email)s)
       ON DUPLICATE KEY UPDATE
         u_username = VALUES(u_username),
-        u_email = IF(u_email IS NULL, VALUES(u_email), u_email)
+        u_email = VALUES(u_email)
       ''',
       {
         'u_id': identity['sub'],


### PR DESCRIPTION
This PR enhances the OAuth `complete()` flow by ensuring that the user's email is properly retrieved and stored.

If the identity object from the OAuth provider includes an email, it is used directly.
If not, the email is fetched from the users table using the user ID.
The email is then stored in both the session and the users table.
Added also `test_complete_sets_email_in_session()` to verify that the email is correctly set in the session after a successful OAuth flow.

Fixes #916 (wikimedia oauth consumer needs to be updated/recreated with email permissions)
