### PR TITLE
Refactor `logic/builder.py:handle_zim_generation()` to be used in scheduled workers

### DIFF
--- a/db/migrations/20220818_01_5x0T9-add-object-key-column-to-selections.py
+++ b/db/migrations/20220818_01_5x0T9-add-object-key-column-to-selections.py
@@ -5,6 +5,7 @@ Add object_key column to selections
 from yoyo import group, step
 
 import wp1.logic.selection as logic_selection
+from wp1.models.wp10.builder import Builder
 from wp1.redis_db import connect
 from wp1.selection.models.simple import Builder as SimpleBuilder
 from wp1 import queues
@@ -33,10 +34,11 @@ def re_materialize_builders(conn):
   redis = connect()
 
   cursor = conn.cursor()
-  cursor.execute('''SELECT b_id FROM builders''')
+  cursor.execute('''SELECT * FROM builders''')
   data = cursor.fetchall()
   for row in data:
-    queues.enqueue_materialize(redis, SimpleBuilder, row[0],
+    builder = Builder(**row)
+    queues.enqueue_materialize(redis, SimpleBuilder, builder,
                                'text/tab-separated-values')
 
 

--- a/wp1/queues.py
+++ b/wp1/queues.py
@@ -167,11 +167,11 @@ def enqueue_project(project_name,
                    'not PRODUCTION')
 
 
-def enqueue_materialize(redis, builder_cls, builder_id, content_type):
+def enqueue_materialize(redis, builder_cls, builder, content_type):
   materialize_q = _get_materializer_queue(redis)
   materialize_q.enqueue(logic_builder.materialize_builder,
                         builder_cls,
-                        builder_id,
+                        builder,
                         content_type,
                         job_timeout=constants.JOB_TIMEOUT,
                         failure_ttl=constants.JOB_FAILURE_TTL)

--- a/wp1/queues_test.py
+++ b/wp1/queues_test.py
@@ -164,17 +164,16 @@ class QueuesTest(BaseWpOneDbTest):
 
   @patch('wp1.queues.Queue')
   @patch('wp1.queues.logic_builder.materialize_builder')
-  def test_enqueue_materialize(self, patched_materialize_builder,
-                               patched_queue):
+  def test_enqueue_materialize(self, mock_materialize_builder,
+                               mock_queue):
     materialize_q_mock = MagicMock()
-    patched_queue.return_value = materialize_q_mock
-
-    queues.enqueue_materialize(self.redis, SimpleBuilder, 1234,
-                               'text/tab-separated-values')
+    mock_queue.return_value = materialize_q_mock
+    builder = MagicMock()
+    queues.enqueue_materialize(self.redis, SimpleBuilder, builder, 'text/tab-separated-values')
     materialize_q_mock.enqueue.assert_called_once_with(
-        patched_materialize_builder,
+        mock_materialize_builder,
         SimpleBuilder,
-        1234,
+        builder,
         'text/tab-separated-values',
         job_timeout=constants.JOB_TIMEOUT,
         failure_ttl=constants.JOB_FAILURE_TTL)


### PR DESCRIPTION
This PR refactors zim file generation by decoupling `request_zim_file_for_builder()` from `handle_zim_generation()`, and creating a new `request_scheduled_zim_file_for_builder`.

The main reason for this change is to make the zim file request logic flexible for use in scheduled workers.
The new `request_scheduled_zim_file_for_builder()` now handles:
- skipping `user_id` checks, as these are not relevant for scheduled tasks
- re-opening db, redis and s3 connections independently
- rebuilding selections
- initiating the zimfarm request and updating the zim file status

Also a new `materialize_builder_with_connections()` has been added to skip repeated connections and clean the materialize process.

New tests have been added.

Fixes #928 