### PR TITLE
Use latest selection when creating zimfarm schedules

### DIFF
--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -295,9 +295,7 @@ def request_zimfarm_task(s3,
         (article_count if article_count is not None else 'UNKNOWN number of',
          MAX_ZIMFARM_ARTICLE_COUNT))
 
-  params = _get_params(s3,
-                       wp10db,
-                       builder,
+  params = _get_params(builder,
                        selection,
                        title=title,
                        description=description,

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -225,7 +225,7 @@ def _get_params(builder: Builder,
           'forceRender':
               'ActionParse',
           'articleList':
-              logic_selection.url_for_selection(selection),
+              logic_builder.latest_url_for(builder.b_id.decode('utf-8'), selection.s_content_type.decode('utf-8')),
           'customZimTitle':
               title,
           'customZimDescription':

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -27,7 +27,7 @@ from wp1.zimfarm import (
 
 class ZimFarmTest(BaseWpOneDbTest):
   expected_params = {
-      'name': 'wp1_selection_def',
+      'name': 'wp1_selection_12345def',
       'language': {
           'code': 'eng',
           'name_en': 'English',
@@ -68,7 +68,7 @@ class ZimFarmTest(BaseWpOneDbTest):
               'adminEmail':
                   'contact+wp1@kiwix.org',
               'articleList':
-                  'http://credentials.not.found.fake/selections/foo/1234/name.tsv',
+                  'http://test.server.fake/v1/builders/1a-2b-3c-4d/selection/latest.tsv',
               'customZimTitle':
                   'My Builder',
               'filenamePrefix':

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -140,6 +140,25 @@ class ZimFarmTest(BaseWpOneDbTest):
     self._insert_builder()
     self._insert_selection(b'abc-12345-def')
 
+  def test_get_zimfarm_schedule_name_valid(self):
+    selection_id = '123e4567-e89b-12d3-a456-abc123456789'
+    result = zimfarm.get_zimfarm_schedule_name(selection_id)
+    # Should join last two parts: 'a456-abc123456789' -> 'wp1_selection_a456abc123456789'
+    self.assertEqual(result, 'wp1_selection_a456abc123456789')
+
+  def test_get_zimfarm_schedule_name_none(self):
+    with self.assertRaises(ObjectNotFoundError):
+      zimfarm.get_zimfarm_schedule_name(None)
+
+  def test_get_zim_filename_prefix_valid(self):
+    # builder_name: 'My Builder' -> safe_name: 'MyBuilder', selection_id_frag: 'def'
+    result = zimfarm.get_zim_filename_prefix(self.builder, self.selection)
+    self.assertEqual(result, 'MyBuilder-def')
+
+  def test_get_zim_filename_prefix_none(self):
+    with self.assertRaises(ObjectNotFoundError):
+      zimfarm.get_zim_filename_prefix(None, None)
+
   def test_get_params(self):
     s3 = MagicMock()
     s3.client.head_object.return_value = {'ContentLength': 20000000}

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -148,8 +148,6 @@ class ZimFarmTest(BaseWpOneDbTest):
         Environment.TEST]['ZIMFARM']['cache_url'] = 'https://wasabi.fake/bucket'
 
     actual = zimfarm._get_params(
-        s3,
-        self.wp10db,
         self.builder,
         self.selection,
         title='My Builder',
@@ -175,8 +173,6 @@ class ZimFarmTest(BaseWpOneDbTest):
     }
 
     actual = zimfarm._get_params(
-        s3,
-        self.wp10db,
         self.builder,
         self.selection,
         title='My Builder',
@@ -190,7 +186,7 @@ class ZimFarmTest(BaseWpOneDbTest):
     s3 = MagicMock()
 
     with self.assertRaises(ObjectNotFoundError):
-      zimfarm._get_params(s3, self.wp10db, None, self.selection)
+      zimfarm._get_params(None, self.selection)
 
   @patch('wp1.zimfarm.requests')
   def test_request_zimfarm_token(self, mock_requests):


### PR DESCRIPTION
Refactor schedule name and zimfile name generation.
Use latest selection from api when creating ZIMFARM schedules.

Fixes #947 