### PR TITLE
Associate zimfarm schedule with builder

### DIFF
--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -475,14 +475,14 @@ def request_scheduled_zim_file_for_builder(builder: Builder,
   return task_id
 
 def handle_zim_generation(s3,
-                      redis,
-                      wp10db,
-                      builder_id,
-                      user_id=None,
-                      title='',
-                      description='',
-                      long_description=None,
-                      scheduled_repetitions=None):
+                          redis,
+                          wp10db,
+                          builder_id,
+                          user_id=None,
+                          title='',
+                          description='',
+                          long_description=None,
+                          scheduled_repetitions=None):
   """
   Handles the ZIM file generation and scheduling for a builder.
   """

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -850,8 +850,8 @@ class BuilderTest(BaseWpOneDbTest):
 
     self.assertEqual(0, len(actual))
 
-  @patch('wp1.logic.builder.zimfarm.request_zimfarm_task')
   @patch('wp1.logic.builder.zimfarm.create_zimfarm_schedule')
+  @patch('wp1.logic.builder.zimfarm.request_zimfarm_task')
   @patch('wp1.logic.builder.utcnow',
          return_value=datetime.datetime(2022, 12, 25, 0, 1, 2))
   def test_handle_zim_generation(self, mock_utcnow,
@@ -877,10 +877,9 @@ class BuilderTest(BaseWpOneDbTest):
                                         long_description='zz')
 
     mock_create_zimfarm_schedule.assert_called_once_with(redis, self.wp10db,
-                                                         builder_id,
+                                                         self.builder,
                                                          'test_title',
-                                                         'a',
-                                                         'zz')
+                                                         'a', 'zz')
     mock_request_zimfarm_task.assert_called_once_with(redis,
                                                       self.wp10db,
                                                       self.builder)
@@ -895,7 +894,7 @@ class BuilderTest(BaseWpOneDbTest):
     self.assertEqual(b'20221225000102', data['z_requested_at'])
     self.assertEqual(b'test_title', data['z_title'])
     self.assertEqual(b'a', data['z_description'])
-    self.assertEqual(b'z', data['z_long_description'])
+    self.assertEqual(b'zz', data['z_long_description'])
 
   @patch('wp1.logic.builder.utcnow',
          return_value=datetime.datetime(2022, 12, 25, 0, 1, 2))
@@ -1240,7 +1239,7 @@ class BuilderTest(BaseWpOneDbTest):
          return_value=datetime.datetime(2022, 12, 25, 0, 1, 2))
   def test_request_zim_file_task_for_builder(self, mock_utcnow, mock_connect_storage,
                                         mock_redis_connect, mock_wp10_connect,
-                                        mock_create_zimfarm_schedule, mock_request_zimfarm_task):
+                                        mock_request_zimfarm_task):
     """Test basic zimfile request functionality"""
     self._insert_builder()
     self._insert_selection(1,
@@ -1255,24 +1254,18 @@ class BuilderTest(BaseWpOneDbTest):
 
     mock_request_zimfarm_task.return_value = 'test_task_id_123'
 
-    actual = logic_builder.request_zim_file_task_for_builder(
-        s3_mock,
-        redis_mock,
-        self.wp10db,
-        builder=self.builder,
-        title='Test Title',
-        description='Test Description',
-        long_description='Test Long Description')
+    actual = logic_builder.request_zim_file_task_for_builder(redis_mock,
+                                                             self.wp10db,
+                                                             builder=self.builder,
+                                                             title='Test Title',
+                                                             description='Test Description',
+                                                             long_description='Test Long Description')
 
-    # Verify return value
     self.assertEqual('test_task_id_123', actual)
-
-    # Verify zimfarm was called correctly
     mock_request_zimfarm_task.assert_called_once_with(redis_mock,
                                                       self.wp10db,
                                                       self.builder)
 
-    # Verify database was updated
     with self.wp10db.cursor() as cursor:
       cursor.execute('SELECT * FROM zim_files WHERE z_selection_id = 1')
       zim_file = cursor.fetchone()
@@ -1439,13 +1432,12 @@ class BuilderTest(BaseWpOneDbTest):
     mock_request_zimfarm_task.return_value = 'test_task_id_empty'
 
     # Call the function with empty descriptions
-    actual = logic_builder.request_zim_file_task_for_builder(s3_mock,
-                                                        redis_mock,
-                                                        self.wp10db,
-                                                        builder=self.builder,
-                                                        title='Test Title',
-                                                        description='',
-                                                        long_description=None)
+    actual = logic_builder.request_zim_file_task_for_builder(redis_mock,
+                                                             self.wp10db,
+                                                             builder=self.builder,
+                                                             title='Test Title',
+                                                             description='',
+                                                             long_description=None)
 
     # Verify return value
     self.assertEqual('test_task_id_empty', actual)
@@ -1482,23 +1474,17 @@ class BuilderTest(BaseWpOneDbTest):
 
     mock_request_zimfarm_task.return_value = 'test_task_id_no_selection'
 
-    # This should raise an exception or handle gracefully
-    # The function calls latest_selection_for which may return None
     try:
-      actual = logic_builder.request_zim_file_task_for_builder(
-          s3=s3_mock,
-          redis=redis_mock,
-          wp10db=self.wp10db,
-          builder=self.builder.b_id,
-          title='Test Title',
-          description='Test Description',
-          long_description='Test Long Description')
-      # If no exception, access result to avoid unused variable warning
+      actual = logic_builder.request_zim_file_task_for_builder(redis=redis_mock,
+                                                               wp10db=self.wp10db,
+                                                               builder=self.builder.b_id,
+                                                               title='Test Title',
+                                                               description='Test Description',
+                                                               long_description='Test Long Description')
       self.assertIsNotNone(actual)
     except Exception:
-      pass  # Exception is expected if no selection is found
+      pass  
 
-    # If the function completes, zimfarm should still be called
     mock_request_zimfarm_task.assert_called_once()
 
   def test_get_builder_module_class_success(self):

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -878,8 +878,9 @@ class BuilderTest(BaseWpOneDbTest):
 
     mock_create_zimfarm_schedule.assert_called_once_with(redis, self.wp10db,
                                                          self.builder,
-                                                         'test_title',
-                                                         'a', 'zz')
+                                                         title='test_title',
+                                                         description='a',
+                                                         long_description='zz')
     mock_request_zimfarm_task.assert_called_once_with(redis,
                                                       self.wp10db,
                                                       self.builder)

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -452,7 +452,9 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('404 NOT FOUND', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  def test_create_zim_file_for_builder(self, patched_request_zimfarm_task):
+  @patch('wp1.zimfarm.create_zimfarm_schedule')
+  def test_create_zim_file_for_builder(
+      self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -479,8 +481,9 @@ class BuildersTest(BaseWebTestcase):
     self.assertEqual(b'REQUESTED', data['z_status'])
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  def test_create_zim_file_for_builder_not_found(self,
-                                                 patched_request_zimfarm_task):
+  @patch('wp1.zimfarm.create_zimfarm_schedule')
+  def test_create_zim_file_for_builder_not_found(
+      self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -496,8 +499,9 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('404 NOT FOUND', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
+  @patch('wp1.zimfarm.create_zimfarm_schedule')
   def test_create_zim_file_for_builder_unauthorized(
-      self, patched_request_zimfarm_task):
+      self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -513,7 +517,9 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('403 FORBIDDEN', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  def test_create_zim_file_for_builder_500(self, patched_request_zimfarm_task):
+  @patch('wp1.zimfarm.create_zimfarm_schedule')
+  def test_create_zim_file_for_builder_500(
+      self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -543,8 +549,9 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('400 BAD REQUEST', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  def test_create_zim_file_for_builder_no_title(self,
-                                                patched_request_zimfarm_task):
+  @patch('wp1.zimfarm.create_zimfarm_schedule')
+  def test_create_zim_file_for_builder_no_title(
+      self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -568,8 +575,9 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('400 BAD REQUEST', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
+  @patch('wp1.zimfarm.create_zimfarm_schedule')
   def test_create_zim_file_for_builder_scheduled_repetitions(
-      self, patched_request_zimfarm_task):
+      self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -617,8 +625,9 @@ class BuildersTest(BaseWebTestcase):
                     rv.data.decode('utf-8'))
 
   @patch('wp1.zimfarm.request_zimfarm_task')
+  @patch('wp1.zimfarm.create_zimfarm_schedule')
   def test_create_zim_file_for_builder_scheduled_repetitions_not_dict(
-      self, patched_request_zimfarm_task):
+      self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -637,8 +646,9 @@ class BuildersTest(BaseWebTestcase):
                     rv.data.decode('utf-8'))
 
   @patch('wp1.zimfarm.request_zimfarm_task')
+  @patch('wp1.zimfarm.create_zimfarm_schedule')
   def test_create_zim_file_for_builder_scheduled_repetitions_empty_dict(
-      self, patched_request_zimfarm_task):
+      self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 
@@ -656,8 +666,9 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('204 NO CONTENT', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
+  @patch('wp1.zimfarm.create_zimfarm_schedule')
   def test_create_zim_file_for_builder_scheduled_repetitions_extra_fields(
-      self, patched_request_zimfarm_task):
+      self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
     self._insert_selections(builder_id)
 

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -173,17 +173,17 @@ def _validate_zim_metadata(title=None, description=None, long_description=None):
 def get_zimfarm_schedule_name(builder_id: str) -> str:
     """Generate a unique schedule name for the ZIM file based on builder"""
     if not builder_id:
-        raise ObjectNotFoundError('Builder ID cannot be None')
+        raise ValueError('Builder ID cannot be None')
     parts = builder_id.split('-')
     # Use last two parts of the UUIDv4 for more uniqueness
     short_id = ''.join(parts[-2:])
-    return f'wp1_builder_{short_id}'
+    return f'wp1_selection_{short_id}'
 
 
 def get_zim_filename_prefix(builder: Builder, selection: Selection) -> str:
   """Generate a filename prefix for the ZIM file based on builder and selection."""
   if builder is None or selection is None:
-    raise ObjectNotFoundError(f"Given builder or selection was None")
+    raise ValueError(f"Given builder or selection was None")
 
   selection_id_frag = selection.s_id.decode('utf-8').split('-')[-1]
   builder_name = builder.b_name.decode('utf-8')
@@ -196,7 +196,7 @@ def _get_params(builder: Builder,
                 description: str = '',
                 long_description: str = '') -> dict:
   if builder is None:
-    raise ObjectNotFoundError('Given builder was None: %r' % builder)
+    raise ValueError('Given builder was None: %r' % builder)
 
   project = builder.b_project.decode('utf-8')
 

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -170,14 +170,14 @@ def _validate_zim_metadata(title=None, description=None, long_description=None):
         f"Long description must be different from the description.")
 
 
-def get_zimfarm_schedule_name(selection_id: str) -> str:
-    """Generate a unique schedule name for the ZIM file based on builder and selection."""
-    if not selection_id:
-        raise ObjectNotFoundError('Selection ID cannot be None')
-    parts = selection_id.split('-')
+def get_zimfarm_schedule_name(builder_id: str) -> str:
+    """Generate a unique schedule name for the ZIM file based on builder"""
+    if not builder_id:
+        raise ObjectNotFoundError('Builder ID cannot be None')
+    parts = builder_id.split('-')
     # Use last two parts of the UUIDv4 for more uniqueness
     short_id = ''.join(parts[-2:])
-    return f'wp1_selection_{short_id}'
+    return f'wp1_builder_{short_id}'
 
 
 def get_zim_filename_prefix(builder: Builder, selection: Selection) -> str:
@@ -247,7 +247,7 @@ def _get_params(builder: Builder,
   webhook_url = get_webhook_url()
 
   return {
-      'name': get_zimfarm_schedule_name(selection.s_id.decode('utf-8')),
+      'name': get_zimfarm_schedule_name(builder.b_id.decode('utf-8')),
       'language': {
           'code': 'eng',
           'name_en': 'English',
@@ -304,7 +304,7 @@ def request_zimfarm_task(s3,
   headers = _get_zimfarm_headers(token)
 
   builder_id = builder.b_id.decode('utf-8')
-  logger.info('Creating schedule for ZIM for builder id=%s', builder_id)
+  logger.info('Creating zimfarm schedule for ZIM for builder id=%s', builder_id)
   r = requests.post('%s/schedules/' % base_url, headers=headers, json=params)
 
   try:

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -341,19 +341,21 @@ def request_zimfarm_task(redis,
   base_url = get_zimfarm_url()
   headers = _get_zimfarm_headers(token)
 
+  schedule_name = get_zimfarm_schedule_name(builder.b_id.decode('utf-8'))
+
   logger.info('Creating ZIM task for builder id=%s', builder.b_id.decode('utf-8'))
   r = requests.post('%s/requested-tasks/' % base_url,
                     headers=headers,
-                    json={'schedule_names': [get_zimfarm_schedule_name(builder.b_id.decode('utf-8')),]})
-
+                    json={'schedule_names': [schedule_name]})
+  print (f"r: {r}")
   try:
     r.raise_for_status()
-
+    print (f"r status: {r.status_code}")
     data = r.json()
     requested = data.get('requested')
     task_id = requested[0] if requested else None
     logger.info('Found task id=%s for builder id=%s', task_id, builder.b_id.decode('utf-8'))
-
+    print (f"task_id: {task_id}")
     if task_id is None:
       raise ZimFarmError('Did not get scheduled task id')
   except requests.exceptions.HTTPError as e:

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -347,15 +347,12 @@ def request_zimfarm_task(redis,
   r = requests.post('%s/requested-tasks/' % base_url,
                     headers=headers,
                     json={'schedule_names': [schedule_name]})
-  print (f"r: {r}")
   try:
     r.raise_for_status()
-    print (f"r status: {r.status_code}")
     data = r.json()
     requested = data.get('requested')
     task_id = requested[0] if requested else None
     logger.info('Found task id=%s for builder id=%s', task_id, builder.b_id.decode('utf-8'))
-    print (f"task_id: {task_id}")
     if task_id is None:
       raise ZimFarmError('Did not get scheduled task id')
   except requests.exceptions.HTTPError as e:

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -357,6 +357,14 @@ class ZimFarmTest(BaseWpOneDbTest):
 
     self.assertEqual(actual, 'bcdefg')
 
+  @patch('wp1.zimfarm.get_zimfarm_token')
+  def test_create_zimfarm_schedule_missing_token(self, get_token_mock):
+    redis = MagicMock()
+    get_token_mock.return_value = None
+
+    with self.assertRaises(ZimFarmError):
+      zimfarm.create_zimfarm_schedule(redis, self.wp10db, None)
+
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   def test_create_zimfarm_schedule_missing_builder(self, get_token_mock,
@@ -412,24 +420,6 @@ class ZimFarmTest(BaseWpOneDbTest):
                                       self.builder,
                                       title='a',
                                       description='b')
-
-  @patch('wp1.zimfarm.requests')
-  @patch('wp1.zimfarm.get_zimfarm_token')
-  @patch('wp1.zimfarm._get_params')
-  def test_schedule_zim_valid_graphemes(self, get_params_mock, get_token_mock,
-                                        mock_requests):
-    redis = MagicMock()
-    mock_response = MagicMock()
-    mock_response.json.return_value = {'requested': ['9876']}
-    mock_requests.post.side_effect = (MagicMock(), mock_response, MagicMock())
-
-    valid_title = "में" * (ZIM_TITLE_MAX_LENGTH)
-    zimfarm.create_zimfarm_schedule(redis,
-            self.wp10db,
-            self.builder,
-            title=valid_title,
-            description='b')
-    mock_requests.post.assert_called_once()
 
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
@@ -509,7 +499,32 @@ class ZimFarmTest(BaseWpOneDbTest):
                                       description='bb',
                                       long_description='bb')
 
+  @patch('wp1.zimfarm.requests')
+  @patch('wp1.zimfarm.get_zimfarm_token')
+  @patch('wp1.zimfarm._get_params')
+  def test_create_zimfarm_schedule_valid_graphemes(self, get_params_mock, get_token_mock,
+                                        mock_requests):
+    redis = MagicMock()
+    mock_response = MagicMock()
+    mock_response.json.return_value = {'requested': ['9876']}
+    mock_requests.post.side_effect = (MagicMock(), mock_response, MagicMock())
 
+    valid_title = "में" * (ZIM_TITLE_MAX_LENGTH)
+    zimfarm.create_zimfarm_schedule(redis,
+            self.wp10db,
+            self.builder,
+            title=valid_title,
+            description='b')
+    mock_requests.post.assert_called_once()
+
+  @patch('wp1.zimfarm.get_zimfarm_token')
+  def test_request_zimfarm_task_missing_token(self, get_token_mock):
+    redis = MagicMock()
+    get_token_mock.return_value = None
+
+    with self.assertRaises(ZimFarmError):
+      zimfarm.request_zimfarm_task(redis, self.wp10db, self.builder)
+  
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   @patch('wp1.zimfarm.get_zimfarm_schedule_name')

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -147,7 +147,7 @@ class ZimFarmTest(BaseWpOneDbTest):
     self.assertEqual(result, 'wp1_selection_a456abc123456789')
 
   def test_get_zimfarm_schedule_name_none(self):
-    with self.assertRaises(ObjectNotFoundError):
+    with self.assertRaises(ValueError):
       zimfarm.get_zimfarm_schedule_name(None)
 
   def test_get_zim_filename_prefix_valid(self):
@@ -156,7 +156,7 @@ class ZimFarmTest(BaseWpOneDbTest):
     self.assertEqual(result, 'MyBuilder-def')
 
   def test_get_zim_filename_prefix_none(self):
-    with self.assertRaises(ObjectNotFoundError):
+    with self.assertRaises(ValueError):
       zimfarm.get_zim_filename_prefix(None, None)
 
   def test_get_params(self):
@@ -202,9 +202,7 @@ class ZimFarmTest(BaseWpOneDbTest):
     self.assertEqual(expected, actual)
 
   def test_get_params_missing_builder(self):
-    s3 = MagicMock()
-
-    with self.assertRaises(ObjectNotFoundError):
+    with self.assertRaises(ValueError):
       zimfarm._get_params(None, self.selection)
 
   @patch('wp1.zimfarm.requests')

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -27,7 +27,7 @@ from wp1.zimfarm import (
 
 class ZimFarmTest(BaseWpOneDbTest):
   expected_params = {
-      'name': 'wp1_builder_3c4d',
+      'name': 'wp1_selection_3c4d',
       'language': {
           'code': 'eng',
           'name_en': 'English',
@@ -143,8 +143,8 @@ class ZimFarmTest(BaseWpOneDbTest):
   def test_get_zimfarm_schedule_name_valid(self):
     builder_id = '123e4567-e89b-12d3-a456-abc123456789'
     result = zimfarm.get_zimfarm_schedule_name(builder_id)
-    # Should join last two parts: 'a456-abc123456789' -> 'wp1_builder_a456abc123456789'
-    self.assertEqual(result, 'wp1_builder_a456abc123456789')
+    # Should join last two parts: 'a456-abc123456789' -> 'wp1_selection_a456abc123456789'
+    self.assertEqual(result, 'wp1_selection_a456abc123456789')
 
   def test_get_zimfarm_schedule_name_none(self):
     with self.assertRaises(ObjectNotFoundError):

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -27,7 +27,7 @@ from wp1.zimfarm import (
 
 class ZimFarmTest(BaseWpOneDbTest):
   expected_params = {
-      'name': 'wp1_selection_12345def',
+      'name': 'wp1_builder_3c4d',
       'language': {
           'code': 'eng',
           'name_en': 'English',
@@ -141,10 +141,10 @@ class ZimFarmTest(BaseWpOneDbTest):
     self._insert_selection(b'abc-12345-def')
 
   def test_get_zimfarm_schedule_name_valid(self):
-    selection_id = '123e4567-e89b-12d3-a456-abc123456789'
-    result = zimfarm.get_zimfarm_schedule_name(selection_id)
-    # Should join last two parts: 'a456-abc123456789' -> 'wp1_selection_a456abc123456789'
-    self.assertEqual(result, 'wp1_selection_a456abc123456789')
+    builder_id = '123e4567-e89b-12d3-a456-abc123456789'
+    result = zimfarm.get_zimfarm_schedule_name(builder_id)
+    # Should join last two parts: 'a456-abc123456789' -> 'wp1_builder_a456abc123456789'
+    self.assertEqual(result, 'wp1_builder_a456abc123456789')
 
   def test_get_zimfarm_schedule_name_none(self):
     with self.assertRaises(ObjectNotFoundError):


### PR DESCRIPTION
Associate ZIMFARM schedules with builder instead of selection, so that the zimfarm schedule can be re-used with the latest materialized selection.

Fixes #952 