### PR TITLE
Reuse zim schedules

### DIFF
--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -472,21 +472,6 @@ def request_scheduled_zim_file_for_builder(builder: Builder, zim_schedule_id: by
   return task_id
 
 
-def find_existing_schedule_in_db(wp10db, builder_b_id, scheduled_repetitions):
-  """
-  Returns an existing schedule based on scheduled_repetitions.
-  If scheduled_repetitions is set, looks for a manual schedule (s_remaining_generations is None).
-  Otherwise, looks for a schedule with s_remaining_generations == 0.
-  """
-  
-  # Get all ZIM schedules for this builder
-  schedules = logic_zim_schedules.list_zim_schedules_for_builder(wp10db, builder_b_id)
-  print(f"Existing schedules in DB: {schedules}, scheduled_repetitions={scheduled_repetitions}")
-  for schedule in schedules:
-    print(f"Checking schedule: {schedule.s_remaining_generations}")
-    if schedule.s_remaining_generations == 0 or schedule.s_remaining_generations is None: # Look for a schedule with no remaining generations
-      return schedule
-
 def handle_zim_generation(redis,
                           wp10db,
                           builder_id,
@@ -514,24 +499,13 @@ def handle_zim_generation(redis,
       raise UserNotAuthorizedError(
           'Could not use builder id = %s for user id = %s' %
           (builder_id, user_id))
-  
-  existing_schedule_in_db = find_existing_schedule_in_db(wp10db, builder.b_id, scheduled_repetitions)
-  print(f"Existing schedule in DB: {existing_schedule_in_db}")
-  if existing_schedule_in_db and zimfarm.zimfarm_schedule_exists(redis, existing_schedule_in_db.s_id):
-    zim_schedule = zimfarm.update_zimfarm_schedule(
-      redis, wp10db, builder, zim_schedule=existing_schedule_in_db,
-      title=title,
-      description=description,
-      long_description=long_description
-    )
-  else:
-    zim_schedule = zimfarm.create_zimfarm_schedule(
-      redis, wp10db, builder,
-      title=title,
-      description=description,
-      long_description=long_description
-    )
-  print(f"ZIM schedule created/updated: {zim_schedule.s_id}")
+
+  zim_schedule = zimfarm.create_or_update_zimfarm_schedule(
+    redis, wp10db, builder,
+    title=title,
+    description=description,
+    long_description=long_description
+  )
   zim_file: ZimTask = request_zim_file_task_for_builder(redis, wp10db, builder, zim_schedule.s_id)
 
   # If scheduled_repetitions is set, schedule future ZIM file generations

--- a/wp1/logic/zim_schedules.py
+++ b/wp1/logic/zim_schedules.py
@@ -13,10 +13,11 @@ def insert_zim_schedule(wp10db, zim_schedule : ZimSchedule):
     cursor.execute(
       '''INSERT INTO zim_schedules
          (s_id, s_builder_id, s_rq_job_id, s_last_updated_at,
-          s_interval, s_remaining_generations)
+          s_interval, s_remaining_generations, s_email, s_title, s_description, s_long_description)
          VALUES
          (%(s_id)s, %(s_builder_id)s,  %(s_rq_job_id)s,
-          %(s_last_updated_at)s, %(s_interval)s, %(s_remaining_generations)s)
+          %(s_last_updated_at)s, %(s_interval)s, %(s_remaining_generations)s,
+          %(s_email)s, %(s_title)s, %(s_description)s, %(s_long_description)s)
       ''', attr.asdict(zim_schedule)
     )
   wp10db.commit()

--- a/wp1/logic/zim_schedules.py
+++ b/wp1/logic/zim_schedules.py
@@ -30,7 +30,10 @@ def update_zim_schedule(wp10db, zim_schedule : ZimSchedule):
          s_last_updated_at = %(s_last_updated_at)s,
          s_interval = %(s_interval)s,
          s_remaining_generations = %(s_remaining_generations)s,
-         s_email = %(s_email)s
+         s_email = %(s_email)s,
+         s_title = %(s_title)s,
+         s_description = %(s_description)s,
+         s_long_description = %(s_long_description)s
          WHERE s_id = %(s_id)s
       ''', attr.asdict(zim_schedule)
     )

--- a/wp1/logic/zim_schedules_test.py
+++ b/wp1/logic/zim_schedules_test.py
@@ -73,12 +73,14 @@ class LogicZimSchedulesTest(BaseWpOneDbTest):
     schedule.s_last_updated_at = new_time.strftime(TS_FORMAT_WP10).encode('utf-8')
     schedule.s_interval = 5
     schedule.s_remaining_generations = 10
+    schedule.s_title = b'New Title'
     ok = update_zim_schedule(self.wp10db, schedule)
     self.assertTrue(ok)
     fetched = get_zim_schedule(self.wp10db, schedule.s_id)
     self.assertEqual(5, fetched.s_interval)
     self.assertEqual(10, fetched.s_remaining_generations)
     self.assertEqual(schedule.s_last_updated_at, fetched.s_last_updated_at)
+    self.assertEqual(b'New Title', fetched.s_title)
 
   def test_decrement_remaining_generations(self):
     schedule = self.new_schedule(remaining=2)

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -468,7 +468,7 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('404 NOT FOUND', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  @patch('wp1.zimfarm.create_zimfarm_schedule')
+  @patch('wp1.zimfarm.create_or_update_zimfarm_schedule')
   def test_create_zim_file_for_builder(
       self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
@@ -502,7 +502,7 @@ class BuildersTest(BaseWebTestcase):
     self.assertEqual(b'REQUESTED', data['z_status'])
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  @patch('wp1.zimfarm.create_zimfarm_schedule')
+  @patch('wp1.zimfarm.create_or_update_zimfarm_schedule')
   def test_create_zim_file_for_builder_not_found(
       self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
@@ -520,7 +520,7 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('404 NOT FOUND', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  @patch('wp1.zimfarm.create_zimfarm_schedule')
+  @patch('wp1.zimfarm.create_or_update_zimfarm_schedule')
   def test_create_zim_file_for_builder_unauthorized(
       self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
@@ -538,7 +538,7 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('403 FORBIDDEN', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  @patch('wp1.zimfarm.create_zimfarm_schedule')
+  @patch('wp1.zimfarm.create_or_update_zimfarm_schedule')
   def test_create_zim_file_for_builder_500(
       self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
@@ -570,7 +570,7 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('400 BAD REQUEST', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  @patch('wp1.zimfarm.create_zimfarm_schedule')
+  @patch('wp1.zimfarm.create_or_update_zimfarm_schedule')
   def test_create_zim_file_for_builder_no_title(
       self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
@@ -596,7 +596,7 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('400 BAD REQUEST', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  @patch('wp1.zimfarm.create_zimfarm_schedule')
+  @patch('wp1.zimfarm.create_or_update_zimfarm_schedule')
   def test_create_zim_file_for_builder_scheduled_repetitions(
       self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
@@ -629,7 +629,7 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('204 NO CONTENT', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  @patch('wp1.zimfarm.create_zimfarm_schedule')
+  @patch('wp1.zimfarm.create_or_update_zimfarm_schedule')
   def test_create_zim_file_for_builder_scheduled_repetitions_extra_fields(
       self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
@@ -688,7 +688,7 @@ class BuildersTest(BaseWebTestcase):
                     rv.data.decode('utf-8'))
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  @patch('wp1.zimfarm.create_zimfarm_schedule')
+  @patch('wp1.zimfarm.create_or_update_zimfarm_schedule')
   def test_create_zim_file_for_builder_scheduled_repetitions_not_dict(
       self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
@@ -709,7 +709,7 @@ class BuildersTest(BaseWebTestcase):
                     rv.data.decode('utf-8'))
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  @patch('wp1.zimfarm.create_zimfarm_schedule')
+  @patch('wp1.zimfarm.create_or_update_zimfarm_schedule')
   def test_create_zim_file_for_builder_scheduled_repetitions_empty_dict(
       self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()
@@ -734,7 +734,7 @@ class BuildersTest(BaseWebTestcase):
       self.assertEqual('204 NO CONTENT', rv.status)
 
   @patch('wp1.zimfarm.request_zimfarm_task')
-  @patch('wp1.zimfarm.create_zimfarm_schedule')
+  @patch('wp1.zimfarm.create_or_update_zimfarm_schedule')
   def test_create_zim_file_for_builder_scheduled_repetitions_extra_fields(
       self, patched_create_zimfarm_schedule, patched_request_zimfarm_task):
     builder_id = self._insert_builder()

--- a/wp10_test.up.sql
+++ b/wp10_test.up.sql
@@ -135,9 +135,9 @@ CREATE TABLE zim_schedules (
   s_remaining_generations INTEGER NULL,
   s_email VARBINARY(255) NULL,
   s_last_updated_at BINARY(14) NOT NULL,
-  s_long_description blob,
-  s_description tinyblob,
-  s_title tinyblob
+  s_long_description mediumblob,
+  s_description blob,
+  s_title blob
 );
 
 CREATE TABLE `temp_pageviews` (


### PR DESCRIPTION
This PR adds functionality to re-use zim schedules, updating or creating new ones depending if the exists in the zimfarm or are already used.

Fixes #964 (ZIM schedule migration: check for schedule when requesting manual ZIM)

the zimfile schedule name is changed to not use the builder id so that more then 1 schedule can be created per builder (manual + scheduled)