### PR TITLE
Remove polling from zim status update

### DIFF
--- a/wp1/queues_test.py
+++ b/wp1/queues_test.py
@@ -1,12 +1,11 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import fakeredis
 
+from wp1 import constants, queues
 from wp1.base_db_test import BaseWpOneDbTest
-from wp1 import constants
 from wp1.environment import Environment
-from wp1 import queues
 from wp1.selection.models.simple import Builder as SimpleBuilder
 
 
@@ -177,15 +176,3 @@ class QueuesTest(BaseWpOneDbTest):
         'text/tab-separated-values',
         job_timeout=constants.JOB_TIMEOUT,
         failure_ttl=constants.JOB_FAILURE_TTL)
-
-  @patch('wp1.queues.Queue')
-  @patch('wp1.queues.Scheduler')
-  def test_poll_for_zim_file_status(self, patched_scheduler, patched_queue):
-    poll_q_mock = MagicMock()
-    patched_queue.return_value = poll_q_mock
-    scheduler_mock = MagicMock()
-    patched_scheduler.return_value = scheduler_mock
-
-    queues.poll_for_zim_file_status(self.redis, '1234')
-
-    scheduler_mock.enqueue_in.assert_called_once()

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -3,7 +3,8 @@ from unittest.mock import patch
 
 import attr
 
-from wp1.exceptions import ObjectNotFoundError, UserNotAuthorizedError, ZimFarmError
+from wp1.exceptions import (ObjectNotFoundError, UserNotAuthorizedError,
+                            ZimFarmError)
 from wp1.models.wp10.builder import Builder
 from wp1.web.app import create_app
 from wp1.web.base_web_testcase import BaseWebTestcase
@@ -478,8 +479,8 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('404 NOT FOUND', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  def test_create_zim_file_for_builder_unauthorized(self,
-                                                    patched_request_zimfarm_task):
+  def test_create_zim_file_for_builder_unauthorized(
+      self, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -550,8 +551,8 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('400 BAD REQUEST', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  def test_create_zim_file_for_builder_scheduled_repetitions(self,
-                                                                   patched_request_zimfarm_task):
+  def test_create_zim_file_for_builder_scheduled_repetitions(
+      self, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -574,8 +575,8 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('204 NO CONTENT', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  def test_create_zim_file_for_builder_scheduled_repetitions_missing_fields(self,
-                                                                            patched_request_zimfarm_task):
+  def test_create_zim_file_for_builder_scheduled_repetitions_missing_fields(
+      self, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -583,22 +584,24 @@ class BuildersTest(BaseWebTestcase):
     with self.override_db(self.app), self.app.test_client() as client:
       with client.session_transaction() as sess:
         sess['user'] = self.USER
-      rv = client.post('/v1/builders/%s/zim' % builder_id,
-                       json={
-                           'title': 'Test title',
-                           'description': 'Test description',
-                           'scheduled_repetitions': {
-                               'repetition_period_in_months': 6,
-                               'number_of_repetitions': 3
-                               # missing 'email' field
-                           }
-                       })
+      rv = client.post(
+          '/v1/builders/%s/zim' % builder_id,
+          json={
+              'title': 'Test title',
+              'description': 'Test description',
+              'scheduled_repetitions': {
+                  'repetition_period_in_months': 6,
+                  'number_of_repetitions': 3
+                  # missing 'email' field
+              }
+          })
       self.assertEqual('400 BAD REQUEST', rv.status)
-      self.assertIn('Invalid or missing fields in scheduled_repetitions', rv.data.decode('utf-8'))
+      self.assertIn('Invalid or missing fields in scheduled_repetitions',
+                    rv.data.decode('utf-8'))
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  def test_create_zim_file_for_builder_scheduled_repetitions_not_dict(self,
-                                                                      patched_request_zimfarm_task):
+  def test_create_zim_file_for_builder_scheduled_repetitions_not_dict(
+      self, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -613,11 +616,12 @@ class BuildersTest(BaseWebTestcase):
                            'scheduled_repetitions': 'not a dict'
                        })
       self.assertEqual('400 BAD REQUEST', rv.status)
-      self.assertIn('Invalid or missing fields in scheduled_repetitions', rv.data.decode('utf-8'))
+      self.assertIn('Invalid or missing fields in scheduled_repetitions',
+                    rv.data.decode('utf-8'))
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  def test_create_zim_file_for_builder_scheduled_repetitions_empty_dict(self,
-                                                                        patched_request_zimfarm_task):
+  def test_create_zim_file_for_builder_scheduled_repetitions_empty_dict(
+      self, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -635,8 +639,8 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('204 NO CONTENT', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  def test_create_zim_file_for_builder_scheduled_repetitions_extra_fields(self,
-                                                                          patched_request_zimfarm_task):
+  def test_create_zim_file_for_builder_scheduled_repetitions_extra_fields(
+      self, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -659,36 +663,9 @@ class BuildersTest(BaseWebTestcase):
                        })
       self.assertEqual('204 NO CONTENT', rv.status)
 
-  @patch('wp1.web.builders.queues.poll_for_zim_file_status')
-  def test_update_zimfarm_status(self, patched_poll):
-    builder_id = self._insert_builder()
-    self._insert_selections(builder_id)
-
-    self.app = create_app()
-    with self.override_db(self.app), self.app.test_client() as client:
-      with client.session_transaction() as sess:
-        sess['user'] = self.USER
-      rv = client.post('/v1/builders/zim/status?token=hook-token-abc',
-                       json={
-                           '_id': 'task-id-1234',
-                           'foo': 'bar'
-                       })
-      self.assertEqual('204 NO CONTENT', rv.status)
-      patched_poll.assert_called_once()
-
-    with self.wp10db.cursor() as cursor:
-      cursor.execute('SELECT z_status, z_updated_at '
-                     'FROM zim_files WHERE z_task_id = "task-id-1234"')
-      status = cursor.fetchone()
-
-    self.assertIsNotNone(status)
-    self.assertEqual(b'ENDED', status['z_status'])
-    self.assertIsNone(status['z_updated_at'])
-
-  @patch('wp1.web.builders.queues.poll_for_zim_file_status')
   @patch('wp1.logic.selection.utcnow',
          return_value=datetime.datetime(2022, 12, 25, 0, 1, 2))
-  def test_update_zimfarm_status_file_ready(self, patched_utcnow, patched_poll):
+  def test_update_zimfarm_status_file_ready(self, patched_utcnow):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -700,6 +677,7 @@ class BuildersTest(BaseWebTestcase):
                        json={
                            '_id': 'task-id-1234',
                            'foo': 'bar',
+                           'status': 'succeeded',
                            'files': {
                                'zimfile.1234': {
                                    'status': 'uploaded'
@@ -747,8 +725,7 @@ class BuildersTest(BaseWebTestcase):
                        })
       self.assertEqual('400 BAD REQUEST', rv.status)
 
-  @patch('wp1.web.builders.queues.poll_for_zim_file_status')
-  def test_update_zimfarm_status_not_found_task_id(self, patched_poll):
+  def test_update_zimfarm_status_not_found_task_id(self):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -762,8 +739,6 @@ class BuildersTest(BaseWebTestcase):
                            'foo': 'bar'
                        })
       self.assertEqual('204 NO CONTENT', rv.status)
-
-    patched_poll.assert_not_called()
 
   def test_zimfarm_status(self):
     builder_id = self._insert_builder()


### PR DESCRIPTION
This code was seemingly half-baked, in that it is not only unnecessary, but the Schedule worker didn't get deployed until now so it wouldn't have functioned anyways.