### PR TITLE
Modify `builders.py` api for scheduled zim generations support

### DIFF
--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -392,7 +392,8 @@ def handle_zim_generation(s3,
                       user_id=None,
                       title='',
                       description='',
-                      long_description=None):
+                      long_description=None,
+                      scheduled_repetitions=None):
   if isinstance(builder_id, str):
     builder_id = builder_id.encode('utf-8')
   builder = get_builder(wp10db, builder_id)

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -195,7 +195,10 @@ def create_zim_file_for_builder(builder_id):
   if not desc:
     error_messages.append('Description is required for ZIM file')
 
-  if scheduled_repetitions is not None:
+  if error_messages:
+    return flask.jsonify({'error_messages': error_messages}), 400
+
+  if scheduled_repetitions not in (None, {}):
     if not (
       isinstance(scheduled_repetitions, dict) and
       all(k in scheduled_repetitions for k in (
@@ -204,11 +207,11 @@ def create_zim_file_for_builder(builder_id):
           "email",
       ))
   ):
-      error_messages.append('Invalid or missing fields in scheduled_repetitions')
+      return 'Invalid or missing fields in scheduled_repetitions', 400
 
-  if error_messages:
-    return flask.jsonify({'error_messages': error_messages}), 400
-
+  # Set scheduled_repetitions to None if it's an empty dict
+  if scheduled_repetitions == {}:
+    scheduled_repetitions = None
 
   try:
     logic_builder.handle_zim_generation(s3,

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -550,7 +550,7 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('400 BAD REQUEST', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  def test_create_zim_file_for_builder_scheduled_repetitions_valid(self,
+  def test_create_zim_file_for_builder_scheduled_repetitions(self,
                                                                    patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
@@ -594,9 +594,7 @@ class BuildersTest(BaseWebTestcase):
                            }
                        })
       self.assertEqual('400 BAD REQUEST', rv.status)
-      response_data = rv.get_json()
-      self.assertIn('error_messages', response_data)
-      self.assertIn('Invalid or missing fields in scheduled_repetitions', response_data['error_messages'])
+      self.assertIn('Invalid or missing fields in scheduled_repetitions', rv.data.decode('utf-8'))
 
   @patch('wp1.zimfarm.request_zimfarm_task')
   def test_create_zim_file_for_builder_scheduled_repetitions_not_dict(self,
@@ -615,9 +613,7 @@ class BuildersTest(BaseWebTestcase):
                            'scheduled_repetitions': 'not a dict'
                        })
       self.assertEqual('400 BAD REQUEST', rv.status)
-      response_data = rv.get_json()
-      self.assertIn('error_messages', response_data)
-      self.assertIn('Invalid or missing fields in scheduled_repetitions', response_data['error_messages'])
+      self.assertIn('Invalid or missing fields in scheduled_repetitions', rv.data.decode('utf-8'))
 
   @patch('wp1.zimfarm.request_zimfarm_task')
   def test_create_zim_file_for_builder_scheduled_repetitions_empty_dict(self,
@@ -635,10 +631,8 @@ class BuildersTest(BaseWebTestcase):
                            'description': 'Test description',
                            'scheduled_repetitions': {}
                        })
-      self.assertEqual('400 BAD REQUEST', rv.status)
-      response_data = rv.get_json()
-      self.assertIn('error_messages', response_data)
-      self.assertIn('Invalid or missing fields in scheduled_repetitions', response_data['error_messages'])
+      # Expecting a 204 NO CONTENT response since the empty dict is treated as None
+      self.assertEqual('204 NO CONTENT', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
   def test_create_zim_file_for_builder_scheduled_repetitions_extra_fields(self,

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -549,6 +549,122 @@ class BuildersTest(BaseWebTestcase):
                        json={'description': 'Test description'})
       self.assertEqual('400 BAD REQUEST', rv.status)
 
+  @patch('wp1.zimfarm.request_zimfarm_task')
+  def test_create_zim_file_for_builder_scheduled_repetitions_valid(self,
+                                                                   patched_request_zimfarm_task):
+    builder_id = self._insert_builder()
+    self._insert_selections(builder_id)
+
+    patched_request_zimfarm_task.return_value = '1234-a'
+
+    self.app = create_app()
+    with self.override_db(self.app), self.app.test_client() as client:
+      with client.session_transaction() as sess:
+        sess['user'] = self.USER
+      rv = client.post('/v1/builders/%s/zim' % builder_id,
+                       json={
+                           'title': 'Test title',
+                           'description': 'Test description',
+                           'scheduled_repetitions': {
+                               'repetition_period_in_months': 6,
+                               'number_of_repetitions': 3,
+                               'email': 'test@example.com'
+                           }
+                       })
+      self.assertEqual('204 NO CONTENT', rv.status)
+
+  @patch('wp1.zimfarm.request_zimfarm_task')
+  def test_create_zim_file_for_builder_scheduled_repetitions_missing_fields(self,
+                                                                            patched_request_zimfarm_task):
+    builder_id = self._insert_builder()
+    self._insert_selections(builder_id)
+
+    self.app = create_app()
+    with self.override_db(self.app), self.app.test_client() as client:
+      with client.session_transaction() as sess:
+        sess['user'] = self.USER
+      rv = client.post('/v1/builders/%s/zim' % builder_id,
+                       json={
+                           'title': 'Test title',
+                           'description': 'Test description',
+                           'scheduled_repetitions': {
+                               'repetition_period_in_months': 6,
+                               'number_of_repetitions': 3
+                               # missing 'email' field
+                           }
+                       })
+      self.assertEqual('400 BAD REQUEST', rv.status)
+      response_data = rv.get_json()
+      self.assertIn('error_messages', response_data)
+      self.assertIn('Invalid or missing fields in scheduled_repetitions', response_data['error_messages'])
+
+  @patch('wp1.zimfarm.request_zimfarm_task')
+  def test_create_zim_file_for_builder_scheduled_repetitions_not_dict(self,
+                                                                      patched_request_zimfarm_task):
+    builder_id = self._insert_builder()
+    self._insert_selections(builder_id)
+
+    self.app = create_app()
+    with self.override_db(self.app), self.app.test_client() as client:
+      with client.session_transaction() as sess:
+        sess['user'] = self.USER
+      rv = client.post('/v1/builders/%s/zim' % builder_id,
+                       json={
+                           'title': 'Test title',
+                           'description': 'Test description',
+                           'scheduled_repetitions': 'not a dict'
+                       })
+      self.assertEqual('400 BAD REQUEST', rv.status)
+      response_data = rv.get_json()
+      self.assertIn('error_messages', response_data)
+      self.assertIn('Invalid or missing fields in scheduled_repetitions', response_data['error_messages'])
+
+  @patch('wp1.zimfarm.request_zimfarm_task')
+  def test_create_zim_file_for_builder_scheduled_repetitions_empty_dict(self,
+                                                                        patched_request_zimfarm_task):
+    builder_id = self._insert_builder()
+    self._insert_selections(builder_id)
+
+    self.app = create_app()
+    with self.override_db(self.app), self.app.test_client() as client:
+      with client.session_transaction() as sess:
+        sess['user'] = self.USER
+      rv = client.post('/v1/builders/%s/zim' % builder_id,
+                       json={
+                           'title': 'Test title',
+                           'description': 'Test description',
+                           'scheduled_repetitions': {}
+                       })
+      self.assertEqual('400 BAD REQUEST', rv.status)
+      response_data = rv.get_json()
+      self.assertIn('error_messages', response_data)
+      self.assertIn('Invalid or missing fields in scheduled_repetitions', response_data['error_messages'])
+
+  @patch('wp1.zimfarm.request_zimfarm_task')
+  def test_create_zim_file_for_builder_scheduled_repetitions_extra_fields(self,
+                                                                          patched_request_zimfarm_task):
+    builder_id = self._insert_builder()
+    self._insert_selections(builder_id)
+
+    patched_request_zimfarm_task.return_value = '1234-a'
+
+    self.app = create_app()
+    with self.override_db(self.app), self.app.test_client() as client:
+      with client.session_transaction() as sess:
+        sess['user'] = self.USER
+      rv = client.post('/v1/builders/%s/zim' % builder_id,
+                       json={
+                           'title': 'Test title',
+                           'description': 'Test description',
+                           'scheduled_repetitions': {
+                               'repetition_period_in_months': 6,
+                               'number_of_repetitions': 3,
+                               'email': 'test@example.com',
+                               'extra_field': 'should be ignored'
+                           }
+                       })
+      self.assertEqual('204 NO CONTENT', rv.status)
+
   @patch('wp1.web.builders.queues.poll_for_zim_file_status')
   def test_update_zimfarm_status(self, patched_poll):
     builder_id = self._insert_builder()


### PR DESCRIPTION
Introduce the ability to schedule repeated ZIM file generations directly from the `create_zim_file_for_builder()` endpoint.

- Extended `create_zim_file_for_builder()` to accept a `scheduled_repetitions` field from the request body.
- Added input validation to ensure `scheduled_repetitions` includes the required fields:
 - `repetition_period_in_months`
 - `number_of_repetitions`
 - `email`
- Passed the validated `scheduled_repetitions` to `handle_zim_generation()`.
- Updated `handle_zim_generation()` function signature to include the new optional parameter.

Fixes #912 