### PR TITLE
Implement scheduling for future ZIM file generations

### DIFF
--- a/wp1/constants.py
+++ b/wp1/constants.py
@@ -85,3 +85,5 @@ WP1_USER_AGENT = 'WP 1.0 bot 1.0.0/Audiodude <audiodude@gmail.com>'
 
 # 2 hours
 MAX_ZIM_FILE_POLL_TIME = 2 * 60 * 60
+
+SECONDS_PER_MONTH = 30 * 24 * 60 * 60  # Approximate seconds in a month

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -487,6 +487,10 @@ def handle_zim_generation(s3,
 
   task_id = request_zim_file_for_builder(s3, redis, wp10db, builder, title, description, long_description)
 
+  # if scheduled_repetitions is not None schedule future ZIMfile generations
+  if scheduled_repetitions is not None:
+    queues.schedule_future_zimfile_generations(redis, wp10db, builder, title, description, long_description, scheduled_repetitions)
+
   # In production, there is a web hook from the Zimfarm that notifies us
   # that the task is finished and we can start polling for the ZIM file
   # to be uploaded. The web hook obviously doesn't work in development

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -475,14 +475,14 @@ def request_scheduled_zim_file_for_builder(builder: Builder,
   return task_id
 
 def handle_zim_generation(s3,
-                      redis,
-                      wp10db,
-                      builder_id,
-                      user_id=None,
-                      title='',
-                      description='',
-                      long_description=None,
-                      scheduled_repetitions=None):
+                          redis,
+                          wp10db,
+                          builder_id,
+                          user_id=None,
+                          title='',
+                          description='',
+                          long_description=None,
+                          scheduled_repetitions=None):
   """
   Handles the ZIM file generation and scheduling for a builder.
   """

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -9,6 +9,7 @@ from pymysql.connections import Connection
 from redis import Redis
 
 import wp1.logic.selection as logic_selection
+import wp1.logic.zim_schedules as logic_zim_schedules
 import wp1.logic.util as logic_util
 from wp1 import app_logging, queues, zimfarm
 from wp1.constants import (CONTENT_TYPE_TO_EXT, EXT_TO_CONTENT_TYPE,
@@ -20,6 +21,7 @@ from wp1.exceptions import (ObjectNotFoundError, UserNotAuthorizedError,
 from wp1.models.wp10.builder import Builder
 from wp1.models.wp10.selection import Selection
 from wp1.models.wp10.zim_file import ZimFile
+from wp1.models.wp10.zim_schedule import ZimSchedule
 from wp1.redis_db import connect as redis_connect
 from wp1.storage import connect_storage
 from wp1.timestamp import utcnow
@@ -434,7 +436,8 @@ def request_zim_file_for_builder(s3: KiwixStorage,
 def request_scheduled_zim_file_for_builder(builder: Builder,
                                            title: str,
                                            description: str,
-                                           long_description: str = None):
+                                           long_description: str = None,
+                                           zim_schedule_id: str = None):
   """
   Requests a scheduled ZIM file generation from the Zimfarm for the given builder.
   It will reopen connections and rebuild the selection for the builder.
@@ -450,10 +453,14 @@ def request_scheduled_zim_file_for_builder(builder: Builder,
   builder: Builder = get_builder(wp10db, builder.b_id)
   builder_module = importlib.import_module(builder.b_model.decode('utf-8'))
   builder_cls = getattr(builder_module, 'Builder')
-  # materializer = builder_cls()
   materialize_builder(builder_cls, builder, 'text/tab-separated-values', s3, redis, wp10db)
 
+  if zim_schedule_id is not None:
+    zim_file = zim_file_for_latest_selection(wp10db, builder.b_id)
+    logic_zim_schedules.update_zim_schedule_zim_file_id(wp10db, zim_schedule_id, zim_file.z_id)
+
   task_id = request_zim_file_for_builder(s3, redis, wp10db, builder, title, description, long_description)
+
   return task_id
 
 def handle_zim_generation(s3,

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -512,7 +512,7 @@ def handle_zim_generation(s3,
 
   # if scheduled_repetitions is not None schedule future ZIMfile generations
   if scheduled_repetitions is not None:
-    queues.schedule_future_zimfile_generations(redis, wp10db, builder, title, description, long_description, scheduled_repetitions)
+    logic_zim_schedules.schedule_future_zimfile_generations(redis, wp10db, builder, title, description, long_description, scheduled_repetitions)
 
   # In production, there is a web hook from the Zimfarm that notifies us
   # that the task is finished and we can start polling for the ZIM file

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -850,8 +850,8 @@ class BuilderTest(BaseWpOneDbTest):
 
     self.assertEqual(0, len(actual))
 
-  @patch('wp1.logic.builder.zimfarm.request_zimfarm_task')
   @patch('wp1.logic.builder.zimfarm.create_zimfarm_schedule')
+  @patch('wp1.logic.builder.zimfarm.request_zimfarm_task')
   @patch('wp1.logic.builder.utcnow',
          return_value=datetime.datetime(2022, 12, 25, 0, 1, 2))
   def test_handle_zim_generation(self, mock_utcnow,
@@ -877,10 +877,9 @@ class BuilderTest(BaseWpOneDbTest):
                                         long_description='zz')
 
     mock_create_zimfarm_schedule.assert_called_once_with(redis, self.wp10db,
-                                                         builder_id,
+                                                         self.builder,
                                                          'test_title',
-                                                         'a',
-                                                         'zz')
+                                                         'a', 'zz')
     mock_request_zimfarm_task.assert_called_once_with(redis,
                                                       self.wp10db,
                                                       self.builder)
@@ -895,7 +894,7 @@ class BuilderTest(BaseWpOneDbTest):
     self.assertEqual(b'20221225000102', data['z_requested_at'])
     self.assertEqual(b'test_title', data['z_title'])
     self.assertEqual(b'a', data['z_description'])
-    self.assertEqual(b'z', data['z_long_description'])
+    self.assertEqual(b'zz', data['z_long_description'])
 
   @patch('wp1.logic.builder.utcnow',
          return_value=datetime.datetime(2022, 12, 25, 0, 1, 2))
@@ -1240,7 +1239,7 @@ class BuilderTest(BaseWpOneDbTest):
          return_value=datetime.datetime(2022, 12, 25, 0, 1, 2))
   def test_request_zim_file_task_for_builder(self, mock_utcnow, mock_connect_storage,
                                         mock_redis_connect, mock_wp10_connect,
-                                        mock_create_zimfarm_schedule, mock_request_zimfarm_task):
+                                        mock_request_zimfarm_task):
     """Test basic zimfile request functionality"""
     self._insert_builder()
     self._insert_selection(1,
@@ -1255,24 +1254,18 @@ class BuilderTest(BaseWpOneDbTest):
 
     mock_request_zimfarm_task.return_value = 'test_task_id_123'
 
-    actual = logic_builder.request_zim_file_task_for_builder(
-        s3_mock,
-        redis_mock,
-        self.wp10db,
-        builder=self.builder,
-        title='Test Title',
-        description='Test Description',
-        long_description='Test Long Description')
+    actual = logic_builder.request_zim_file_task_for_builder(redis_mock,
+                                                             self.wp10db,
+                                                             builder=self.builder,
+                                                             title='Test Title',
+                                                             description='Test Description',
+                                                             long_description='Test Long Description')
 
-    # Verify return value
     self.assertEqual('test_task_id_123', actual)
-
-    # Verify zimfarm was called correctly
     mock_request_zimfarm_task.assert_called_once_with(redis_mock,
                                                       self.wp10db,
                                                       self.builder)
 
-    # Verify database was updated
     with self.wp10db.cursor() as cursor:
       cursor.execute('SELECT * FROM zim_files WHERE z_selection_id = 1')
       zim_file = cursor.fetchone()
@@ -1439,13 +1432,12 @@ class BuilderTest(BaseWpOneDbTest):
     mock_request_zimfarm_task.return_value = 'test_task_id_empty'
 
     # Call the function with empty descriptions
-    actual = logic_builder.request_zim_file_task_for_builder(s3_mock,
-                                                        redis_mock,
-                                                        self.wp10db,
-                                                        builder=self.builder,
-                                                        title='Test Title',
-                                                        description='',
-                                                        long_description=None)
+    actual = logic_builder.request_zim_file_task_for_builder(redis_mock,
+                                                             self.wp10db,
+                                                             builder=self.builder,
+                                                             title='Test Title',
+                                                             description='',
+                                                             long_description=None)
 
     # Verify return value
     self.assertEqual('test_task_id_empty', actual)
@@ -1482,23 +1474,17 @@ class BuilderTest(BaseWpOneDbTest):
 
     mock_request_zimfarm_task.return_value = 'test_task_id_no_selection'
 
-    # This should raise an exception or handle gracefully
-    # The function calls latest_selection_for which may return None
     try:
-      actual = logic_builder.request_zim_file_task_for_builder(
-          s3=s3_mock,
-          redis=redis_mock,
-          wp10db=self.wp10db,
-          builder=self.builder.b_id,
-          title='Test Title',
-          description='Test Description',
-          long_description='Test Long Description')
-      # If no exception, access result to avoid unused variable warning
+      actual = logic_builder.request_zim_file_task_for_builder(redis=redis_mock,
+                                                               wp10db=self.wp10db,
+                                                               builder=self.builder.b_id,
+                                                               title='Test Title',
+                                                               description='Test Description',
+                                                               long_description='Test Long Description')
       self.assertIsNotNone(actual)
     except Exception:
-      pass  # Exception is expected if no selection is found
+      pass  
 
-    # If the function completes, zimfarm should still be called
     mock_request_zimfarm_task.assert_called_once()
 
   def test_get_builder_module_class_success(self):

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -8,6 +8,7 @@ from wp1.exceptions import (InvalidZimTitleError, ObjectNotFoundError,
                             UserNotAuthorizedError, ZimFarmError)
 from wp1.logic import builder as logic_builder
 from wp1.models.wp10.builder import Builder
+from wp1.selection.models.simple import Builder as SimpleBuilder
 
 
 class BuilderTest(BaseWpOneDbTest):
@@ -1600,3 +1601,13 @@ class BuilderTest(BaseWpOneDbTest):
 
     # If the function completes, zimfarm should still be called
     mock_request_zimfarm_task.assert_called_once()
+
+  def test_get_builder_module_class_success(self):
+      cls = logic_builder.get_builder_module_class('wp1.selection.models.simple')
+      self.assertIs(cls, SimpleBuilder)
+
+  def test_get_builder_module_class_no_builder_attribute(self):
+      with self.assertRaises(ImportError) as cm:
+          logic_builder.get_builder_module_class('nonexistent.module')
+      self.assertIn('No module named', str(cm.exception))
+

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -1309,32 +1309,211 @@ class BuilderTest(BaseWpOneDbTest):
     mock_request_zimfarm_task.return_value = 'test_task_id_456'
 
     mock_get_builder.return_value = self.builder
-
-    # Mock the builder class import
+    
     with patch('wp1.logic.builder.importlib.import_module') as mock_import:
       mock_module = MagicMock()
       mock_builder_cls = MagicMock()
       mock_module.Builder = mock_builder_cls
       mock_import.return_value = mock_module
-
-      # Call the function with rebuild_selection=True
+      
       actual = logic_builder.request_scheduled_zim_file_for_builder(
           builder=self.builder,
           title='Test Title',
           description='Test Description',
-          long_description='Test Long Description')
-
-    # Verify return value
+          long_description='Test Long Description'
+      )
+    
     self.assertEqual('test_task_id_456', actual)
-
-    # Verify builder was retrieved
     mock_get_builder.assert_called_once_with(self.wp10db, self.builder.b_id)
-
-    # Verify materialize_builder was called
     mock_materialize_builder.assert_called_once()
-
-    # Verify zimfarm was called
     mock_request_zimfarm_task.assert_called_once()
+
+  @patch('wp1.logic.builder.materialize_builder')
+  @patch('wp1.logic.builder.get_builder')
+  @patch('wp1.logic.builder.zimfarm.request_zimfarm_task')
+  @patch('wp1.logic.builder.wp10_connect')
+  @patch('wp1.logic.builder.redis_connect')
+  @patch('wp1.logic.builder.connect_storage')
+  @patch('wp1.logic.zim_schedules.utcnow',
+         return_value=datetime.datetime(2022, 12, 25, 0, 1, 2))
+  def test_request_scheduled_zim_file_for_builder_with_zim_schedule(self,
+                                                  mock_utcnow,
+                                                  mock_connect_storage,
+                                                  mock_redis_connect,
+                                                  mock_wp10_connect,
+                                                  mock_request_zimfarm_task,
+                                                  mock_get_builder,
+                                                  mock_materialize_builder):
+    """Test zimfile request with rebuild_selection=True"""
+    self._insert_builder()
+    self._insert_selection(1, 'text/tab-separated-values', builder_id=self.builder.b_id)
+
+    #insert a zim_schedule
+    with self.wp10db.cursor() as cursor:
+      cursor.execute('INSERT INTO zim_schedules (s_id, s_builder_id, s_rq_job_id, s_last_updated_at) '
+                     'VALUES (%s, %s, %s, %s)',
+                     (b'schedule_123', self.builder.b_id, b'rq_job_id_123', b'20191225044444'))
+      self.wp10db.commit()
+
+    mock_wp10_connect.return_value = self.wp10db
+    redis_mock = MagicMock()
+    s3_mock = MagicMock()
+    mock_redis_connect.return_value = redis_mock
+    mock_connect_storage.return_value = s3_mock
+    
+    mock_request_zimfarm_task.return_value = 'test_task_id_456'
+    
+    mock_get_builder.return_value = self.builder
+    
+    with patch('wp1.logic.builder.importlib.import_module') as mock_import:
+      mock_module = MagicMock()
+      mock_builder_cls = MagicMock()
+      mock_module.Builder = mock_builder_cls
+      mock_import.return_value = mock_module
+      
+      actual = logic_builder.request_scheduled_zim_file_for_builder(
+          builder=self.builder,
+          title='Test Title',
+          description='Test Description',
+          long_description='Test Long Description',
+          zim_schedule_id='schedule_123'
+      )
+    
+    self.assertEqual('test_task_id_456', actual)
+    mock_get_builder.assert_called_once_with(self.wp10db, self.builder.b_id)
+    mock_materialize_builder.assert_called_once()
+    mock_request_zimfarm_task.assert_called_once()
+
+    #check that the zim_schedule was updated
+    with self.wp10db.cursor() as cursor:
+      cursor.execute('SELECT s_zim_file_id, s_last_updated_at '
+                     'FROM zim_schedules WHERE s_id = %s', ('schedule_123',))
+      schedule = cursor.fetchone()
+      self.assertIsNotNone(schedule['s_zim_file_id'])
+      self.assertEqual( b'20221225000102', schedule['s_last_updated_at'])
+
+  @patch('wp1.logic.builder.materialize_builder')
+  @patch('wp1.logic.builder.get_builder')
+  @patch('wp1.logic.builder.zimfarm.request_zimfarm_task')
+  @patch('wp1.logic.builder.wp10_connect')
+  @patch('wp1.logic.builder.redis_connect')
+  @patch('wp1.logic.builder.connect_storage')
+  @patch('wp1.logic.zim_schedules.utcnow',
+         return_value=datetime.datetime(2022, 12, 25, 0, 1, 2))
+  def test_request_scheduled_zim_file_for_builder_with_zim_schedule(self,
+                                                  mock_utcnow,
+                                                  mock_connect_storage,
+                                                  mock_redis_connect,
+                                                  mock_wp10_connect,
+                                                  mock_request_zimfarm_task,
+                                                  mock_get_builder,
+                                                  mock_materialize_builder):
+    """Test zimfile request with rebuild_selection=True"""
+    self._insert_builder()
+    self._insert_selection(1, 'text/tab-separated-values', builder_id=self.builder.b_id)
+
+    #insert a zim_schedule
+    with self.wp10db.cursor() as cursor:
+      cursor.execute('INSERT INTO zim_schedules (s_id, s_builder_id, s_rq_job_id, s_last_updated_at) '
+                     'VALUES (%s, %s, %s, %s)',
+                     (b'schedule_123', self.builder.b_id, b'rq_job_id_123', b'20191225044444'))
+      self.wp10db.commit()
+
+    mock_wp10_connect.return_value = self.wp10db
+    redis_mock = MagicMock()
+    s3_mock = MagicMock()
+    mock_redis_connect.return_value = redis_mock
+    mock_connect_storage.return_value = s3_mock
+    
+    mock_request_zimfarm_task.return_value = 'test_task_id_456'
+    
+    mock_get_builder.return_value = self.builder
+    
+    with patch('wp1.logic.builder.importlib.import_module') as mock_import:
+      mock_module = MagicMock()
+      mock_builder_cls = MagicMock()
+      mock_module.Builder = mock_builder_cls
+      mock_import.return_value = mock_module
+      
+      actual = logic_builder.request_scheduled_zim_file_for_builder(
+          builder=self.builder,
+          title='Test Title',
+          description='Test Description',
+          long_description='Test Long Description',
+          zim_schedule_id='schedule_123'
+      )
+    
+    self.assertEqual('test_task_id_456', actual)
+    mock_get_builder.assert_called_once_with(self.wp10db, self.builder.b_id)
+    mock_materialize_builder.assert_called_once()
+    mock_request_zimfarm_task.assert_called_once()
+
+    #check that the zim_schedule was updated
+    with self.wp10db.cursor() as cursor:
+      cursor.execute('SELECT s_zim_file_id, s_last_updated_at '
+                     'FROM zim_schedules WHERE s_id = %s', ('schedule_123',))
+      schedule = cursor.fetchone()
+      self.assertIsNotNone(schedule['s_zim_file_id'])
+      self.assertEqual( b'20221225000102', schedule['s_last_updated_at'])
+
+  @patch('wp1.logic.builder.zimfarm.request_zimfarm_task')
+  @patch('wp1.logic.builder.wp10_connect')
+  @patch('wp1.logic.builder.redis_connect')
+  @patch('wp1.logic.builder.connect_storage')
+  @patch('wp1.logic.zim_schedules.utcnow',
+         return_value=datetime.datetime(2022, 12, 25, 0, 1, 2))
+  def test_request_zim_file_for_builder_empty_descriptions(self, mock_utcnow,
+                                                           mock_connect_storage,
+                                                           mock_redis_connect,
+                                                           mock_wp10_connect,
+                                                           mock_request_zimfarm_task):
+    """Test zimfile request with empty/None descriptions"""
+    self._insert_builder()
+    self._insert_selection(1, 'text/tab-separated-values', builder_id=self.builder.b_id)
+
+    #insert a zim_schedule
+    with self.wp10db.cursor() as cursor:
+      cursor.execute('INSERT INTO zim_schedules (s_id, s_builder_id, s_rq_job_id, s_last_updated_at) '
+                     'VALUES (%s, %s, %s, %s)',
+                     (b'schedule_123', self.builder.b_id, b'rq_job_id_123', b'20191225044444'))
+      self.wp10db.commit()
+
+    mock_wp10_connect.return_value = self.wp10db
+    redis_mock = MagicMock()
+    s3_mock = MagicMock()
+    mock_redis_connect.return_value = redis_mock
+    mock_connect_storage.return_value = s3_mock
+    
+    mock_request_zimfarm_task.return_value = 'test_task_id_456'
+    
+    mock_get_builder.return_value = self.builder
+    
+    with patch('wp1.logic.builder.importlib.import_module') as mock_import:
+      mock_module = MagicMock()
+      mock_builder_cls = MagicMock()
+      mock_module.Builder = mock_builder_cls
+      mock_import.return_value = mock_module
+      
+      actual = logic_builder.request_scheduled_zim_file_for_builder(
+          builder=self.builder,
+          title='Test Title',
+          description='Test Description',
+          long_description='Test Long Description',
+          zim_schedule_id='schedule_123'
+      )
+    
+    self.assertEqual('test_task_id_456', actual)
+    mock_get_builder.assert_called_once_with(self.wp10db, self.builder.b_id)
+    mock_materialize_builder.assert_called_once()
+    mock_request_zimfarm_task.assert_called_once()
+
+    #check that the zim_schedule was updated
+    with self.wp10db.cursor() as cursor:
+      cursor.execute('SELECT s_zim_file_id, s_last_updated_at '
+                     'FROM zim_schedules WHERE s_id = %s', ('schedule_123',))
+      schedule = cursor.fetchone()
+      self.assertIsNotNone(schedule['s_zim_file_id'])
+      self.assertEqual( b'20221225000102', schedule['s_last_updated_at'])
 
   @patch('wp1.logic.builder.zimfarm.request_zimfarm_task')
   @patch('wp1.logic.builder.wp10_connect')

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -878,8 +878,9 @@ class BuilderTest(BaseWpOneDbTest):
 
     mock_create_zimfarm_schedule.assert_called_once_with(redis, self.wp10db,
                                                          self.builder,
-                                                         'test_title',
-                                                         'a', 'zz')
+                                                         title='test_title',
+                                                         description='a',
+                                                         long_description='zz')
     mock_request_zimfarm_task.assert_called_once_with(redis,
                                                       self.wp10db,
                                                       self.builder)

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -1284,7 +1284,6 @@ class BuilderTest(BaseWpOneDbTest):
       self.assertEqual(zim_file['z_long_description'], b'Test Long Description')
 
   @patch('wp1.logic.builder.materialize_builder')
-  @patch('wp1.logic.builder.get_builder')
   @patch('wp1.logic.builder.zimfarm.request_zimfarm_task')
   @patch('wp1.logic.builder.wp10_connect')
   @patch('wp1.logic.builder.redis_connect')
@@ -1293,8 +1292,7 @@ class BuilderTest(BaseWpOneDbTest):
          return_value=datetime.datetime(2022, 12, 25, 0, 1, 2))
   def test_request_scheduled_zim_file_for_builder(
       self, mock_utcnow, mock_connect_storage, mock_redis_connect,
-      mock_wp10_connect, mock_request_zimfarm_task, mock_get_builder,
-      mock_materialize_builder):
+      mock_wp10_connect, mock_request_zimfarm_task, mock_materialize_builder):
     """Test zimfile request with rebuild_selection=True"""
     self._insert_builder()
     self._insert_selection(1,
@@ -1308,8 +1306,6 @@ class BuilderTest(BaseWpOneDbTest):
     mock_connect_storage.return_value = s3_mock
 
     mock_request_zimfarm_task.return_value = 'test_task_id_456'
-
-    mock_get_builder.return_value = self.builder
     
     with patch('wp1.logic.builder.importlib.import_module') as mock_import:
       mock_module = MagicMock()
@@ -1324,11 +1320,10 @@ class BuilderTest(BaseWpOneDbTest):
       )
     
     self.assertEqual('test_task_id_456', actual)
-    mock_get_builder.assert_called_once_with(self.wp10db, self.builder.b_id)
     mock_materialize_builder.assert_called_once()
     mock_request_zimfarm_task.assert_called_once()
 
-  @patch('wp1.logic.builder.get_builder')
+  @patch('wp1.logic.builder.importlib.import_module')
   @patch('wp1.logic.builder.wp10_connect')
   @patch('wp1.logic.builder.redis_connect')
   @patch('wp1.logic.builder.connect_storage')
@@ -1336,7 +1331,7 @@ class BuilderTest(BaseWpOneDbTest):
          return_value=datetime.datetime(2022, 12, 25, 0, 1, 2))
   def test_request_scheduled_zim_file_for_builder_missing_class(
       self, mock_utcnow, mock_connect_storage, mock_redis_connect,
-      mock_wp10_connect, mock_get_builder):
+      mock_wp10_connect, mock_import_module):
     """Test zimfile request with missing builder class in module"""
     self._insert_builder()
     self._insert_selection(1,
@@ -1349,23 +1344,19 @@ class BuilderTest(BaseWpOneDbTest):
     mock_redis_connect.return_value = redis_mock
     mock_connect_storage.return_value = s3_mock
     
-    mock_get_builder.return_value = self.builder
-    
-    with patch('wp1.logic.builder.importlib.import_module') as mock_import:
-      mock_module = MagicMock()
-      mock_module.Builder = None  # Simulate missing Builder class 
-      mock_import.return_value = mock_module
-      with self.assertRaises(ImportError) as cm:
-          actual = logic_builder.request_scheduled_zim_file_for_builder(
-              builder=self.builder,
-              title='Test Title',
-              description='Test Description',
-              long_description='Test Long Description'
-          )
-      self.assertIn('Builder class not found in module', str(cm.exception)) 
-      
+    mock_module = MagicMock()
+    mock_module.Builder = None  # Simulate missing Builder class 
+    mock_import_module.return_value = mock_module
+    with self.assertRaises(ImportError) as cm:
+        actual = logic_builder.request_scheduled_zim_file_for_builder(
+            builder=self.builder,
+            title='Test Title',
+            description='Test Description',
+            long_description='Test Long Description'
+        )
+
+  @patch('wp1.logic.builder.importlib.import_module')
   @patch('wp1.logic.builder.materialize_builder')
-  @patch('wp1.logic.builder.get_builder')
   @patch('wp1.logic.builder.zimfarm.request_zimfarm_task')
   @patch('wp1.logic.builder.wp10_connect')
   @patch('wp1.logic.builder.redis_connect')
@@ -1378,8 +1369,8 @@ class BuilderTest(BaseWpOneDbTest):
                                                   mock_redis_connect,
                                                   mock_wp10_connect,
                                                   mock_request_zimfarm_task,
-                                                  mock_get_builder,
-                                                  mock_materialize_builder):
+                                                  mock_materialize_builder,
+                                                  mock_import_module):
     """Test zimfile request with rebuild_selection=True"""
     self._insert_builder()
     self._insert_selection(1, 'text/tab-separated-values', builder_id=self.builder.b_id)
@@ -1399,24 +1390,20 @@ class BuilderTest(BaseWpOneDbTest):
     
     mock_request_zimfarm_task.return_value = 'test_task_id_456'
     
-    mock_get_builder.return_value = self.builder
+    mock_module = MagicMock()
+    mock_builder_cls = MagicMock()
+    mock_module.Builder = mock_builder_cls
+    mock_import_module.return_value = mock_module
     
-    with patch('wp1.logic.builder.importlib.import_module') as mock_import:
-      mock_module = MagicMock()
-      mock_builder_cls = MagicMock()
-      mock_module.Builder = mock_builder_cls
-      mock_import.return_value = mock_module
-      
-      actual = logic_builder.request_scheduled_zim_file_for_builder(
-          builder=self.builder,
-          title='Test Title',
-          description='Test Description',
-          long_description='Test Long Description',
-          zim_schedule_id='schedule_123'
-      )
+    actual = logic_builder.request_scheduled_zim_file_for_builder(
+        builder=self.builder,
+        title='Test Title',
+        description='Test Description',
+        long_description='Test Long Description',
+        zim_schedule_id='schedule_123'
+    )
     
     self.assertEqual('test_task_id_456', actual)
-    mock_get_builder.assert_called_once_with(self.wp10db, self.builder.b_id)
     mock_materialize_builder.assert_called_once()
     mock_request_zimfarm_task.assert_called_once()
 

--- a/wp1/logic/zim_schedules.py
+++ b/wp1/logic/zim_schedules.py
@@ -37,6 +37,22 @@ def update_zim_schedule(wp10db, zim_schedule : ZimSchedule):
   return updated
 
 
+def update_zim_schedule_zim_file_id(wp10db, schedule_id, zim_file_id):
+  """Updates the s_zim_file_id of a ZimSchedule by its s_id. Returns True if updated."""
+  updated_at = utcnow().strftime(TS_FORMAT_WP10).encode('utf-8')
+  with wp10db.cursor() as cursor:
+    cursor.execute(
+      '''UPDATE zim_schedules SET
+         s_zim_file_id = %s,
+         s_last_updated_at = %s
+         WHERE s_id = %s
+      ''', (zim_file_id, updated_at, schedule_id)
+    )
+    updated = bool(cursor.rowcount)
+  wp10db.commit()
+  return updated
+
+
 def get_zim_schedule(wp10db, schedule_id):
   """Retrieves a ZimSchedule by its s_id. Returns a ZimSchedule or None."""
   with wp10db.cursor() as cursor:

--- a/wp1/logic/zim_schedules_test.py
+++ b/wp1/logic/zim_schedules_test.py
@@ -8,6 +8,7 @@ from wp1.logic.zim_schedules import (
     get_zim_schedule,
     list_zim_schedules_for_builder,
     update_zim_schedule,
+    update_zim_schedule_zim_file_id,
     decrement_remaining_generations,
     get_scheduled_zimfarm_task_from_taskid
 )
@@ -76,6 +77,14 @@ class LogicZimSchedulesTest(BaseWpOneDbTest):
     self.assertEqual(5, fetched.s_interval)
     self.assertEqual(10, fetched.s_remaining_generations)
     self.assertEqual(schedule.s_last_updated_at, fetched.s_last_updated_at)
+
+  def test_update_schedule_zim_file_id(self):
+    zim_schedule = self.new_schedule(interval=1, remaining=1)
+    insert_zim_schedule(self.wp10db, zim_schedule)
+    ok = update_zim_schedule_zim_file_id(self.wp10db, zim_schedule.s_id, 999)
+    self.assertTrue(ok)
+    fetched = get_zim_schedule(self.wp10db, zim_schedule.s_id)
+    self.assertEqual(999, fetched.s_zim_file_id)
 
   def test_decrement_remaining_generations(self):
     schedule = self.new_schedule(remaining=2)

--- a/wp1/models/wp10/zim_schedule.py
+++ b/wp1/models/wp10/zim_schedule.py
@@ -17,11 +17,11 @@ class ZimSchedule:
   s_id: bytes = attr.ib()
   s_builder_id: bytes = attr.ib()
   s_rq_job_id: bytes = attr.ib()
-  s_last_updated_at: bytes = attr.ib()
   s_zim_file_id: int = attr.ib(default=None)
   s_interval: int = attr.ib(default=None)  # in months
   s_email: bytes = attr.ib(default=None)  # Email to notify when the zim generation is done
   s_remaining_generations: int = attr.ib(default=None)  # how many more ZIMs to generate
+  s_last_updated_at: bytes = attr.ib(default=None)
 
   def set_id(self):
     self.s_id = str(uuid.uuid4()).encode('utf-8')

--- a/wp1/queues.py
+++ b/wp1/queues.py
@@ -1,10 +1,6 @@
-from datetime import datetime, timedelta, UTC
-from dateutil.relativedelta import relativedelta
+from datetime import  timedelta
 import logging
-import uuid
 
-from pymysql import Connection
-from redis import Redis
 from rq import Queue
 import rq.exceptions
 from rq.job import Job
@@ -15,9 +11,6 @@ from wp1 import custom_tables
 from wp1.environment import Environment
 import wp1.logic.builder as logic_builder
 import wp1.logic.project as logic_project
-import wp1.logic.zim_schedules as logic_zim_schedules
-from wp1.models.wp10.zim_schedule import ZimSchedule
-from wp1.models.wp10.builder import Builder
 from wp1.wiki_db import connect as wiki_connect
 from wp1 import logs
 from wp1 import tables
@@ -193,52 +186,19 @@ def poll_for_zim_file_status(redis, task_id):
   scheduler.enqueue_in(timedelta(minutes=2),
                        logic_builder.on_zim_file_status_poll, task_id)
 
-def schedule_future_zimfile_generations(redis: Redis,
-                                        wp10db: Connection,
-                                        builder: Builder,
-                                        title: str,
-                                        description: str,
-                                        long_description: str,
-                                        scheduled_repetitions: dict):
-  """
-  Schedule future ZIM file creations using rq-scheduler.
-  """
-  required_keys = {'repetition_period_in_months', 'number_of_repetitions', 'email'}
-  has_min_required_keys = required_keys <= scheduled_repetitions.keys()
-  if not isinstance(scheduled_repetitions, dict) or not has_min_required_keys:
-    raise ValueError(f'scheduled_repetitions must be a dict containing {required_keys}')
 
+def schedule_recurring_zimfarm_task(redis, args, scheduled_time, interval_seconds, repeat_count):
+  """Schedule a recurring zimfarm task using rq-scheduler."""
   queue = _get_zimfile_scheduling_queue(redis)
   scheduler = Scheduler(connection=queue.connection, queue=queue)
-
-  period_months = scheduled_repetitions['repetition_period_in_months']
-  # For simplicity, we assume 30 days per month and 24 hours per day to calculate the interval.
-  interval_seconds = period_months * constants.SECONDS_PER_MONTH
-  first_future_run = datetime.now(UTC) + relativedelta(seconds=interval_seconds)
-
-  num_scheduled_repetitions = scheduled_repetitions['number_of_repetitions']
-
-  zim_schedule_id = str(uuid.uuid4())
-
+  
   job = scheduler.schedule(
-    scheduled_time=first_future_run,
+    scheduled_time=scheduled_time,
     func=logic_builder.request_scheduled_zim_file_for_builder,
-    args=[builder, title, description, long_description, zim_schedule_id],
+    args=args,
     interval=interval_seconds,
-    repeat=num_scheduled_repetitions - 1,  # Repeat for the specified number of repetitions minus the first one
+    repeat=repeat_count,
     queue_name='zimfile-scheduling',
   )
-
-  zim_schedule = ZimSchedule(
-      s_id=zim_schedule_id.encode('utf-8'),
-      s_builder_id=builder.b_id,
-      s_zim_file_id=None,
-      s_rq_job_id=job.id.encode('utf-8'),
-      s_interval=period_months,
-      s_remaining_generations=num_scheduled_repetitions,
-      # s_email=scheduled_repetitions['email'].encode('utf-8')
-  )
-  zim_schedule.set_last_updated_at_now()
-  logic_zim_schedules.insert_zim_schedule(wp10db, zim_schedule)
-
-  return job.id
+  
+  return job

--- a/wp1/queues.py
+++ b/wp1/queues.py
@@ -217,17 +217,19 @@ def schedule_future_zimfile_generations(redis: Redis,
   # For simplicity, we assume 30 days per month and 24 hours per day to calculate the interval.
   interval_seconds = period_months * 30 * 24 * 3600
 
+  zim_schedule_id = str(uuid.uuid4())
+
   job = scheduler.schedule(
     scheduled_time=first_future_run,
     func=logic_builder.request_scheduled_zim_file_for_builder,
-    args=[builder, title, description, long_description],
+    args=[builder, title, description, long_description, zim_schedule_id],
     interval=interval_seconds,
     repeat=num_scheduled_repetitions,
     queue_name='zimfile-scheduling',
   )
 
   zim_schedule = ZimSchedule(
-      s_id=str(uuid.uuid4()).encode('utf-8'),
+      s_id=zim_schedule_id.encode('utf-8'),
       s_builder_id=builder.b_id,
       s_zim_file_id=None,
       s_rq_job_id=job.id.encode('utf-8'),

--- a/wp1/queues.py
+++ b/wp1/queues.py
@@ -211,7 +211,9 @@ def schedule_future_zimfile_generations(redis: Redis,
   scheduler = Scheduler(connection=queue.connection, queue=queue)
 
   period_months = scheduled_repetitions['repetition_period_in_months']
-  num_scheduled_repetitions = scheduled_repetitions['number_of_repetitions']
+  # Calculate the number of scheduled repetitions minus one, 
+  # since the first run is still considered a repetition.
+  num_scheduled_repetitions = scheduled_repetitions['number_of_repetitions'] - 1
   first_future_run = datetime.now(UTC) + relativedelta(months=period_months)
 
   # For simplicity, we assume 30 days per month and 24 hours per day to calculate the interval.

--- a/wp1/queues_test.py
+++ b/wp1/queues_test.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, patch, MagicMock
 
 import fakeredis
 
@@ -226,7 +226,8 @@ class QueuesTest(BaseWpOneDbTest):
     mock_scheduler.return_value.schedule.assert_called_once()
     _, call_kwargs = mock_scheduler.return_value.schedule.call_args
     self.assertEqual(queues.logic_builder.request_scheduled_zim_file_for_builder, call_kwargs['func'])
-    expected_args = [builder, title, description, long_description]
+
+    expected_args = [builder, title, description, long_description, ANY]
     self.assertEqual(expected_args, call_kwargs['args'])
     expected_interval = scheduled_repetitions['repetition_period_in_months'] * 30 * 24 * 3600
     self.assertEqual(expected_interval, call_kwargs['interval'])

--- a/wp1/queues_test.py
+++ b/wp1/queues_test.py
@@ -231,7 +231,7 @@ class QueuesTest(BaseWpOneDbTest):
     self.assertEqual(expected_args, call_kwargs['args'])
     expected_interval = scheduled_repetitions['repetition_period_in_months'] * 30 * 24 * 3600
     self.assertEqual(expected_interval, call_kwargs['interval'])
-    self.assertEqual(scheduled_repetitions['number_of_repetitions'], call_kwargs['repeat'])
+    self.assertEqual(scheduled_repetitions['number_of_repetitions'] - 1, call_kwargs['repeat'])
     self.assertEqual('zimfile-scheduling', call_kwargs['queue_name'])
 
     with self.wp10db.cursor() as cursor:

--- a/wp1/queues_test.py
+++ b/wp1/queues_test.py
@@ -242,7 +242,7 @@ class QueuesTest(BaseWpOneDbTest):
       self.assertEqual(b'builder-id', zim_schedule['s_builder_id'])
       self.assertEqual(b'job-id', zim_schedule['s_rq_job_id'])
       self.assertEqual(scheduled_repetitions['repetition_period_in_months'], zim_schedule['s_interval'])
-      self.assertEqual(scheduled_repetitions['number_of_repetitions'], zim_schedule['s_remaining_generations'])
+      self.assertEqual(scheduled_repetitions['number_of_repetitions'] - 1, zim_schedule['s_remaining_generations'])
   
   def test_schedule_future_zimfile_generations_missing_fields(self):
     

--- a/wp1/queues_test.py
+++ b/wp1/queues_test.py
@@ -227,19 +227,10 @@ class QueuesTest(BaseWpOneDbTest):
       scheduled_time=ANY,
       func=queues.logic_builder.request_scheduled_zim_file_for_builder,
       args=[builder, title, description, long_description, 'uuid-1'],
-      interval=two_months_in_seconds
+      interval=two_months_in_seconds,
       repeat=scheduled_repetitions['number_of_repetitions'] - 1,
       queue_name='zimfile-scheduling',
     )
-    _, call_kwargs = mock_scheduler.return_value.schedule.call_args
-    self.assertEqual(queues.logic_builder.request_scheduled_zim_file_for_builder, call_kwargs['func'])
-
-    expected_args = [builder, title, description, long_description, ANY]
-    self.assertEqual(expected_args, call_kwargs['args'])
-    expected_interval = two_months_in_seconds
-    self.assertEqual(expected_interval, call_kwargs['interval'])
-    self.assertEqual(scheduled_repetitions['number_of_repetitions'] - 1, call_kwargs['repeat'])
-    self.assertEqual('zimfile-scheduling', call_kwargs['queue_name'])
 
     with self.wp10db.cursor() as cursor:
       cursor.execute('SELECT * FROM zim_schedules WHERE s_id = %s', (b'uuid-1',))

--- a/wp1/queues_test.py
+++ b/wp1/queues_test.py
@@ -6,6 +6,8 @@ import fakeredis
 from wp1 import constants, queues
 from wp1.base_db_test import BaseWpOneDbTest
 from wp1.environment import Environment
+from wp1 import queues  
+from wp1.models.wp10.builder import Builder
 from wp1.selection.models.simple import Builder as SimpleBuilder
 
 
@@ -176,3 +178,73 @@ class QueuesTest(BaseWpOneDbTest):
         'text/tab-separated-values',
         job_timeout=constants.JOB_TIMEOUT,
         failure_ttl=constants.JOB_FAILURE_TTL)
+
+  @patch('wp1.queues.Queue')
+  @patch('wp1.queues.Scheduler')
+  def test_poll_for_zim_file_status(self, patched_scheduler, patched_queue):
+    poll_q_mock = MagicMock()
+    patched_queue.return_value = poll_q_mock
+    scheduler_mock = MagicMock()
+    patched_scheduler.return_value = scheduler_mock
+
+    queues.poll_for_zim_file_status(self.redis, '1234')
+
+    scheduler_mock.enqueue_in.assert_called_once()
+
+  @patch('wp1.queues.Scheduler')
+  @patch('wp1.queues.uuid.uuid4')
+  @patch('wp1.queues.logic_zim_schedules.insert_zim_schedule')
+  def test_schedule_future_zimfile_generations(self, patched_insert, patched_uuid4, patched_scheduler):
+    # Prepare a fake builder and parameters
+    mock_builder = Builder(
+        b_id=b'builder-id',
+        b_name=b'Test Builder',
+        b_user_id=b'1234',
+        b_project=b'en.wikipedia.fake',
+        b_model=b'wp1.selection.models.simple',
+        b_params=b'{}',
+    )
+    title = 'Title'
+    description = 'Description'
+    long_description = 'Long Description'
+    scheduled_repetitions = {
+        'repetition_period_in_months': 2,
+        'number_of_repetitions': 3,
+        'email': 'user@example.com'
+    }
+    # Fake job returned by scheduler
+    job_mock = MagicMock()
+    job_mock.id = 'job-id'
+    patched_scheduler.return_value.schedule.return_value = job_mock
+    patched_uuid4.return_value = 'uuid-1'
+
+    # Call the function under test
+    result = queues.schedule_future_zimfile_generations(
+        self.redis, self.wp10db,
+        mock_builder, title, description, long_description,
+        scheduled_repetitions
+    )
+
+    # Should return the job ID
+    self.assertEqual(result, job_mock.id)
+    # Verify scheduler.schedule was called with correct parameters
+    patched_scheduler.return_value.schedule.assert_called_once()
+    _, call_kwargs = patched_scheduler.return_value.schedule.call_args
+    self.assertEqual(queues.logic_builder.request_scheduled_zim_file_for_builder, call_kwargs['func'])
+    expected_args = [mock_builder, title, description, long_description]
+    self.assertEqual(expected_args, call_kwargs['args'])
+    expected_interval = scheduled_repetitions['repetition_period_in_months'] * 30 * 24 * 3600
+    self.assertEqual(expected_interval, call_kwargs['interval'])
+    self.assertEqual(scheduled_repetitions['number_of_repetitions'], call_kwargs['repeat'])
+    self.assertEqual('zimfile-scheduling', call_kwargs['queue_name'])
+
+    # Verify insert_zim_schedule call and attributes on the model
+    patched_insert.assert_called_once()
+    insert_args = patched_insert.call_args[0]
+    self.assertIs(insert_args[0], self.wp10db)
+    zim_schedule = insert_args[1]
+    self.assertEqual(b'uuid-1', zim_schedule.s_id)
+    self.assertEqual(b'builder-id', zim_schedule.s_builder_id)
+    self.assertEqual(b'job-id', zim_schedule.s_rq_job_id)
+    self.assertEqual(scheduled_repetitions['repetition_period_in_months'], zim_schedule.s_interval)
+    self.assertEqual(scheduled_repetitions['number_of_repetitions'], zim_schedule.s_remaining_generations)

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -1,4 +1,3 @@
-import importlib
 import logging
 
 import flask
@@ -30,10 +29,10 @@ def _create_or_update_builder(wp10db, data, builder_id=None):
   if not list_name or not project or not model or not params:
     return 'Missing list_name or project or model or params', 400
 
-  builder_module = importlib.import_module(model)
-  builder_cls = getattr(builder_module, 'Builder')
-  if builder_cls is None:
-    logger.warning('Could not find model: %s', model)
+  try:
+    builder_cls = logic_builder.get_builder_module_class(model)
+  except ImportError as e:
+    logger.warning(str(e))
     flask.abort(400)
 
   builder_obj = builder_cls()

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -9,6 +9,7 @@ from wp1.models.wp10.builder import Builder
 from wp1.web.app import create_app
 from wp1.web.base_web_testcase import BaseWebTestcase
 from wp1.zimfarm import MAX_ZIMFARM_ARTICLE_COUNT
+from wp1.web.builders import _create_or_update_builder
 
 
 class BuildersTest(BaseWebTestcase):
@@ -160,6 +161,22 @@ class BuildersTest(BaseWebTestcase):
                            'project': 'my_project'
                        })
       self.assertEqual(self.successful_response, rv.get_json())
+
+  def test_create_throws(self):
+    self.app = create_app()
+    with self.app.test_client() as client, self.override_db(self.app):
+      with client.session_transaction() as sess:
+        sess['user'] = self.USER
+      rv = client.post('/v1/builders/',
+               json={
+                 'model': 'fake_model',
+                 'params': {
+                   'list': self.valid_article_name
+                 },
+                 'name': 'my_list',
+                 'project': 'my_project'
+               })
+      self.assertEqual('400 BAD REQUEST', rv.status)
 
   def test_update_unsuccessful(self):
     builder_id = self._insert_builder()

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -452,7 +452,9 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('404 NOT FOUND', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  def test_create_zim_file_for_builder(self, patched_request_zimfarm_task):
+  @patch('wp1.zimfarm.create_zimfarm_schedule')
+  def test_create_zim_file_for_builder(
+      self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -479,8 +481,9 @@ class BuildersTest(BaseWebTestcase):
     self.assertEqual(b'REQUESTED', data['z_status'])
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  def test_create_zim_file_for_builder_not_found(self,
-                                                 patched_request_zimfarm_task):
+  @patch('wp1.zimfarm.create_zimfarm_schedule')
+  def test_create_zim_file_for_builder_not_found(
+      self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -496,8 +499,9 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('404 NOT FOUND', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
+  @patch('wp1.zimfarm.create_zimfarm_schedule')
   def test_create_zim_file_for_builder_unauthorized(
-      self, patched_request_zimfarm_task):
+      self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -513,7 +517,9 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('403 FORBIDDEN', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  def test_create_zim_file_for_builder_500(self, patched_request_zimfarm_task):
+  @patch('wp1.zimfarm.create_zimfarm_schedule')
+  def test_create_zim_file_for_builder_500(
+      self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -543,8 +549,9 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('400 BAD REQUEST', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  def test_create_zim_file_for_builder_no_title(self,
-                                                patched_request_zimfarm_task):
+  @patch('wp1.zimfarm.create_zimfarm_schedule')
+  def test_create_zim_file_for_builder_no_title(
+      self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -568,8 +575,9 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('400 BAD REQUEST', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
+  @patch('wp1.zimfarm.create_zimfarm_schedule')
   def test_create_zim_file_for_builder_scheduled_repetitions(
-      self, patched_request_zimfarm_task):
+      self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -617,8 +625,9 @@ class BuildersTest(BaseWebTestcase):
                     rv.data.decode('utf-8'))
 
   @patch('wp1.zimfarm.request_zimfarm_task')
+  @patch('wp1.zimfarm.create_zimfarm_schedule')
   def test_create_zim_file_for_builder_scheduled_repetitions_not_dict(
-      self, patched_request_zimfarm_task):
+      self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -637,8 +646,9 @@ class BuildersTest(BaseWebTestcase):
                     rv.data.decode('utf-8'))
 
   @patch('wp1.zimfarm.request_zimfarm_task')
+  @patch('wp1.zimfarm.create_zimfarm_schedule')
   def test_create_zim_file_for_builder_scheduled_repetitions_empty_dict(
-      self, patched_request_zimfarm_task):
+      self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -656,8 +666,9 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('204 NO CONTENT', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
+  @patch('wp1.zimfarm.create_zimfarm_schedule')
   def test_create_zim_file_for_builder_scheduled_repetitions_extra_fields(
-      self, patched_request_zimfarm_task):
+      self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -173,17 +173,17 @@ def _validate_zim_metadata(title=None, description=None, long_description=None):
 def get_zimfarm_schedule_name(builder_id: str) -> str:
     """Generate a unique schedule name for the ZIM file based on builder"""
     if not builder_id:
-        raise ObjectNotFoundError('Builder ID cannot be None')
+        raise ValueError('Builder ID cannot be None')
     parts = builder_id.split('-')
     # Use last two parts of the UUIDv4 for more uniqueness
     short_id = ''.join(parts[-2:])
-    return f'wp1_builder_{short_id}'
+    return f'wp1_selection_{short_id}'
 
 
 def get_zim_filename_prefix(builder: Builder, selection: Selection) -> str:
   """Generate a filename prefix for the ZIM file based on builder and selection."""
   if builder is None or selection is None:
-    raise ObjectNotFoundError(f"Given builder or selection was None")
+    raise ValueError(f"Given builder or selection was None")
 
   selection_id_frag = selection.s_id.decode('utf-8').split('-')[-1]
   builder_name = builder.b_name.decode('utf-8')
@@ -196,7 +196,7 @@ def _get_params(builder: Builder,
                 description: str = '',
                 long_description: str = '') -> dict:
   if builder is None:
-    raise ObjectNotFoundError('Given builder was None: %r' % builder)
+    raise ValueError('Given builder was None: %r' % builder)
 
   project = builder.b_project.decode('utf-8')
 

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -295,9 +295,7 @@ def request_zimfarm_task(s3,
         (article_count if article_count is not None else 'UNKNOWN number of',
          MAX_ZIMFARM_ARTICLE_COUNT))
 
-  params = _get_params(s3,
-                       wp10db,
-                       builder,
+  params = _get_params(builder,
                        selection,
                        title=title,
                        description=description,

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -225,7 +225,7 @@ def _get_params(builder: Builder,
           'forceRender':
               'ActionParse',
           'articleList':
-              logic_selection.url_for_selection(selection),
+              logic_builder.latest_url_for(builder.b_id.decode('utf-8'), selection.s_content_type.decode('utf-8')),
           'customZimTitle':
               title,
           'customZimDescription':

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -331,10 +331,6 @@ def request_zimfarm_task(s3,
   except requests.exceptions.HTTPError as e:
     logger.exception(r.text)
     raise ZimFarmError('Error requesting task for ZIM file creation') from e
-  finally:
-    logger.info('Deleting schedule for builder id=%s', builder_id)
-    requests.delete('%s/schedules/%s' % (base_url, params['name']),
-                    headers=headers)
 
   return task_id
 

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -170,14 +170,14 @@ def _validate_zim_metadata(title=None, description=None, long_description=None):
         f"Long description must be different from the description.")
 
 
-def get_zimfarm_schedule_name(selection_id: str) -> str:
-    """Generate a unique schedule name for the ZIM file based on builder and selection."""
-    if not selection_id:
-        raise ObjectNotFoundError('Selection ID cannot be None')
-    parts = selection_id.split('-')
+def get_zimfarm_schedule_name(builder_id: str) -> str:
+    """Generate a unique schedule name for the ZIM file based on builder"""
+    if not builder_id:
+        raise ObjectNotFoundError('Builder ID cannot be None')
+    parts = builder_id.split('-')
     # Use last two parts of the UUIDv4 for more uniqueness
     short_id = ''.join(parts[-2:])
-    return f'wp1_selection_{short_id}'
+    return f'wp1_builder_{short_id}'
 
 
 def get_zim_filename_prefix(builder: Builder, selection: Selection) -> str:
@@ -247,7 +247,7 @@ def _get_params(builder: Builder,
   webhook_url = get_webhook_url()
 
   return {
-      'name': get_zimfarm_schedule_name(selection.s_id.decode('utf-8')),
+      'name': get_zimfarm_schedule_name(builder.b_id.decode('utf-8')),
       'language': {
           'code': 'eng',
           'name_en': 'English',
@@ -304,7 +304,7 @@ def request_zimfarm_task(s3,
   headers = _get_zimfarm_headers(token)
 
   builder_id = builder.b_id.decode('utf-8')
-  logger.info('Creating schedule for ZIM for builder id=%s', builder_id)
+  logger.info('Creating zimfarm schedule for ZIM for builder id=%s', builder_id)
   r = requests.post('%s/schedules/' % base_url, headers=headers, json=params)
 
   try:

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -341,19 +341,21 @@ def request_zimfarm_task(redis,
   base_url = get_zimfarm_url()
   headers = _get_zimfarm_headers(token)
 
+  schedule_name = get_zimfarm_schedule_name(builder.b_id.decode('utf-8'))
+
   logger.info('Creating ZIM task for builder id=%s', builder.b_id.decode('utf-8'))
   r = requests.post('%s/requested-tasks/' % base_url,
                     headers=headers,
-                    json={'schedule_names': [get_zimfarm_schedule_name(builder.b_id.decode('utf-8')),]})
-
+                    json={'schedule_names': [schedule_name]})
+  print (f"r: {r}")
   try:
     r.raise_for_status()
-
+    print (f"r status: {r.status_code}")
     data = r.json()
     requested = data.get('requested')
     task_id = requested[0] if requested else None
     logger.info('Found task id=%s for builder id=%s', task_id, builder.b_id.decode('utf-8'))
-
+    print (f"task_id: {task_id}")
     if task_id is None:
       raise ZimFarmError('Did not get scheduled task id')
   except requests.exceptions.HTTPError as e:

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -347,15 +347,12 @@ def request_zimfarm_task(redis,
   r = requests.post('%s/requested-tasks/' % base_url,
                     headers=headers,
                     json={'schedule_names': [schedule_name]})
-  print (f"r: {r}")
   try:
     r.raise_for_status()
-    print (f"r status: {r.status_code}")
     data = r.json()
     requested = data.get('requested')
     task_id = requested[0] if requested else None
     logger.info('Found task id=%s for builder id=%s', task_id, builder.b_id.decode('utf-8'))
-    print (f"task_id: {task_id}")
     if task_id is None:
       raise ZimFarmError('Did not get scheduled task id')
   except requests.exceptions.HTTPError as e:

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -357,6 +357,14 @@ class ZimFarmTest(BaseWpOneDbTest):
 
     self.assertEqual(actual, 'bcdefg')
 
+  @patch('wp1.zimfarm.get_zimfarm_token')
+  def test_create_zimfarm_schedule_missing_token(self, get_token_mock):
+    redis = MagicMock()
+    get_token_mock.return_value = None
+
+    with self.assertRaises(ZimFarmError):
+      zimfarm.create_zimfarm_schedule(redis, self.wp10db, None)
+
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   def test_create_zimfarm_schedule_missing_builder(self, get_token_mock,
@@ -412,24 +420,6 @@ class ZimFarmTest(BaseWpOneDbTest):
                                       self.builder,
                                       title='a',
                                       description='b')
-
-  @patch('wp1.zimfarm.requests')
-  @patch('wp1.zimfarm.get_zimfarm_token')
-  @patch('wp1.zimfarm._get_params')
-  def test_schedule_zim_valid_graphemes(self, get_params_mock, get_token_mock,
-                                        mock_requests):
-    redis = MagicMock()
-    mock_response = MagicMock()
-    mock_response.json.return_value = {'requested': ['9876']}
-    mock_requests.post.side_effect = (MagicMock(), mock_response, MagicMock())
-
-    valid_title = "में" * (ZIM_TITLE_MAX_LENGTH)
-    zimfarm.create_zimfarm_schedule(redis,
-            self.wp10db,
-            self.builder,
-            title=valid_title,
-            description='b')
-    mock_requests.post.assert_called_once()
 
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
@@ -509,7 +499,32 @@ class ZimFarmTest(BaseWpOneDbTest):
                                       description='bb',
                                       long_description='bb')
 
+  @patch('wp1.zimfarm.requests')
+  @patch('wp1.zimfarm.get_zimfarm_token')
+  @patch('wp1.zimfarm._get_params')
+  def test_create_zimfarm_schedule_valid_graphemes(self, get_params_mock, get_token_mock,
+                                        mock_requests):
+    redis = MagicMock()
+    mock_response = MagicMock()
+    mock_response.json.return_value = {'requested': ['9876']}
+    mock_requests.post.side_effect = (MagicMock(), mock_response, MagicMock())
 
+    valid_title = "में" * (ZIM_TITLE_MAX_LENGTH)
+    zimfarm.create_zimfarm_schedule(redis,
+            self.wp10db,
+            self.builder,
+            title=valid_title,
+            description='b')
+    mock_requests.post.assert_called_once()
+
+  @patch('wp1.zimfarm.get_zimfarm_token')
+  def test_request_zimfarm_task_missing_token(self, get_token_mock):
+    redis = MagicMock()
+    get_token_mock.return_value = None
+
+    with self.assertRaises(ZimFarmError):
+      zimfarm.request_zimfarm_task(redis, self.wp10db, self.builder)
+  
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   @patch('wp1.zimfarm.get_zimfarm_schedule_name')

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -27,7 +27,7 @@ from wp1.zimfarm import (
 
 class ZimFarmTest(BaseWpOneDbTest):
   expected_params = {
-      'name': 'wp1_selection_def',
+      'name': 'wp1_selection_12345def',
       'language': {
           'code': 'eng',
           'name_en': 'English',
@@ -68,7 +68,7 @@ class ZimFarmTest(BaseWpOneDbTest):
               'adminEmail':
                   'contact+wp1@kiwix.org',
               'articleList':
-                  'http://credentials.not.found.fake/selections/foo/1234/name.tsv',
+                  'http://test.server.fake/v1/builders/1a-2b-3c-4d/selection/latest.tsv',
               'customZimTitle':
                   'My Builder',
               'filenamePrefix':

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -140,6 +140,25 @@ class ZimFarmTest(BaseWpOneDbTest):
     self._insert_builder()
     self._insert_selection(b'abc-12345-def')
 
+  def test_get_zimfarm_schedule_name_valid(self):
+    selection_id = '123e4567-e89b-12d3-a456-abc123456789'
+    result = zimfarm.get_zimfarm_schedule_name(selection_id)
+    # Should join last two parts: 'a456-abc123456789' -> 'wp1_selection_a456abc123456789'
+    self.assertEqual(result, 'wp1_selection_a456abc123456789')
+
+  def test_get_zimfarm_schedule_name_none(self):
+    with self.assertRaises(ObjectNotFoundError):
+      zimfarm.get_zimfarm_schedule_name(None)
+
+  def test_get_zim_filename_prefix_valid(self):
+    # builder_name: 'My Builder' -> safe_name: 'MyBuilder', selection_id_frag: 'def'
+    result = zimfarm.get_zim_filename_prefix(self.builder, self.selection)
+    self.assertEqual(result, 'MyBuilder-def')
+
+  def test_get_zim_filename_prefix_none(self):
+    with self.assertRaises(ObjectNotFoundError):
+      zimfarm.get_zim_filename_prefix(None, None)
+
   def test_get_params(self):
     s3 = MagicMock()
     s3.client.head_object.return_value = {'ContentLength': 20000000}

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -423,13 +423,6 @@ class ZimFarmTest(BaseWpOneDbTest):
 
     mock_requests.post.assert_has_calls(
         (schedule_create_call, task_request_call))
-    mock_requests.delete.assert_called_once_with(
-        'https://fake.farm/v1/schedules/bar',
-        headers={
-            'Authorization': 'Token abcdef',
-            'User-Agent': 'WP 1.0 bot 1.0.0/Audiodude <audiodude@gmail.com>'
-        },
-    )
 
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
@@ -612,8 +605,6 @@ class ZimFarmTest(BaseWpOneDbTest):
 
     with self.assertRaises(ZimFarmError):
       zimfarm.request_zimfarm_task(s3, redis, self.wp10db, self.builder)
-
-    mock_requests.delete.assert_called_once()
 
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -147,7 +147,7 @@ class ZimFarmTest(BaseWpOneDbTest):
     self.assertEqual(result, 'wp1_selection_a456abc123456789')
 
   def test_get_zimfarm_schedule_name_none(self):
-    with self.assertRaises(ObjectNotFoundError):
+    with self.assertRaises(ValueError):
       zimfarm.get_zimfarm_schedule_name(None)
 
   def test_get_zim_filename_prefix_valid(self):
@@ -156,7 +156,7 @@ class ZimFarmTest(BaseWpOneDbTest):
     self.assertEqual(result, 'MyBuilder-def')
 
   def test_get_zim_filename_prefix_none(self):
-    with self.assertRaises(ObjectNotFoundError):
+    with self.assertRaises(ValueError):
       zimfarm.get_zim_filename_prefix(None, None)
 
   def test_get_params(self):
@@ -202,9 +202,7 @@ class ZimFarmTest(BaseWpOneDbTest):
     self.assertEqual(expected, actual)
 
   def test_get_params_missing_builder(self):
-    s3 = MagicMock()
-
-    with self.assertRaises(ObjectNotFoundError):
+    with self.assertRaises(ValueError):
       zimfarm._get_params(None, self.selection)
 
   @patch('wp1.zimfarm.requests')

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -27,7 +27,7 @@ from wp1.zimfarm import (
 
 class ZimFarmTest(BaseWpOneDbTest):
   expected_params = {
-      'name': 'wp1_builder_3c4d',
+      'name': 'wp1_selection_3c4d',
       'language': {
           'code': 'eng',
           'name_en': 'English',
@@ -143,8 +143,8 @@ class ZimFarmTest(BaseWpOneDbTest):
   def test_get_zimfarm_schedule_name_valid(self):
     builder_id = '123e4567-e89b-12d3-a456-abc123456789'
     result = zimfarm.get_zimfarm_schedule_name(builder_id)
-    # Should join last two parts: 'a456-abc123456789' -> 'wp1_builder_a456abc123456789'
-    self.assertEqual(result, 'wp1_builder_a456abc123456789')
+    # Should join last two parts: 'a456-abc123456789' -> 'wp1_selection_a456abc123456789'
+    self.assertEqual(result, 'wp1_selection_a456abc123456789')
 
   def test_get_zimfarm_schedule_name_none(self):
     with self.assertRaises(ObjectNotFoundError):

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -148,8 +148,6 @@ class ZimFarmTest(BaseWpOneDbTest):
         Environment.TEST]['ZIMFARM']['cache_url'] = 'https://wasabi.fake/bucket'
 
     actual = zimfarm._get_params(
-        s3,
-        self.wp10db,
         self.builder,
         self.selection,
         title='My Builder',
@@ -175,8 +173,6 @@ class ZimFarmTest(BaseWpOneDbTest):
     }
 
     actual = zimfarm._get_params(
-        s3,
-        self.wp10db,
         self.builder,
         self.selection,
         title='My Builder',
@@ -190,7 +186,7 @@ class ZimFarmTest(BaseWpOneDbTest):
     s3 = MagicMock()
 
     with self.assertRaises(ObjectNotFoundError):
-      zimfarm._get_params(s3, self.wp10db, None, self.selection)
+      zimfarm._get_params(None, self.selection)
 
   @patch('wp1.zimfarm.requests')
   def test_request_zimfarm_token(self, mock_requests):

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -27,7 +27,7 @@ from wp1.zimfarm import (
 
 class ZimFarmTest(BaseWpOneDbTest):
   expected_params = {
-      'name': 'wp1_selection_12345def',
+      'name': 'wp1_builder_3c4d',
       'language': {
           'code': 'eng',
           'name_en': 'English',
@@ -141,10 +141,10 @@ class ZimFarmTest(BaseWpOneDbTest):
     self._insert_selection(b'abc-12345-def')
 
   def test_get_zimfarm_schedule_name_valid(self):
-    selection_id = '123e4567-e89b-12d3-a456-abc123456789'
-    result = zimfarm.get_zimfarm_schedule_name(selection_id)
-    # Should join last two parts: 'a456-abc123456789' -> 'wp1_selection_a456abc123456789'
-    self.assertEqual(result, 'wp1_selection_a456abc123456789')
+    builder_id = '123e4567-e89b-12d3-a456-abc123456789'
+    result = zimfarm.get_zimfarm_schedule_name(builder_id)
+    # Should join last two parts: 'a456-abc123456789' -> 'wp1_builder_a456abc123456789'
+    self.assertEqual(result, 'wp1_builder_a456abc123456789')
 
   def test_get_zimfarm_schedule_name_none(self):
     with self.assertRaises(ObjectNotFoundError):


### PR DESCRIPTION
- Added a new function `schedule_future_zimfile_generations()` in `queues.py that:
  - calculates next first future xim generation run and interval in months (1 month=30days)
  - schedules future zim-generations
  - inserts schedule in the DB

- Added call to `schedule_future_zimfile_generations()` function in `handle_zim_generations()`
- Added tests

Fixes #911 