### PR TITLE
Refactor zim_files and zim_schedules data model

### DIFF
--- a/db/migrations/20250707_01_qY30l-add-title-to-zim-files-table.py
+++ b/db/migrations/20250707_01_qY30l-add-title-to-zim-files-table.py
@@ -1,5 +1,5 @@
 """
-
+Migration to add a title column to the zim_files table
 """
 
 from yoyo import step

--- a/db/migrations/20250729_01_8hH6B-refactor-zim-schedules-zim-files.py
+++ b/db/migrations/20250729_01_8hH6B-refactor-zim-schedules-zim-files.py
@@ -1,0 +1,48 @@
+"""
+Migration to update zim_files and zim_schedules tables:
+- Rename zim_files table to zim_tasks
+- Alter zim_schedules: remove s_zim_file_id, make s_rq_job_id nullable, add s_long_description, s_description, s_title
+"""
+
+from yoyo import step
+
+__depends__ = set()
+
+steps = [
+  step(
+    '''
+    ALTER TABLE zim_files
+      RENAME zim_tasks, 
+      DROP COLUMN z_title, 
+      DROP COLUMN z_description, 
+      DROP COLUMN z_long_description, 
+      ADD COLUMN z_zim_schedule_id VARBINARY(36) NOT NULL
+    ''',
+    '''
+    ALTER TABLE zim_tasks 
+      RENAME zim_files, 
+      DROP COLUMN z_zim_schedule_id, 
+      ADD COLUMN z_title tinyblob, 
+      ADD COLUMN z_description tinyblob, 
+      ADD COLUMN z_long_description blob
+    '''
+  ),
+  step(
+      '''
+    ALTER TABLE zim_schedules
+      DROP COLUMN s_zim_file_id,
+      MODIFY COLUMN s_rq_job_id VARBINARY(36) NULL,
+      ADD COLUMN s_long_description blob,
+      ADD COLUMN s_description tinyblob,
+      ADD COLUMN s_title tinyblob
+    ''',
+    '''
+    ALTER TABLE zim_schedules
+      DROP COLUMN s_long_description,
+      DROP COLUMN s_description,
+      DROP COLUMN s_title,
+      ADD COLUMN s_zim_file_id INTEGER NULL,
+      MODIFY COLUMN s_rq_job_id VARBINARY(36) NOT NULL
+    '''
+  ),
+]

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -32,8 +32,8 @@ def insert_selection(wp10db, selection):
               %(s_article_count)s)
     ''', attr.asdict(selection))
     cursor.execute(
-        'INSERT INTO zim_files (z_selection_id, z_status)'
-        ' VALUES (%s, "NOT_REQUESTED")', (selection.s_id,))
+        'INSERT INTO zim_tasks (z_selection_id, z_zim_schedule_id, z_status)'
+        ' VALUES (%s, %s, "NOT_REQUESTED")', (selection.s_id, b'schedule_123'))
   wp10db.commit()
 
 
@@ -70,7 +70,7 @@ def zim_file_requested_at_for(wp10db, task_id):
   with wp10db.cursor() as cursor:
     cursor.execute(
         'SELECT z_requested_at '
-        'FROM zim_files WHERE z_task_id = %s', task_id)
+        'FROM zim_tasks WHERE z_task_id = %s', task_id)
     data = cursor.fetchone()
     if data is None or data['z_requested_at'] is None:
       return None
@@ -161,16 +161,15 @@ def update_zimfarm_task(wp10db, task_id, status, set_updated_now=False):
       updated_at = utcnow().strftime(TS_FORMAT_WP10).encode('utf-8')
       with wp10db.cursor() as cursor:
         cursor.execute(
-            '''UPDATE zim_files SET z_status = %s, z_updated_at = %s
+            '''UPDATE zim_tasks SET z_status = %s, z_updated_at = %s
                WHERE z_task_id = %s''', (status, updated_at, task_id))
         found = bool(cursor.rowcount)
     else:
-      cursor.execute('UPDATE zim_files SET z_status = %s WHERE z_task_id = %s',
+      cursor.execute('UPDATE zim_tasks SET z_status = %s WHERE z_task_id = %s',
                      (status, task_id))
       found = bool(cursor.rowcount)
   wp10db.commit()
   return found
-
 
 def is_zim_file_deleted(update_at_timestamp):
   return utcnow().timestamp() - update_at_timestamp > ZIM_FILE_TTL

--- a/wp1/logic/zim_schedules.py
+++ b/wp1/logic/zim_schedules.py
@@ -13,10 +13,10 @@ def insert_zim_schedule(wp10db, zim_schedule : ZimSchedule):
   with wp10db.cursor() as cursor:
     cursor.execute(
       '''INSERT INTO zim_schedules
-         (s_id, s_builder_id, s_zim_file_id, s_rq_job_id, s_last_updated_at,
+         (s_id, s_builder_id, s_rq_job_id, s_last_updated_at,
           s_interval, s_remaining_generations)
          VALUES
-         (%(s_id)s, %(s_builder_id)s, %(s_zim_file_id)s, %(s_rq_job_id)s,
+         (%(s_id)s, %(s_builder_id)s,  %(s_rq_job_id)s,
           %(s_last_updated_at)s, %(s_interval)s, %(s_remaining_generations)s)
       ''', attr.asdict(zim_schedule)
     )
@@ -28,28 +28,12 @@ def update_zim_schedule(wp10db, zim_schedule : ZimSchedule):
   with wp10db.cursor() as cursor:
     cursor.execute(
       '''UPDATE zim_schedules SET
-         s_zim_file_id = %(s_zim_file_id)s,
          s_last_updated_at = %(s_last_updated_at)s,
          s_interval = %(s_interval)s,
-         s_remaining_generations = %(s_remaining_generations)s
+         s_remaining_generations = %(s_remaining_generations)s,
+         s_email = %(s_email)s
          WHERE s_id = %(s_id)s
       ''', attr.asdict(zim_schedule)
-    )
-    updated = bool(cursor.rowcount)
-  wp10db.commit()
-  return updated
-
-
-def update_zim_schedule_zim_file_id(wp10db, schedule_id, zim_file_id):
-  """Updates the s_zim_file_id of a ZimSchedule by its s_id. Returns True if updated."""
-  updated_at = utcnow().strftime(TS_FORMAT_WP10).encode('utf-8')
-  with wp10db.cursor() as cursor:
-    cursor.execute(
-      '''UPDATE zim_schedules SET
-         s_zim_file_id = %s,
-         s_last_updated_at = %s
-         WHERE s_id = %s
-      ''', (zim_file_id, updated_at, schedule_id)
     )
     updated = bool(cursor.rowcount)
   wp10db.commit()
@@ -68,6 +52,22 @@ def get_zim_schedule(wp10db, schedule_id):
   return ZimSchedule(**row)
 
 
+def get_zim_schedule_by_zim_file_id(wp10db, zim_file_id):
+  """Retrieves a ZimSchedule by its associated zim_file_id."""
+  with wp10db.cursor() as cursor:
+    cursor.execute(
+      '''
+      SELECT zs.* FROM zim_schedules zs
+      JOIN zim_tasks zf ON zs.s_id = zf.z_zim_schedule_id
+      WHERE zf.z_id = %s
+      ''', (zim_file_id,)
+    )
+    row = cursor.fetchone()
+  if not row:
+    return None
+  return ZimSchedule(**row)
+
+
 def list_zim_schedules_for_builder(wp10db, builder_id):
   """Lists all ZimSchedule entries for a given builder_id."""
   with wp10db.cursor() as cursor:
@@ -79,22 +79,23 @@ def list_zim_schedules_for_builder(wp10db, builder_id):
     ZimSchedule(**row) for row in rows
   ]
 
-def decrement_remaining_generations(wp10db, schedule_id):
+
+def decrement_remaining_generations_and_update_file_id(wp10db, schedule_id: bytes, zim_file_id: int):
     """Decrements s_remaining_generations by 1 for the given schedule, not going below 0. Also updates s_last_updated_at. Returns True if updated."""
     updated_at = utcnow().strftime(TS_FORMAT_WP10).encode('utf-8')
     with wp10db.cursor() as cursor:
-        cursor.execute(
-            'SELECT s_remaining_generations FROM zim_schedules WHERE s_id = %s', (schedule_id,)
-        )
-        row = cursor.fetchone()
-        if not row or not row['s_remaining_generations'] or row['s_remaining_generations'] <= 0:
-            return False
-        new_value = row['s_remaining_generations'] - 1
-        cursor.execute(
-            'UPDATE zim_schedules SET s_remaining_generations = %s, s_last_updated_at = %s WHERE s_id = %s',
-            (new_value, updated_at, schedule_id)
-        )
-        updated = bool(cursor.rowcount)
+      cursor.execute(
+        'SELECT s_remaining_generations FROM zim_schedules WHERE s_id = %s', (schedule_id,)
+      )
+      row = cursor.fetchone()
+      if not row or not row['s_remaining_generations'] or row['s_remaining_generations'] <= 0:
+        return False
+      new_value = row['s_remaining_generations'] - 1
+      cursor.execute(
+          'UPDATE zim_schedules SET s_remaining_generations = %s, s_last_updated_at = %s WHERE s_id = %s',
+          (new_value, updated_at, schedule_id)
+      )
+      updated = bool(cursor.rowcount)
     wp10db.commit()
     return updated
 
@@ -103,7 +104,7 @@ def get_scheduled_zimfarm_task_from_taskid(wp10db, task_id):
     """Checks if a task_id is scheduled in zim_schedules. Returns the ZimSchedule if found, else None."""
     with wp10db.cursor() as cursor:
         cursor.execute(
-            'SELECT zs.* FROM zim_schedules zs JOIN zim_files zf ON zs.s_zim_file_id = zf.z_id WHERE zf.z_task_id = %s',
+            'SELECT zs.* FROM zim_schedules zs JOIN zim_tasks zf ON zs.s_id = zf.z_zim_schedule_id WHERE zf.z_task_id = %s',
             (task_id,)
         )
         row = cursor.fetchone()
@@ -112,51 +113,47 @@ def get_scheduled_zimfarm_task_from_taskid(wp10db, task_id):
     return ZimSchedule(**row)
 
 
-def create_zim_schedule_with_job(wp10db, builder, scheduled_repetitions, job_id, schedule_id=None):
-    """Create and save a ZimSchedule with the given RQ job information."""
-    required_keys = {'repetition_period_in_months', 'number_of_repetitions', 'email'}
-    has_min_required_keys = required_keys <= scheduled_repetitions.keys()
-    if not isinstance(scheduled_repetitions, dict) or not has_min_required_keys:
-        raise ValueError(f'scheduled_repetitions must be a dict containing {required_keys}')
-
-    period_months = scheduled_repetitions['repetition_period_in_months']
-    num_scheduled_repetitions = scheduled_repetitions['number_of_repetitions']
-    
-    if schedule_id is None:
-        schedule_id = str(uuid.uuid4())
-    
-    zim_schedule = ZimSchedule(
-        s_id=schedule_id.encode('utf-8'),
-        s_builder_id=builder.b_id,
-        s_zim_file_id=None,
-        s_rq_job_id=job_id.encode('utf-8'),
-        s_interval=period_months,
-        s_remaining_generations=num_scheduled_repetitions,
-        # s_email=scheduled_repetitions['email'].encode('utf-8')
-    )
-    zim_schedule.set_last_updated_at_now()
-    insert_zim_schedule(wp10db, zim_schedule)
-    
-    return schedule_id
+def set_zim_schedule_id_to_zim_file(wp10db, zim_file_id: bytes, zim_schedule_id: bytes):
+    """Sets the z_zim_schedule_id field in zim_tasks to the given zim_schedule_id."""
+    with wp10db.cursor() as cursor:
+        cursor.execute(
+            'UPDATE zim_tasks SET z_zim_schedule_id = %s WHERE z_id = %s',
+            (zim_schedule_id, zim_file_id)
+        )
+        updated = bool(cursor.rowcount)
+    wp10db.commit()
+    return updated
 
 
-def schedule_future_zimfile_generations(redis, wp10db, builder, title, description, long_description, scheduled_repetitions):
+def schedule_future_zimfile_generations(redis, wp10db, builder, zim_schedule_id: bytes, scheduled_repetitions):
   """
   Calculate timing and schedule future ZIM file creations using rq-scheduler, then save the schedule to the database.
   """
+
+  required_keys = {'repetition_period_in_months', 'number_of_repetitions', 'email'}
+  has_min_required_keys = required_keys <= scheduled_repetitions.keys()
+  if not isinstance(scheduled_repetitions, dict) or not has_min_required_keys:
+    raise ValueError(f'scheduled_repetitions must be a dict containing {required_keys}')
+
   period_months = scheduled_repetitions['repetition_period_in_months']
   interval_seconds = period_months * SECONDS_PER_MONTH
   first_future_run = utcnow() + relativedelta(seconds=interval_seconds)
-  zim_schedule_id = str(uuid.uuid4())
+  total_repetitions = scheduled_repetitions['number_of_repetitions']
 
   job = queues.schedule_recurring_zimfarm_task(
     redis=redis,
-    args=[builder, title, description, long_description, zim_schedule_id],
+    args=[builder, zim_schedule_id],
     scheduled_time=first_future_run,
     interval_seconds=interval_seconds,
-    repeat_count=scheduled_repetitions['number_of_repetitions'] - 1,
+    repeat_count=total_repetitions - 1, # -1 because the first run is not counted as a repetition
   )
 
-  create_zim_schedule_with_job(wp10db, builder, scheduled_repetitions, job.id, zim_schedule_id)
-  return job.id
+  zim_schedule: ZimSchedule = get_zim_schedule(wp10db, zim_schedule_id)
+  zim_schedule.s_remaining_generations = total_repetitions
+  zim_schedule.s_interval = period_months
+  zim_schedule.s_rq_job_id = job.id.encode('utf-8')
+  zim_schedule.s_email = scheduled_repetitions['email'].encode('utf-8')
+  zim_schedule.set_last_updated_at_now()
+  update_zim_schedule(wp10db, zim_schedule)
 
+  return job.id

--- a/wp1/models/wp10/zim_file.py
+++ b/wp1/models/wp10/zim_file.py
@@ -7,18 +7,16 @@ from wp1.timestamp import utcnow
 
 
 @attr.s
-class ZimFile:
-  table_name = 'zim_files'
+class ZimTask:
+  table_name = 'zim_tasks'
 
   z_id = attr.ib()
+  z_zim_schedule_id = attr.ib() 
   z_selection_id = attr.ib()
   z_status = attr.ib(default=b'NOT_REQUESTED')
   z_task_id = attr.ib(default=None)
   z_requested_at = attr.ib(default=None)
   z_updated_at = attr.ib(default=None)
-  z_long_description = attr.ib(default=None)
-  z_description = attr.ib(default=None)
-  z_title = attr.ib(default=None)
 
   @property
   def updated_at_dt(self):

--- a/wp1/models/wp10/zim_file_test.py
+++ b/wp1/models/wp10/zim_file_test.py
@@ -2,15 +2,16 @@ import datetime
 from unittest.mock import patch
 
 from wp1.base_db_test import BaseWpOneDbTest
-from wp1.models.wp10.zim_file import ZimFile
+from wp1.models.wp10.zim_file import ZimTask
 
 
-class ZimFileTest(BaseWpOneDbTest):
+class ZimTaskTest(BaseWpOneDbTest):
 
   def setUp(self):
     super().setUp()
-    self.zim_file = ZimFile(z_id=1,
+    self.zim_file = ZimTask(z_id=1,
                             z_selection_id='deadbeef',
+                            z_zim_schedule_id='schedule_123',
                             z_task_id='abcd-5678',
                             z_updated_at=b'20190830112844')
 

--- a/wp1/models/wp10/zim_schedule.py
+++ b/wp1/models/wp10/zim_schedule.py
@@ -16,12 +16,14 @@ class ZimSchedule:
 
   s_id: bytes = attr.ib()
   s_builder_id: bytes = attr.ib()
-  s_rq_job_id: bytes = attr.ib()
-  s_zim_file_id: int = attr.ib(default=None)
+  s_last_updated_at: bytes = attr.ib()
+  s_rq_job_id: bytes = attr.ib(default=None) 
   s_interval: int = attr.ib(default=None)  # in months
   s_email: bytes = attr.ib(default=None)  # Email to notify when the zim generation is done
   s_remaining_generations: int = attr.ib(default=None)  # how many more ZIMs to generate
-  s_last_updated_at: bytes = attr.ib(default=None)
+  s_title: bytes = attr.ib(default=None)  # Title of the ZIM selection, if any
+  s_description: bytes = attr.ib(default=None)  # Description of the ZIM selection, if any
+  s_long_description: bytes = attr.ib(default=None)  # Long description of the ZIM selection, if any
 
   def set_id(self):
     self.s_id = str(uuid.uuid4()).encode('utf-8')

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -174,12 +174,9 @@ def latest_selection_article_count_for_builder(builder_id):
 def create_zim_file_for_builder(builder_id):
   redis = get_redis()
   wp10db = get_db('wp10db')
-  s3 = get_storage()
 
   user_id = flask.session['user']['identity']['sub']
-
   data = flask.request.get_json()
-
   title = data.get('title')
   desc = data.get('description')
   long_desc = data.get('long_description')
@@ -209,16 +206,14 @@ def create_zim_file_for_builder(builder_id):
     scheduled_repetitions = None
 
   try:
-    logic_builder.handle_zim_generation(
-        s3,
-        redis,
-        wp10db,
-        builder_id,
-        user_id=user_id,
-        title=title,
-        description=desc,
-        long_description=long_desc,
-        scheduled_repetitions=scheduled_repetitions)
+    logic_builder.handle_zim_generation(redis,
+                    wp10db,
+                    builder_id,
+                    user_id=user_id,
+                    title=title,
+                    description=desc,
+                    long_description=long_desc,
+                    scheduled_repetitions=scheduled_repetitions)
   except ObjectNotFoundError:
     return flask.jsonify(
         {'error_messages': ['No builder found with id = %s' % builder_id]}), 404

--- a/wp1/web/selection_test.py
+++ b/wp1/web/selection_test.py
@@ -140,7 +140,7 @@ class SelectionTest(BaseWebTestcase):
 
   def _insert_selection(self, values, zim_values=None):
     if zim_values is None:
-      zim_values = ('NOT_REQUESTED',)
+      zim_values = ('NOT_REQUESTED', b'schedule_123')
     zim_values = zim_values + (values[0],)
 
     with self.wp10db.cursor() as cursor:
@@ -152,7 +152,7 @@ class SelectionTest(BaseWebTestcase):
               (%s, %s, %s, %s, %s, %s, %s, %s)
         ''', values)
       cursor.execute(
-          'INSERT INTO zim_files (z_status, z_selection_id) VALUES (%s, %s)',
+          'INSERT INTO zim_tasks (z_status, z_zim_schedule_id, z_selection_id) VALUES (%s, %s, %s)',
           zim_values)
     self.wp10db.commit()
 
@@ -178,7 +178,7 @@ class SelectionTest(BaseWebTestcase):
            'object_key_1', 'CAN_RETRY', '{"errors"["error1"]}'))
       self._insert_selection((2, '1a-2b-3c-4d', 'application/vnd.ms-excel',
                               '20201225105544', 1, 'object_key_2', None, None),
-                             ('NOT_REQUESTED',))
+                             ('NOT_REQUESTED', b'schedule_123'))
       self.wp10db.commit()
       with client.session_transaction() as sess:
         sess['user'] = self.USER

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -577,21 +577,6 @@ class ZimFarmTest(BaseWpOneDbTest):
   @patch('wp1.zimfarm.requests')
   @patch('wp1.zimfarm.get_zimfarm_token')
   @patch('wp1.zimfarm.get_zimfarm_schedule_name')
-  def test_request_zimfarm_task_task_create_raises(self, get_zimfarm_schedule_name_mock,
-                                                   get_token_mock, mock_requests):
-    redis = MagicMock()
-    get_zimfarm_schedule_name_mock.return_value = 'bar'
-    get_token_mock.return_value = 'abcdef'
-    mock_response = MagicMock()
-    mock_response.json.side_effect = requests.exceptions.HTTPError
-    mock_requests.exceptions.HTTPError = requests.exceptions.HTTPError
-    mock_requests.post.return_value = mock_response
-    with self.assertRaises(ZimFarmError):
-      zimfarm.request_zimfarm_task(redis, self.wp10db, self.builder)
-
-  @patch('wp1.zimfarm.requests')
-  @patch('wp1.zimfarm.get_zimfarm_token')
-  @patch('wp1.zimfarm.get_zimfarm_schedule_name')
   def test_request_zimfarm_task_missing_task_id(self, get_zimfarm_schedule_name_mock,
                                                 get_token_mock, mock_requests):
     redis = MagicMock()

--- a/wp10_test.down.sql
+++ b/wp10_test.down.sql
@@ -10,7 +10,7 @@ DROP TABLE IF EXISTS `users`;
 DROP TABLE IF EXISTS `builders`;
 DROP TABLE IF EXISTS `selections`;
 DROP TABLE IF EXISTS `custom`;
-DROP TABLE IF EXISTS `zim_files`;
+DROP TABLE IF EXISTS `zim_tasks`;
 DROP TABLE IF EXISTS `zim_schedules`;
 DROP TABLE IF EXISTS `page_scores`;
 DROP TABLE IF EXISTS `temp_pageviews`;

--- a/wp10_test.up.sql
+++ b/wp10_test.up.sql
@@ -117,27 +117,27 @@ CREATE TABLE custom (
   c_is_active TINYINT
 );
 
-CREATE TABLE zim_files (
+CREATE TABLE zim_tasks (
   z_id INTEGER NOT NULL PRIMARY KEY AUTO_INCREMENT,
   z_selection_id VARBINARY(255) NOT NULL,
+  z_zim_schedule_id VARBINARY(36) NOT NULL,
   z_status VARBINARY(255) DEFAULT "NOT_REQUESTED",
   z_task_id VARBINARY(255),
   z_requested_at BINARY(14),
-  z_updated_at BINARY(14),
-  z_long_description blob,
-  z_description tinyblob,
-  z_title tinyblob
+  z_updated_at BINARY(14)
 );
 
 CREATE TABLE zim_schedules (
   s_id VARBINARY(36) NOT NULL PRIMARY KEY,
   s_builder_id VARBINARY(255) NOT NULL,
-  s_zim_file_id INTEGER NULL,
-  s_rq_job_id VARBINARY(36) NOT NULL,
+  s_rq_job_id VARBINARY(36) NULL,
   s_interval INTEGER NULL,
   s_remaining_generations INTEGER NULL,
   s_email VARBINARY(255) NULL,
-  s_last_updated_at BINARY(14) NOT NULL
+  s_last_updated_at BINARY(14) NOT NULL,
+  s_long_description blob,
+  s_description tinyblob,
+  s_title tinyblob
 );
 
 CREATE TABLE `temp_pageviews` (


### PR DESCRIPTION
- Renamed `ZimFile` class to `ZimTask` and updated related references.
- Removed `s_zim_file_id` from `ZimSchedule` and added `s_title`, `s_description`, and `s_long_description`.
- Updated tests to reflect changes in `ZimSchedule` and `ZimTask.`
- Consolidated update logic for remaining generations and ZIM file ID into a single function.
- Modified database schema to accommodate new fields and relationships.
- Adjusted logic for creating and managing ZIM schedules and tasks in the application.
- Cleaned up unused code and improved test coverage for new functionality.

Fixes #962 