### PR TITLE
Skip re-confirming email if a confirmed row already exists

### DIFF
--- a/wp1/logic/zim_schedules.py
+++ b/wp1/logic/zim_schedules.py
@@ -10,27 +10,26 @@ from wp1.models.wp10.zim_schedule import ZimSchedule
 from wp1.web.emails_confirmation import send_zim_email_confirmation
 
 
-def insert_zim_schedule(wp10db, zim_schedule : ZimSchedule):
+def insert_zim_schedule(wp10db, zim_schedule: ZimSchedule):
   """Inserts a ZimSchedule into the zim_schedules table"""
   with wp10db.cursor() as cursor:
     cursor.execute(
-      '''INSERT INTO zim_schedules
+        '''INSERT INTO zim_schedules
          (s_id, s_builder_id, s_rq_job_id, s_last_updated_at,
           s_interval, s_remaining_generations, s_email, s_title, s_description, s_long_description, s_email_confirmation_token)
          VALUES
          (%(s_id)s, %(s_builder_id)s,  %(s_rq_job_id)s,
           %(s_last_updated_at)s, %(s_interval)s, %(s_remaining_generations)s,
           %(s_email)s, %(s_title)s, %(s_description)s, %(s_long_description)s, %(s_email_confirmation_token)s)
-      ''', attr.asdict(zim_schedule)
-    )
+      ''', attr.asdict(zim_schedule))
   wp10db.commit()
 
 
-def update_zim_schedule(wp10db, zim_schedule : ZimSchedule):
+def update_zim_schedule(wp10db, zim_schedule: ZimSchedule):
   """Updates a ZimSchedule record based on the model state. Returns True if updated."""
   with wp10db.cursor() as cursor:
     cursor.execute(
-      '''UPDATE zim_schedules SET
+        '''UPDATE zim_schedules SET
          s_last_updated_at = %(s_last_updated_at)s,
          s_interval = %(s_interval)s,
          s_remaining_generations = %(s_remaining_generations)s,
@@ -40,8 +39,7 @@ def update_zim_schedule(wp10db, zim_schedule : ZimSchedule):
          s_long_description = %(s_long_description)s,
          s_email_confirmation_token = %(s_email_confirmation_token)s
          WHERE s_id = %(s_id)s
-      ''', attr.asdict(zim_schedule)
-    )
+      ''', attr.asdict(zim_schedule))
     updated = bool(cursor.rowcount)
   wp10db.commit()
   return updated
@@ -50,9 +48,8 @@ def update_zim_schedule(wp10db, zim_schedule : ZimSchedule):
 def get_zim_schedule(wp10db, schedule_id):
   """Retrieves a ZimSchedule by its s_id. Returns a ZimSchedule or None."""
   with wp10db.cursor() as cursor:
-    cursor.execute(
-      'SELECT * FROM zim_schedules WHERE s_id = %s', (schedule_id,)
-    )
+    cursor.execute('SELECT * FROM zim_schedules WHERE s_id = %s',
+                   (schedule_id,))
     row = cursor.fetchone()
   if not row:
     return None
@@ -63,12 +60,11 @@ def get_zim_schedule_by_zim_file_id(wp10db, z_id):
   """Retrieves a ZimSchedule by its associated zim_file_id."""
   with wp10db.cursor() as cursor:
     cursor.execute(
-      '''
+        '''
       SELECT zs.* FROM zim_schedules zs
       JOIN zim_tasks zf ON zs.s_id = zf.z_zim_schedule_id
       WHERE zf.z_id = %s
-      ''', (z_id,)
-    )
+      ''', (z_id,))
     row = cursor.fetchone()
   if not row:
     return None
@@ -78,13 +74,10 @@ def get_zim_schedule_by_zim_file_id(wp10db, z_id):
 def list_zim_schedules_for_builder(wp10db, builder_id):
   """Lists all ZimSchedule entries for a given builder_id."""
   with wp10db.cursor() as cursor:
-    cursor.execute(
-      'SELECT * FROM zim_schedules WHERE s_builder_id = %s', (builder_id,)
-    )
+    cursor.execute('SELECT * FROM zim_schedules WHERE s_builder_id = %s',
+                   (builder_id,))
     rows = cursor.fetchall()
-  return [
-    ZimSchedule(**row) for row in rows
-  ]
+  return [ZimSchedule(**row) for row in rows]
 
 
 def find_active_recurring_schedule_for_builder(wp10db, builder_id):
@@ -101,74 +94,74 @@ def delete_zim_schedule(redis, wp10db, schedule_id):
   schedule = get_zim_schedule(wp10db, schedule_id)
   if not schedule:
     return False
-  
+
   # Cancel the scheduled RQ job if it exists
   if schedule.s_rq_job_id:
     queues.cancel_scheduled_job(redis, schedule.s_rq_job_id)
-  
+
   # Delete the schedule from the database
   with wp10db.cursor() as cursor:
     cursor.execute('DELETE FROM zim_schedules WHERE s_id = %s', (schedule_id,))
     deleted = bool(cursor.rowcount)
   wp10db.commit()
-  
+
   return deleted
 
 
 def decrement_remaining_generations(wp10db, schedule_id: bytes):
-    """Decrements s_remaining_generations by 1 for the given schedule, not going below 0. Also updates s_last_updated_at. Returns True if updated."""
-    updated_at = utcnow().strftime(TS_FORMAT_WP10).encode('utf-8')
-    with wp10db.cursor() as cursor:
-      cursor.execute(
-        'SELECT s_remaining_generations FROM zim_schedules WHERE s_id = %s', (schedule_id,)
-      )
-      row = cursor.fetchone()
-      if not row or not row['s_remaining_generations'] or row['s_remaining_generations'] <= 0:
-        return False
-      new_value = row['s_remaining_generations'] - 1
-      cursor.execute(
-          'UPDATE zim_schedules SET s_remaining_generations = %s, s_last_updated_at = %s WHERE s_id = %s',
-          (new_value, updated_at, schedule_id)
-      )
-      updated = bool(cursor.rowcount)
-    wp10db.commit()
-    return updated
+  """Decrements s_remaining_generations by 1 for the given schedule, not going below 0. Also updates s_last_updated_at. Returns True if updated."""
+  updated_at = utcnow().strftime(TS_FORMAT_WP10).encode('utf-8')
+  with wp10db.cursor() as cursor:
+    cursor.execute(
+        'SELECT s_remaining_generations FROM zim_schedules WHERE s_id = %s',
+        (schedule_id,))
+    row = cursor.fetchone()
+    if not row or not row[
+        's_remaining_generations'] or row['s_remaining_generations'] <= 0:
+      return False
+    new_value = row['s_remaining_generations'] - 1
+    cursor.execute(
+        'UPDATE zim_schedules SET s_remaining_generations = %s, s_last_updated_at = %s WHERE s_id = %s',
+        (new_value, updated_at, schedule_id))
+    updated = bool(cursor.rowcount)
+  wp10db.commit()
+  return updated
 
 
 def get_scheduled_zimfarm_task_from_taskid(wp10db, task_id):
-    """Checks if a task_id is scheduled in zim_schedules. Returns the ZimSchedule if found, else None."""
-    with wp10db.cursor() as cursor:
-        cursor.execute(
-            'SELECT zs.* FROM zim_schedules zs JOIN zim_tasks zf ON zs.s_id = zf.z_zim_schedule_id WHERE zf.z_task_id = %s',
-            (task_id,)
-        )
-        row = cursor.fetchone()
-    if not row:
-        return None
-    return ZimSchedule(**row)
+  """Checks if a task_id is scheduled in zim_schedules. Returns the ZimSchedule if found, else None."""
+  with wp10db.cursor() as cursor:
+    cursor.execute(
+        'SELECT zs.* FROM zim_schedules zs JOIN zim_tasks zf ON zs.s_id = zf.z_zim_schedule_id WHERE zf.z_task_id = %s',
+        (task_id,))
+    row = cursor.fetchone()
+  if not row:
+    return None
+  return ZimSchedule(**row)
+
 
 def get_username_by_zim_schedule_id(wp10db, schedule_id):
-    """Retrieves the username associated with a ZimSchedule by its ID. Returns the username or None."""
-    with wp10db.cursor() as cursor:
-        cursor.execute(
-            'SELECT u.u_username FROM zim_schedules zs JOIN users u ON zs.s_builder_id = u.u_id WHERE zs.s_id = %s',
-            (schedule_id,)
-        )
-        row = cursor.fetchone()
-    if not row:
-        return None
-    return row['u_username'].decode('utf-8') if row['u_username'] else None
+  """Retrieves the username associated with a ZimSchedule by its ID. Returns the username or None."""
+  with wp10db.cursor() as cursor:
+    cursor.execute(
+        'SELECT u.u_username FROM zim_schedules zs JOIN users u ON zs.s_builder_id = u.u_id WHERE zs.s_id = %s',
+        (schedule_id,))
+    row = cursor.fetchone()
+  if not row:
+    return None
+  return row['u_username'].decode('utf-8') if row['u_username'] else None
 
-def set_zim_schedule_id_to_zim_task_by_selection(wp10db, selection_id: bytes, zim_schedule_id: bytes):
-    """Sets the z_zim_schedule_id field in zim_tasks to the given the selection_id."""
-    with wp10db.cursor() as cursor:
-        cursor.execute(
-            'UPDATE zim_tasks SET z_zim_schedule_id = %s WHERE z_selection_id = %s',
-            (zim_schedule_id, selection_id)
-        )
-        updated = bool(cursor.rowcount)
-    wp10db.commit()
-    return updated
+
+def set_zim_schedule_id_to_zim_task_by_selection(wp10db, selection_id: bytes,
+                                                 zim_schedule_id: bytes):
+  """Sets the z_zim_schedule_id field in zim_tasks to the given the selection_id."""
+  with wp10db.cursor() as cursor:
+    cursor.execute(
+        'UPDATE zim_tasks SET z_zim_schedule_id = %s WHERE z_selection_id = %s',
+        (zim_schedule_id, selection_id))
+    updated = bool(cursor.rowcount)
+  wp10db.commit()
+  return updated
 
 
 def has_email_been_confirmed(wp10db, email):
@@ -176,19 +169,26 @@ def has_email_been_confirmed(wp10db, email):
   Returns True if the email exists with no confirmation token (confirmed), False otherwise."""
   with wp10db.cursor() as cursor:
     cursor.execute(
-      'SELECT 1 FROM zim_schedules WHERE s_email = %s AND s_email_confirmation_token IS NULL LIMIT 1',
-      (email,)
-    )
+        'SELECT 1 FROM zim_schedules WHERE s_email = %s AND s_email_confirmation_token IS NULL LIMIT 1',
+        (email,))
     return cursor.fetchone() is not None
 
 
-def confirm_email_subscription(wp10db, token):
-  """Confirms email subscription by removing the token. Returns True if found and confirmed."""
+def confirm_email_subscription(wp10db, token, email):
+  """Confirms email subscription by removing tokens for all schedules with the given email.
+  First validates that the token exists for this email. Returns True if found and confirmed."""
   with wp10db.cursor() as cursor:
+    # Validate that the token exists for this email
     cursor.execute(
-      'UPDATE zim_schedules SET s_email_confirmation_token = NULL WHERE s_email_confirmation_token = %s',
-      (token,)
-    )
+        'SELECT 1 FROM zim_schedules WHERE s_email_confirmation_token = %s AND s_email = %s LIMIT 1',
+        (token, email))
+    if not cursor.fetchone():
+      return False
+
+    # Update all schedules with this email to remove their tokens (confirm them all)
+    cursor.execute(
+        'UPDATE zim_schedules SET s_email_confirmation_token = NULL WHERE s_email = %s',
+        (email,))
     updated = bool(cursor.rowcount)
   wp10db.commit()
   return updated
@@ -198,9 +198,8 @@ def unsubscribe_email(wp10db, token):
   """Unsubscribes from email notifications by removing email and token. Returns True if found and unsubscribed."""
   with wp10db.cursor() as cursor:
     cursor.execute(
-      'UPDATE zim_schedules SET s_email = NULL, s_email_confirmation_token = NULL WHERE s_email_confirmation_token = %s',
-      (token,)
-    )
+        'UPDATE zim_schedules SET s_email = NULL, s_email_confirmation_token = NULL WHERE s_email_confirmation_token = %s',
+        (token,))
     updated = bool(cursor.rowcount)
   wp10db.commit()
   return updated
@@ -210,9 +209,8 @@ def unsubscribe_email_by_schedule_id(wp10db, schedule_id):
   """Unsubscribes from email notifications by removing email from a schedule. Returns True if found and unsubscribed."""
   with wp10db.cursor() as cursor:
     cursor.execute(
-      'UPDATE zim_schedules SET s_email = NULL WHERE s_id = %s AND s_email IS NOT NULL',
-      (schedule_id,)
-    )
+        'UPDATE zim_schedules SET s_email = NULL WHERE s_id = %s AND s_email IS NOT NULL',
+        (schedule_id,))
     updated = bool(cursor.rowcount)
   wp10db.commit()
   return updated
@@ -222,8 +220,8 @@ def get_zim_schedule_by_token(wp10db, token):
   """Retrieves a ZimSchedule by its email confirmation token. Returns a ZimSchedule or None."""
   with wp10db.cursor() as cursor:
     cursor.execute(
-      'SELECT * FROM zim_schedules WHERE s_email_confirmation_token = %s', (token,)
-    )
+        'SELECT * FROM zim_schedules WHERE s_email_confirmation_token = %s',
+        (token,))
     row = cursor.fetchone()
   if not row:
     return None
@@ -234,7 +232,10 @@ def generate_email_confirmation_token():
   """Generates a secure random token for email confirmation."""
   return secrets.token_urlsafe(32).encode('utf-8')
 
-def schedule_future_zimfile_generations(redis, wp10db, builder, zim_schedule_id: bytes, scheduled_repetitions):
+
+def schedule_future_zimfile_generations(redis, wp10db, builder,
+                                        zim_schedule_id: bytes,
+                                        scheduled_repetitions):
   """
   Calculate timing and schedule future ZIM file creations using rq-scheduler, then save the schedule to the database.
   """
@@ -242,7 +243,8 @@ def schedule_future_zimfile_generations(redis, wp10db, builder, zim_schedule_id:
   required_keys = {'repetition_period_in_months', 'number_of_repetitions'}
   has_min_required_keys = required_keys <= scheduled_repetitions.keys()
   if not isinstance(scheduled_repetitions, dict) or not has_min_required_keys:
-    raise ValueError(f'scheduled_repetitions must be a dict containing {required_keys}')
+    raise ValueError(
+        f'scheduled_repetitions must be a dict containing {required_keys}')
 
   period_months = scheduled_repetitions['repetition_period_in_months']
   interval_seconds = period_months * SECONDS_PER_MONTH
@@ -252,11 +254,12 @@ def schedule_future_zimfile_generations(redis, wp10db, builder, zim_schedule_id:
   email = email.encode('utf-8') if email is not None else None
 
   job = queues.schedule_recurring_zimfarm_task(
-    redis=redis,
-    args=[builder, zim_schedule_id],
-    scheduled_time=first_future_run,
-    interval_seconds=interval_seconds,
-    repeat_count=total_repetitions - 1, # -1 because the first run is not counted as a repetition
+      redis=redis,
+      args=[builder, zim_schedule_id],
+      scheduled_time=first_future_run,
+      interval_seconds=interval_seconds,
+      repeat_count=total_repetitions -
+      1,  # -1 because the first run is not counted as a repetition
   )
 
   zim_schedule: ZimSchedule = get_zim_schedule(wp10db, zim_schedule_id)
@@ -267,23 +270,24 @@ def schedule_future_zimfile_generations(redis, wp10db, builder, zim_schedule_id:
   zim_schedule.set_last_updated_at_now()
   if email is not None and not has_email_been_confirmed(wp10db, email):
     # Email not previously confirmed, generate token and send confirmation email
-    zim_schedule.s_email_confirmation_token = generate_email_confirmation_token()
+    zim_schedule.s_email_confirmation_token = generate_email_confirmation_token(
+    )
     username = get_username_by_zim_schedule_id(wp10db, zim_schedule_id)
-    zim_title = zim_schedule.s_title.decode('utf-8') if zim_schedule.s_title else 'Your ZIM File'
-    
+    zim_title = zim_schedule.s_title.decode(
+        'utf-8') if zim_schedule.s_title else 'Your ZIM File'
+
     token = zim_schedule.s_email_confirmation_token.decode('utf-8')
-    email_confirm_url = CREDENTIALS.get(ENV, {}).get('CLIENT_URL', {}).get('api')
+    email_confirm_url = CREDENTIALS.get(ENV, {}).get('CLIENT_URL',
+                                                     {}).get('api')
     confirm_url = f"{email_confirm_url}/api/v1/zim/confirm-email?token={token}"
     unsubscribe_url = f"{email_confirm_url}/api/v1/zim/unsubscribe-email?token={token}"
-    send_zim_email_confirmation(
-        recipient_username=username,
-        recipient_email=email.decode('utf-8'),
-        zim_title=zim_title,
-        confirm_url=confirm_url,
-        unsubscribe_url=unsubscribe_url,
-        repetition_period_months=period_months,
-        number_of_repetitions=total_repetitions
-    )
+    send_zim_email_confirmation(recipient_username=username,
+                                recipient_email=email.decode('utf-8'),
+                                zim_title=zim_title,
+                                confirm_url=confirm_url,
+                                unsubscribe_url=unsubscribe_url,
+                                repetition_period_months=period_months,
+                                number_of_repetitions=total_repetitions)
 
   update_zim_schedule(wp10db, zim_schedule)
 

--- a/wp1/logic/zim_schedules_email_test.py
+++ b/wp1/logic/zim_schedules_email_test.py
@@ -12,284 +12,308 @@ from wp1.timestamp import utcnow
 
 class ZimSchedulesEmailConfirmationTest(BaseWpOneDbTest):
 
-    def setUp(self):
-        super().setUp()
-        self.schedule_id = str(uuid.uuid4()).encode('utf-8')
-        self.builder_id = str(uuid.uuid4()).encode('utf-8')
-        self.token = zim_schedules.generate_email_confirmation_token()
-        
-        self.zim_schedule = ZimSchedule(
-            s_id=self.schedule_id,
-            s_builder_id=self.builder_id,
-            s_rq_job_id=b'test-job-id',
-            s_last_updated_at=utcnow().strftime(TS_FORMAT_WP10).encode('utf-8'),
-            s_interval=3,
-            s_remaining_generations=5,
-            s_email=b'test@example.com',
-            s_title=b'Test ZIM Schedule',
-            s_description=b'Test description',
-            s_long_description=b'Test long description',
-            s_email_confirmation_token=self.token
-        )
-    
-    def _insert_zim_schedule_directly(self, zim_schedule):
-        """Helper method to insert a ZimSchedule directly into the database without using library functions."""
-        with self.wp10db.cursor() as cursor:
-            cursor.execute(
-                '''INSERT INTO zim_schedules
+  def setUp(self):
+    super().setUp()
+    self.schedule_id = str(uuid.uuid4()).encode('utf-8')
+    self.builder_id = str(uuid.uuid4()).encode('utf-8')
+    self.token = zim_schedules.generate_email_confirmation_token()
+
+    self.zim_schedule = ZimSchedule(
+        s_id=self.schedule_id,
+        s_builder_id=self.builder_id,
+        s_rq_job_id=b'test-job-id',
+        s_last_updated_at=utcnow().strftime(TS_FORMAT_WP10).encode('utf-8'),
+        s_interval=3,
+        s_remaining_generations=5,
+        s_email=b'test@example.com',
+        s_title=b'Test ZIM Schedule',
+        s_description=b'Test description',
+        s_long_description=b'Test long description',
+        s_email_confirmation_token=self.token)
+
+  def _insert_zim_schedule_directly(self, zim_schedule):
+    """Helper method to insert a ZimSchedule directly into the database without using library functions."""
+    with self.wp10db.cursor() as cursor:
+      cursor.execute(
+          '''INSERT INTO zim_schedules
                    (s_id, s_builder_id, s_rq_job_id, s_last_updated_at,
                     s_interval, s_remaining_generations, s_email, s_title, s_description, s_long_description, s_email_confirmation_token)
                    VALUES
                    (%(s_id)s, %(s_builder_id)s, %(s_rq_job_id)s, %(s_last_updated_at)s,
                     %(s_interval)s, %(s_remaining_generations)s, %(s_email)s, %(s_title)s, %(s_description)s, %(s_long_description)s, %(s_email_confirmation_token)s)
-                ''', attr.asdict(zim_schedule)
-            )
-        self.wp10db.commit()
+                ''', attr.asdict(zim_schedule))
+    self.wp10db.commit()
 
-    def test_generate_email_confirmation_token(self):
-        """Test that a token is generated and is valid."""
-        token = zim_schedules.generate_email_confirmation_token()
-        self.assertIsInstance(token, bytes)
-        self.assertTrue(len(token) > 20)  # Should be a reasonable length
+  def test_generate_email_confirmation_token(self):
+    """Test that a token is generated and is valid."""
+    token = zim_schedules.generate_email_confirmation_token()
+    self.assertIsInstance(token, bytes)
+    self.assertTrue(len(token) > 20)  # Should be a reasonable length
 
-    def test_insert_zim_schedule_with_token(self):
-        """Test inserting a schedule with email confirmation token."""
-        self._insert_zim_schedule_directly(self.zim_schedule)
-        
-        fetched = zim_schedules.get_zim_schedule(self.wp10db, self.schedule_id)
-        self.assertIsNotNone(fetched)
-        self.assertEqual(self.token, fetched.s_email_confirmation_token)
-        self.assertEqual(b'test@example.com', fetched.s_email)
+  def test_insert_zim_schedule_with_token(self):
+    """Test inserting a schedule with email confirmation token."""
+    self._insert_zim_schedule_directly(self.zim_schedule)
 
-    def test_get_zim_schedule_by_token(self):
-        """Test retrieving a schedule by its confirmation token."""
-        self._insert_zim_schedule_directly(self.zim_schedule)
-        
-        fetched = zim_schedules.get_zim_schedule_by_token(self.wp10db, self.token)
-        self.assertIsNotNone(fetched)
-        self.assertEqual(self.schedule_id, fetched.s_id)
-        self.assertEqual(self.token, fetched.s_email_confirmation_token)
+    fetched = zim_schedules.get_zim_schedule(self.wp10db, self.schedule_id)
+    self.assertIsNotNone(fetched)
+    self.assertEqual(self.token, fetched.s_email_confirmation_token)
+    self.assertEqual(b'test@example.com', fetched.s_email)
 
-    def test_get_zim_schedule_by_token_not_found(self):
-        """Test retrieving a schedule by non-existent token."""
-        fake_token = b'non-existent-token'
-        fetched = zim_schedules.get_zim_schedule_by_token(self.wp10db, fake_token)
-        self.assertIsNone(fetched)
+  def test_get_zim_schedule_by_token(self):
+    """Test retrieving a schedule by its confirmation token."""
+    self._insert_zim_schedule_directly(self.zim_schedule)
 
-    def test_confirm_email_subscription(self):
-        """Test confirming email subscription by removing token."""
-        self._insert_zim_schedule_directly(self.zim_schedule)
-        
-        success = zim_schedules.confirm_email_subscription(self.wp10db, self.token)
-        self.assertTrue(success)
-        
-        # Verify token was removed
-        fetched = zim_schedules.get_zim_schedule(self.wp10db, self.schedule_id)
-        self.assertIsNone(fetched.s_email_confirmation_token)
-        self.assertEqual(b'test@example.com', fetched.s_email)  # Email should remain
+    fetched = zim_schedules.get_zim_schedule_by_token(self.wp10db, self.token)
+    self.assertIsNotNone(fetched)
+    self.assertEqual(self.schedule_id, fetched.s_id)
+    self.assertEqual(self.token, fetched.s_email_confirmation_token)
 
-    def test_confirm_email_subscription_invalid_token(self):
-        """Test confirming with invalid token."""
-        fake_token = b'invalid-token'
-        success = zim_schedules.confirm_email_subscription(self.wp10db, fake_token)
-        self.assertFalse(success)
+  def test_get_zim_schedule_by_token_not_found(self):
+    """Test retrieving a schedule by non-existent token."""
+    fake_token = b'non-existent-token'
+    fetched = zim_schedules.get_zim_schedule_by_token(self.wp10db, fake_token)
+    self.assertIsNone(fetched)
 
-    def test_unsubscribe_email(self):
-        """Test unsubscribing from email notifications."""
-        self._insert_zim_schedule_directly(self.zim_schedule)
-        
-        success = zim_schedules.unsubscribe_email(self.wp10db, self.token)
-        self.assertTrue(success)
-        
-        # Verify both email and token were removed
-        fetched = zim_schedules.get_zim_schedule(self.wp10db, self.schedule_id)
-        self.assertIsNone(fetched.s_email_confirmation_token)
-        self.assertIsNone(fetched.s_email)
+  def test_confirm_email_subscription(self):
+    """Test confirming email subscription by removing token."""
+    self._insert_zim_schedule_directly(self.zim_schedule)
 
-    def test_unsubscribe_email_invalid_token(self):
-        """Test unsubscribing with invalid token."""
-        fake_token = b'invalid-token'
-        success = zim_schedules.unsubscribe_email(self.wp10db, fake_token)
-        self.assertFalse(success)
+    success = zim_schedules.confirm_email_subscription(self.wp10db, self.token,
+                                                       b'test@example.com')
+    self.assertTrue(success)
 
-    @patch('wp1.logic.zim_schedules.send_zim_email_confirmation')
-    @patch('wp1.logic.zim_schedules.get_username_by_zim_schedule_id')
-    @patch('wp1.queues.schedule_recurring_zimfarm_task')
-    def test_schedule_future_zimfile_generations_with_email_sends_confirmation(self, 
-                                                                               mock_schedule_task,
-                                                                               mock_get_username,
-                                                                               mock_send_confirmation):
-        """Test that scheduling with email sends confirmation email."""
-        job_mock = MagicMock()
-        job_mock.id = 'test-job-id'
-        mock_schedule_task.return_value = job_mock
-        mock_get_username.return_value = 'testuser'
-        mock_send_confirmation.return_value = True
-        
-        schedule_without_email = ZimSchedule(
-            s_id=self.schedule_id,
-            s_builder_id=self.builder_id,
-            s_rq_job_id=None,
-            s_last_updated_at=utcnow().strftime(TS_FORMAT_WP10).encode('utf-8'),
-            s_title=b'Test ZIM Schedule'
-        )
-        self._insert_zim_schedule_directly(schedule_without_email)
-        
-        scheduled_repetitions = {
-            'repetition_period_in_months': 2,
-            'number_of_repetitions': 3,
-            'email': 'test@example.com'
-        }
-        
-        builder = MagicMock()
-        zim_schedules.schedule_future_zimfile_generations(
-            redis=MagicMock(),
-            wp10db=self.wp10db,
-            builder=builder,
-            zim_schedule_id=self.schedule_id,
-            scheduled_repetitions=scheduled_repetitions
-        )
-        
-        # Verify confirmation email was sent
-        mock_send_confirmation.assert_called_once_with(
-            recipient_username='testuser',
-            recipient_email='test@example.com',
-            zim_title='Test ZIM Schedule',
-            confirm_url=ANY,
-            unsubscribe_url=ANY,
-            repetition_period_months=2,
-            number_of_repetitions=3
-        )
-        
-        # Verify schedule has token
-        fetched = zim_schedules.get_zim_schedule(self.wp10db, self.schedule_id)
-        self.assertIsNotNone(fetched.s_email_confirmation_token)
-        self.assertEqual(b'test@example.com', fetched.s_email)
+    # Verify token was removed
+    fetched = zim_schedules.get_zim_schedule(self.wp10db, self.schedule_id)
+    self.assertIsNone(fetched.s_email_confirmation_token)
+    self.assertEqual(b'test@example.com',
+                     fetched.s_email)  # Email should remain
 
-    @patch('wp1.queues.schedule_recurring_zimfarm_task')
-    def test_schedule_future_zimfile_generations_without_email_no_token(self, mock_schedule_task):
-        """Test that scheduling without email doesn't generate token."""
-        job_mock = MagicMock()
-        job_mock.id = 'test-job-id'
-        mock_schedule_task.return_value = job_mock
-        
-        schedule_without_email = ZimSchedule(
-            s_id=self.schedule_id,
-            s_builder_id=self.builder_id,
-            s_rq_job_id=None,
-            s_last_updated_at=utcnow().strftime(TS_FORMAT_WP10).encode('utf-8'),
-            s_title=b'Test ZIM Schedule'
-        )
-        self._insert_zim_schedule_directly(schedule_without_email)
-        
-        scheduled_repetitions = {
-            'repetition_period_in_months': 2,
-            'number_of_repetitions': 3
-        }
-        
-        builder = MagicMock()
-        zim_schedules.schedule_future_zimfile_generations(
-            redis=MagicMock(),
-            wp10db=self.wp10db,
-            builder=builder,
-            zim_schedule_id=self.schedule_id,
-            scheduled_repetitions=scheduled_repetitions
-        )
-        
-        # Verify no token was generated
-        fetched = zim_schedules.get_zim_schedule(self.wp10db, self.schedule_id)
-        self.assertIsNone(fetched.s_email_confirmation_token)
-        self.assertIsNone(fetched.s_email)
+  def test_confirm_email_subscription_invalid_token(self):
+    """Test confirming with invalid token."""
+    fake_token = b'invalid-token'
+    success = zim_schedules.confirm_email_subscription(self.wp10db, fake_token,
+                                                       b'test@example.com')
+    self.assertFalse(success)
 
-    def test_has_email_been_confirmed_false_no_email(self):
-        """Test has_email_been_confirmed returns False when email doesn't exist."""
-        result = zim_schedules.has_email_been_confirmed(self.wp10db, b'nonexistent@example.com')
-        self.assertFalse(result)
+  def test_unsubscribe_email(self):
+    """Test unsubscribing from email notifications."""
+    self._insert_zim_schedule_directly(self.zim_schedule)
 
-    def test_has_email_been_confirmed_false_unconfirmed_email(self):
-        """Test has_email_been_confirmed returns False when email has token."""
-        self._insert_zim_schedule_directly(self.zim_schedule)
-        result = zim_schedules.has_email_been_confirmed(self.wp10db, b'test@example.com')
-        self.assertFalse(result)
+    success = zim_schedules.unsubscribe_email(self.wp10db, self.token)
+    self.assertTrue(success)
 
-    def test_has_email_been_confirmed_true_confirmed_email(self):
-        """Test has_email_been_confirmed returns True when email is confirmed."""
-        # Create schedule with confirmed email (no token)
-        confirmed_schedule = ZimSchedule(
-            s_id=self.schedule_id,
-            s_builder_id=self.builder_id,
-            s_rq_job_id=b'test-job-id',
-            s_last_updated_at=utcnow().strftime(TS_FORMAT_WP10).encode('utf-8'),
-            s_interval=3,
-            s_remaining_generations=5,
-            s_email=b'test@example.com',
-            s_title=b'Test ZIM Schedule',
-            s_description=b'Test description',
-            s_long_description=b'Test long description',
-            s_email_confirmation_token=None  # Already confirmed
-        )
-        self._insert_zim_schedule_directly(confirmed_schedule)
-        
-        result = zim_schedules.has_email_been_confirmed(self.wp10db, b'test@example.com')
-        self.assertTrue(result)
+    # Verify both email and token were removed
+    fetched = zim_schedules.get_zim_schedule(self.wp10db, self.schedule_id)
+    self.assertIsNone(fetched.s_email_confirmation_token)
+    self.assertIsNone(fetched.s_email)
 
-    @patch('wp1.logic.zim_schedules.send_zim_email_confirmation')
-    @patch('wp1.logic.zim_schedules.get_username_by_zim_schedule_id')
-    @patch('wp1.queues.schedule_recurring_zimfarm_task')
-    def test_schedule_with_previously_confirmed_email_skips_confirmation(self,
-                                                                         mock_schedule_task,
-                                                                         mock_get_username,
-                                                                         mock_send_confirmation):
-        """Test that scheduling with previously confirmed email skips confirmation process."""
-        job_mock = MagicMock()
-        job_mock.id = 'test-job-id'
-        mock_schedule_task.return_value = job_mock
-        mock_get_username.return_value = 'testuser'
-        
-        # Create first schedule with confirmed email (no token)
-        first_schedule_id = str(uuid.uuid4()).encode('utf-8')
-        first_schedule = ZimSchedule(
-            s_id=first_schedule_id,
-            s_builder_id=self.builder_id,
-            s_rq_job_id=b'first-job-id',
-            s_last_updated_at=utcnow().strftime(TS_FORMAT_WP10).encode('utf-8'),
-            s_title=b'First ZIM Schedule',
-            s_email=b'test@example.com',
-            s_email_confirmation_token=None  # Already confirmed
-        )
-        self._insert_zim_schedule_directly(first_schedule)
-        
-        # Create second schedule without email initially
-        second_schedule_id = str(uuid.uuid4()).encode('utf-8')
-        second_schedule = ZimSchedule(
-            s_id=second_schedule_id,
-            s_builder_id=self.builder_id,
-            s_rq_job_id=None,
-            s_last_updated_at=utcnow().strftime(TS_FORMAT_WP10).encode('utf-8'),
-            s_title=b'Second ZIM Schedule'
-        )
-        self._insert_zim_schedule_directly(second_schedule)
-        
-        # Schedule with the same confirmed email
-        scheduled_repetitions = {
-            'repetition_period_in_months': 2,
-            'number_of_repetitions': 3,
-            'email': 'test@example.com'
-        }
-        
-        builder = MagicMock()
-        zim_schedules.schedule_future_zimfile_generations(
-            redis=MagicMock(),
-            wp10db=self.wp10db,
-            builder=builder,
-            zim_schedule_id=second_schedule_id,
-            scheduled_repetitions=scheduled_repetitions
-        )
-        
-        # Verify confirmation email was NOT sent (because email was previously confirmed)
-        mock_send_confirmation.assert_not_called()
-        
-        # Verify second schedule has email but no token (automatically confirmed)
-        fetched = zim_schedules.get_zim_schedule(self.wp10db, second_schedule_id)
-        self.assertEqual(b'test@example.com', fetched.s_email)
-        self.assertIsNone(fetched.s_email_confirmation_token)
+  def test_unsubscribe_email_invalid_token(self):
+    """Test unsubscribing with invalid token."""
+    fake_token = b'invalid-token'
+    success = zim_schedules.unsubscribe_email(self.wp10db, fake_token)
+    self.assertFalse(success)
+
+  @patch('wp1.logic.zim_schedules.send_zim_email_confirmation')
+  @patch('wp1.logic.zim_schedules.get_username_by_zim_schedule_id')
+  @patch('wp1.queues.schedule_recurring_zimfarm_task')
+  def test_schedule_future_zimfile_generations_with_email_sends_confirmation(
+      self, mock_schedule_task, mock_get_username, mock_send_confirmation):
+    """Test that scheduling with email sends confirmation email."""
+    job_mock = MagicMock()
+    job_mock.id = 'test-job-id'
+    mock_schedule_task.return_value = job_mock
+    mock_get_username.return_value = 'testuser'
+    mock_send_confirmation.return_value = True
+
+    schedule_without_email = ZimSchedule(
+        s_id=self.schedule_id,
+        s_builder_id=self.builder_id,
+        s_rq_job_id=None,
+        s_last_updated_at=utcnow().strftime(TS_FORMAT_WP10).encode('utf-8'),
+        s_title=b'Test ZIM Schedule')
+    self._insert_zim_schedule_directly(schedule_without_email)
+
+    scheduled_repetitions = {
+        'repetition_period_in_months': 2,
+        'number_of_repetitions': 3,
+        'email': 'test@example.com'
+    }
+
+    builder = MagicMock()
+    zim_schedules.schedule_future_zimfile_generations(
+        redis=MagicMock(),
+        wp10db=self.wp10db,
+        builder=builder,
+        zim_schedule_id=self.schedule_id,
+        scheduled_repetitions=scheduled_repetitions)
+
+    # Verify confirmation email was sent
+    mock_send_confirmation.assert_called_once_with(
+        recipient_username='testuser',
+        recipient_email='test@example.com',
+        zim_title='Test ZIM Schedule',
+        confirm_url=ANY,
+        unsubscribe_url=ANY,
+        repetition_period_months=2,
+        number_of_repetitions=3)
+
+    # Verify schedule has token
+    fetched = zim_schedules.get_zim_schedule(self.wp10db, self.schedule_id)
+    self.assertIsNotNone(fetched.s_email_confirmation_token)
+    self.assertEqual(b'test@example.com', fetched.s_email)
+
+  @patch('wp1.queues.schedule_recurring_zimfarm_task')
+  def test_schedule_future_zimfile_generations_without_email_no_token(
+      self, mock_schedule_task):
+    """Test that scheduling without email doesn't generate token."""
+    job_mock = MagicMock()
+    job_mock.id = 'test-job-id'
+    mock_schedule_task.return_value = job_mock
+
+    schedule_without_email = ZimSchedule(
+        s_id=self.schedule_id,
+        s_builder_id=self.builder_id,
+        s_rq_job_id=None,
+        s_last_updated_at=utcnow().strftime(TS_FORMAT_WP10).encode('utf-8'),
+        s_title=b'Test ZIM Schedule')
+    self._insert_zim_schedule_directly(schedule_without_email)
+
+    scheduled_repetitions = {
+        'repetition_period_in_months': 2,
+        'number_of_repetitions': 3
+    }
+
+    builder = MagicMock()
+    zim_schedules.schedule_future_zimfile_generations(
+        redis=MagicMock(),
+        wp10db=self.wp10db,
+        builder=builder,
+        zim_schedule_id=self.schedule_id,
+        scheduled_repetitions=scheduled_repetitions)
+
+    # Verify no token was generated
+    fetched = zim_schedules.get_zim_schedule(self.wp10db, self.schedule_id)
+    self.assertIsNone(fetched.s_email_confirmation_token)
+    self.assertIsNone(fetched.s_email)
+
+  def test_has_email_been_confirmed_false_no_email(self):
+    """Test has_email_been_confirmed returns False when email doesn't exist."""
+    result = zim_schedules.has_email_been_confirmed(self.wp10db,
+                                                    b'nonexistent@example.com')
+    self.assertFalse(result)
+
+  def test_has_email_been_confirmed_false_unconfirmed_email(self):
+    """Test has_email_been_confirmed returns False when email has token."""
+    self._insert_zim_schedule_directly(self.zim_schedule)
+    result = zim_schedules.has_email_been_confirmed(self.wp10db,
+                                                    b'test@example.com')
+    self.assertFalse(result)
+
+  def test_has_email_been_confirmed_true_confirmed_email(self):
+    """Test has_email_been_confirmed returns True when email is confirmed."""
+    # Create schedule with confirmed email (no token)
+    confirmed_schedule = ZimSchedule(
+        s_id=self.schedule_id,
+        s_builder_id=self.builder_id,
+        s_rq_job_id=b'test-job-id',
+        s_last_updated_at=utcnow().strftime(TS_FORMAT_WP10).encode('utf-8'),
+        s_interval=3,
+        s_remaining_generations=5,
+        s_email=b'test@example.com',
+        s_title=b'Test ZIM Schedule',
+        s_description=b'Test description',
+        s_long_description=b'Test long description',
+        s_email_confirmation_token=None  # Already confirmed
+    )
+    self._insert_zim_schedule_directly(confirmed_schedule)
+
+    result = zim_schedules.has_email_been_confirmed(self.wp10db,
+                                                    b'test@example.com')
+    self.assertTrue(result)
+
+  @patch('wp1.logic.zim_schedules.send_zim_email_confirmation')
+  @patch('wp1.logic.zim_schedules.get_username_by_zim_schedule_id')
+  @patch('wp1.queues.schedule_recurring_zimfarm_task')
+  def test_schedule_with_previously_confirmed_email_skips_confirmation(
+      self, mock_schedule_task, mock_get_username, mock_send_confirmation):
+    """Test that scheduling with previously confirmed email skips confirmation process."""
+    job_mock = MagicMock()
+    job_mock.id = 'test-job-id'
+    mock_schedule_task.return_value = job_mock
+    mock_get_username.return_value = 'testuser'
+
+    # Create first schedule with confirmed email (no token)
+    first_schedule_id = str(uuid.uuid4()).encode('utf-8')
+    first_schedule = ZimSchedule(
+        s_id=first_schedule_id,
+        s_builder_id=self.builder_id,
+        s_rq_job_id=b'first-job-id',
+        s_last_updated_at=utcnow().strftime(TS_FORMAT_WP10).encode('utf-8'),
+        s_title=b'First ZIM Schedule',
+        s_email=b'test@example.com',
+        s_email_confirmation_token=None  # Already confirmed
+    )
+    self._insert_zim_schedule_directly(first_schedule)
+
+    # Create second schedule without email initially
+    second_schedule_id = str(uuid.uuid4()).encode('utf-8')
+    second_schedule = ZimSchedule(
+        s_id=second_schedule_id,
+        s_builder_id=self.builder_id,
+        s_rq_job_id=None,
+        s_last_updated_at=utcnow().strftime(TS_FORMAT_WP10).encode('utf-8'),
+        s_title=b'Second ZIM Schedule')
+    self._insert_zim_schedule_directly(second_schedule)
+
+    # Schedule with the same confirmed email
+    scheduled_repetitions = {
+        'repetition_period_in_months': 2,
+        'number_of_repetitions': 3,
+        'email': 'test@example.com'
+    }
+
+    builder = MagicMock()
+    zim_schedules.schedule_future_zimfile_generations(
+        redis=MagicMock(),
+        wp10db=self.wp10db,
+        builder=builder,
+        zim_schedule_id=second_schedule_id,
+        scheduled_repetitions=scheduled_repetitions)
+
+    # Verify confirmation email was NOT sent (because email was previously confirmed)
+    mock_send_confirmation.assert_not_called()
+
+    # Verify second schedule has email but no token (automatically confirmed)
+    fetched = zim_schedules.get_zim_schedule(self.wp10db, second_schedule_id)
+    self.assertEqual(b'test@example.com', fetched.s_email)
+    self.assertIsNone(fetched.s_email_confirmation_token)
+
+  def test_confirm_email_subscription_confirms_all_with_same_email(self):
+    """Test that confirming one email confirms all schedules with the same email address."""
+    schedule1_id = str(uuid.uuid4()).encode('utf-8')
+    schedule2_id = str(uuid.uuid4()).encode('utf-8')
+    token1 = zim_schedules.generate_email_confirmation_token()
+    token2 = zim_schedules.generate_email_confirmation_token()
+
+    schedule1 = attr.evolve(self.zim_schedule,
+                            s_id=schedule1_id,
+                            s_email_confirmation_token=token1)
+    schedule2 = attr.evolve(self.zim_schedule,
+                            s_id=schedule2_id,
+                            s_email_confirmation_token=token2)
+
+    self._insert_zim_schedule_directly(self.zim_schedule)
+    self._insert_zim_schedule_directly(schedule1)
+    self._insert_zim_schedule_directly(schedule2)
+
+    success = zim_schedules.confirm_email_subscription(self.wp10db, token1,
+                                                       b'test@example.com')
+    self.assertTrue(success)
+
+    with self.wp10db.cursor() as cursor:
+      cursor.execute(
+          'SELECT s_email_confirmation_token FROM zim_schedules WHERE s_email = %s',
+          (b'test@example.com',))
+      tokens = [row['s_email_confirmation_token'] for row in cursor.fetchall()]
+
+    self.assertTrue(not any(tokens))

--- a/wp1/web/zim_emails.py
+++ b/wp1/web/zim_emails.py
@@ -10,146 +10,160 @@ logger = logging.getLogger(__name__)
 zim_emails = flask.Blueprint('zim_emails', __name__)
 
 
-def render_error_page(title, heading, message, status_code=400, is_success=False, zim_title=None):
-    """Renders a standardized error/success page using the shared template."""
-    template = jinja_env.get_template('zim-email-error.html.jinja2')
-    html_content = template.render(
-        title=title,
-        heading=heading,
-        message=message,
-        is_success=is_success,
-        zim_title=zim_title
-    )
-    return flask.Response(html_content, status=status_code, mimetype='text/html')
+def render_error_page(title,
+                      heading,
+                      message,
+                      status_code=400,
+                      is_success=False,
+                      zim_title=None):
+  """Renders a standardized error/success page using the shared template."""
+  template = jinja_env.get_template('zim-email-error.html.jinja2')
+  html_content = template.render(title=title,
+                                 heading=heading,
+                                 message=message,
+                                 is_success=is_success,
+                                 zim_title=zim_title)
+  return flask.Response(html_content, status=status_code, mimetype='text/html')
 
 
 @zim_emails.route('/confirm-email')
 def confirm_email():
-    """Confirms email subscription for ZIM notifications."""
-    token = flask.request.args.get('token')
-    if not token:
-        return render_error_page(
-            title='Invalid Link',
-            heading='Invalid Confirmation Link',
-            message='This confirmation link is invalid or missing required parameters.'
-        )
+  """Confirms email subscription for ZIM notifications."""
+  token = flask.request.args.get('token')
+  if not token:
+    return render_error_page(
+        title='Invalid Link',
+        heading='Invalid Confirmation Link',
+        message=
+        'This confirmation link is invalid or missing required parameters.')
 
-    wp10db = get_db('wp10db')
-    
-    # Get the schedule details before confirming
-    schedule = zim_schedules.get_zim_schedule_by_token(wp10db, token.encode('utf-8'))
-    if not schedule:
-        return render_error_page(
-            title='Invalid Token',
-            heading='Invalid or Expired Confirmation Link',
-            message='This confirmation link is invalid, expired, or has already been used.',
-            status_code=404
-        )
+  wp10db = get_db('wp10db')
 
-    # Confirm the email subscription
-    success = zim_schedules.confirm_email_subscription(wp10db, token.encode('utf-8'))
-    
-    if success:
-        zim_title = schedule.s_title.decode('utf-8') if schedule.s_title else 'Your ZIM File'
-        return render_error_page(
-            title='Email Confirmed',
-            heading='Email Confirmed Successfully!',
-            message='You will now receive email notifications when your ZIM file generation is completed.',
-            status_code=200,
-            is_success=True,
-            zim_title=zim_title
-        )
-    else:
-        return render_error_page(
-            title='Confirmation Failed',
-            heading='Confirmation Failed',
-            message='Unable to confirm your email subscription. The link may have already been used or expired.'
-        )
+  # Get the schedule details before confirming
+  schedule = zim_schedules.get_zim_schedule_by_token(wp10db,
+                                                     token.encode('utf-8'))
+  if not schedule:
+    return render_error_page(
+        title='Invalid Token',
+        heading='Invalid or Expired Confirmation Link',
+        message=
+        'This confirmation link is invalid, expired, or has already been used.',
+        status_code=404)
+
+  # Confirm the email subscription
+  success = zim_schedules.confirm_email_subscription(wp10db,
+                                                     token.encode('utf-8'),
+                                                     schedule.s_email)
+
+  if success:
+    zim_title = schedule.s_title.decode(
+        'utf-8') if schedule.s_title else 'Your ZIM File'
+    return render_error_page(
+        title='Email Confirmed',
+        heading='Email Confirmed Successfully!',
+        message=
+        'You will now receive email notifications when your ZIM file generation is completed.',
+        status_code=200,
+        is_success=True,
+        zim_title=zim_title)
+  else:
+    return render_error_page(
+        title='Confirmation Failed',
+        heading='Confirmation Failed',
+        message=
+        'Unable to confirm your email subscription. The link may have already been used or expired.'
+    )
 
 
 @zim_emails.route('/unsubscribe-email')
 def unsubscribe_email():
-    """Unsubscribes from email notifications for ZIM files."""
-    token = flask.request.args.get('token')
-    if not token:
-        return render_error_page(
-            title='Invalid Link',
-            heading='Invalid Unsubscribe Link',
-            message='This unsubscribe link is invalid or missing required parameters.'
-        )
+  """Unsubscribes from email notifications for ZIM files."""
+  token = flask.request.args.get('token')
+  if not token:
+    return render_error_page(
+        title='Invalid Link',
+        heading='Invalid Unsubscribe Link',
+        message=
+        'This unsubscribe link is invalid or missing required parameters.')
 
-    wp10db = get_db('wp10db')
-    
-    # Get the schedule details before unsubscribing
-    schedule = zim_schedules.get_zim_schedule_by_token(wp10db, token.encode('utf-8'))
-    if not schedule:
-        return render_error_page(
-            title='Invalid Token',
-            heading='Invalid or Expired Unsubscribe Link',
-            message='This unsubscribe link is invalid, expired, or has already been used.',
-            status_code=404
-        )
+  wp10db = get_db('wp10db')
 
-    # Unsubscribe from email notifications
-    success = zim_schedules.unsubscribe_email(wp10db, token.encode('utf-8'))
-    
-    if success:
-        zim_title = schedule.s_title.decode('utf-8') if schedule.s_title else 'Your ZIM File'
-        return render_error_page(
-            title='Successfully Unsubscribed',
-            heading='Successfully Unsubscribed',
-            message='You will no longer receive email notifications for this ZIM file generation.',
-            status_code=200,
-            is_success=True,
-            zim_title=zim_title
-        )
-    else:
-        return render_error_page(
-            title='Unsubscribe Failed',
-            heading='Unsubscribe Failed',
-            message='Unable to unsubscribe from email notifications. The link may have already been used or expired.'
-        )
+  # Get the schedule details before unsubscribing
+  schedule = zim_schedules.get_zim_schedule_by_token(wp10db,
+                                                     token.encode('utf-8'))
+  if not schedule:
+    return render_error_page(
+        title='Invalid Token',
+        heading='Invalid or Expired Unsubscribe Link',
+        message=
+        'This unsubscribe link is invalid, expired, or has already been used.',
+        status_code=404)
+
+  # Unsubscribe from email notifications
+  success = zim_schedules.unsubscribe_email(wp10db, token.encode('utf-8'))
+
+  if success:
+    zim_title = schedule.s_title.decode(
+        'utf-8') if schedule.s_title else 'Your ZIM File'
+    return render_error_page(
+        title='Successfully Unsubscribed',
+        heading='Successfully Unsubscribed',
+        message=
+        'You will no longer receive email notifications for this ZIM file generation.',
+        status_code=200,
+        is_success=True,
+        zim_title=zim_title)
+  else:
+    return render_error_page(
+        title='Unsubscribe Failed',
+        heading='Unsubscribe Failed',
+        message=
+        'Unable to unsubscribe from email notifications. The link may have already been used or expired.'
+    )
 
 
 @zim_emails.route('/unsubscribe-notification')
 def unsubscribe_notification():
-    """Unsubscribes from email notifications for ZIM files using schedule ID."""
-    schedule_id = flask.request.args.get('schedule_id')
-    if not schedule_id:
-        return render_error_page(
-            title='Invalid Link',
-            heading='Invalid Unsubscribe Link',
-            message='This unsubscribe link is invalid or missing required parameters.'
-        )
+  """Unsubscribes from email notifications for ZIM files using schedule ID."""
+  schedule_id = flask.request.args.get('schedule_id')
+  if not schedule_id:
+    return render_error_page(
+        title='Invalid Link',
+        heading='Invalid Unsubscribe Link',
+        message=
+        'This unsubscribe link is invalid or missing required parameters.')
 
-    wp10db = get_db('wp10db')
-    
-    # Get the schedule details before unsubscribing
-    schedule = zim_schedules.get_zim_schedule(wp10db, schedule_id.encode('utf-8'))
-    if not schedule or not schedule.s_email:
-        return render_error_page(
-            title='Invalid Schedule',
-            heading='Invalid or Already Unsubscribed',
-            message='This schedule is invalid or you have already been unsubscribed from email notifications.',
-            status_code=404
-        )
+  wp10db = get_db('wp10db')
 
-    # Unsubscribe from email notifications by removing email
-    success = zim_schedules.unsubscribe_email_by_schedule_id(wp10db, schedule_id.encode('utf-8'))
-    
-    if success:
-        zim_title = schedule.s_title.decode('utf-8') if schedule.s_title else 'Your ZIM File'
-        return render_error_page(
-            title='Successfully Unsubscribed',
-            heading='Successfully Unsubscribed',
-            message='You will no longer receive email notifications for this ZIM file generation.',
-            status_code=200,
-            is_success=True,
-            zim_title=zim_title
-        )
-    else:
-        return render_error_page(
-            title='Unsubscribe Failed',
-            heading='Unsubscribe Failed',
-            message='Unable to unsubscribe from email notifications. You may have already been unsubscribed.'
-        )
+  # Get the schedule details before unsubscribing
+  schedule = zim_schedules.get_zim_schedule(wp10db, schedule_id.encode('utf-8'))
+  if not schedule or not schedule.s_email:
+    return render_error_page(
+        title='Invalid Schedule',
+        heading='Invalid or Already Unsubscribed',
+        message=
+        'This schedule is invalid or you have already been unsubscribed from email notifications.',
+        status_code=404)
+
+  # Unsubscribe from email notifications by removing email
+  success = zim_schedules.unsubscribe_email_by_schedule_id(
+      wp10db, schedule_id.encode('utf-8'))
+
+  if success:
+    zim_title = schedule.s_title.decode(
+        'utf-8') if schedule.s_title else 'Your ZIM File'
+    return render_error_page(
+        title='Successfully Unsubscribed',
+        heading='Successfully Unsubscribed',
+        message=
+        'You will no longer receive email notifications for this ZIM file generation.',
+        status_code=200,
+        is_success=True,
+        zim_title=zim_title)
+  else:
+    return render_error_page(
+        title='Unsubscribe Failed',
+        heading='Unsubscribe Failed',
+        message=
+        'Unable to unsubscribe from email notifications. You may have already been unsubscribed.'
+    )

--- a/wp1/web/zim_emails_test.py
+++ b/wp1/web/zim_emails_test.py
@@ -12,181 +12,190 @@ from wp1.timestamp import utcnow
 
 class ZimEmailsEndpointsTest(BaseWpOneDbTest):
 
-    def setUp(self):
-        super().setUp()
-        self.app = create_app()
-        self.token = zim_schedules.generate_email_confirmation_token()
-        self.schedule_id = str(uuid.uuid4()).encode('utf-8')
-        
-        self.zim_schedule = ZimSchedule(
-            s_id=self.schedule_id,
-            s_builder_id=str(uuid.uuid4()).encode('utf-8'),
-            s_rq_job_id=b'test-job-id',
-            s_last_updated_at=utcnow().strftime(TS_FORMAT_WP10).encode('utf-8'),
-            s_interval=3,
-            s_remaining_generations=5,
-            s_email=b'test@example.com',
-            s_title=b'Test ZIM Schedule',
-            s_description=b'Test description',
-            s_long_description=b'Test long description',
-            s_email_confirmation_token=self.token
-        )
+  def setUp(self):
+    super().setUp()
+    self.app = create_app()
+    self.token = zim_schedules.generate_email_confirmation_token()
+    self.schedule_id = str(uuid.uuid4()).encode('utf-8')
 
-    def test_confirm_email_success(self):
-        """Test successful email confirmation."""
-        # Insert schedule with token
-        zim_schedules.insert_zim_schedule(self.wp10db, self.zim_schedule)
-        
-        with self.app.test_client() as client:
-            response = client.get(f'/v1/zim/confirm-email?token={self.token.decode("utf-8")}')
-            
-            self.assertEqual(200, response.status_code)
-            self.assertIn(b'Email Confirmed Successfully', response.data)
-            self.assertIn(b'Test ZIM Schedule', response.data)
-        
-        # Verify token was removed
-        fetched = zim_schedules.get_zim_schedule(self.wp10db, self.schedule_id)
-        self.assertIsNone(fetched.s_email_confirmation_token)
-        self.assertEqual(b'test@example.com', fetched.s_email)
+    self.zim_schedule = ZimSchedule(
+        s_id=self.schedule_id,
+        s_builder_id=str(uuid.uuid4()).encode('utf-8'),
+        s_rq_job_id=b'test-job-id',
+        s_last_updated_at=utcnow().strftime(TS_FORMAT_WP10).encode('utf-8'),
+        s_interval=3,
+        s_remaining_generations=5,
+        s_email=b'test@example.com',
+        s_title=b'Test ZIM Schedule',
+        s_description=b'Test description',
+        s_long_description=b'Test long description',
+        s_email_confirmation_token=self.token)
 
-    def test_confirm_email_missing_token(self):
-        """Test email confirmation with missing token."""
-        with self.app.test_client() as client:
-            response = client.get('/v1/zim/confirm-email')
-            
-            self.assertEqual(400, response.status_code)
-            self.assertIn(b'Invalid Confirmation Link', response.data)
+  def test_confirm_email_success(self):
+    """Test successful email confirmation."""
+    # Insert schedule with token
+    zim_schedules.insert_zim_schedule(self.wp10db, self.zim_schedule)
 
-    def test_confirm_email_invalid_token(self):
-        """Test email confirmation with invalid token."""
-        with self.app.test_client() as client:
-            response = client.get('/v1/zim/confirm-email?token=invalid-token')
-            
-            self.assertEqual(404, response.status_code)
-            self.assertIn(b'Invalid or Expired Confirmation Link', response.data)
+    with self.app.test_client() as client:
+      response = client.get(
+          f'/v1/zim/confirm-email?token={self.token.decode("utf-8")}')
 
-    def test_confirm_email_already_confirmed(self):
-        """Test email confirmation with already used token."""
-        # Insert schedule and confirm once
-        zim_schedules.insert_zim_schedule(self.wp10db, self.zim_schedule)
-        zim_schedules.confirm_email_subscription(self.wp10db, self.token)
-        
-        with self.app.test_client() as client:
-            response = client.get(f'/v1/zim/confirm-email?token={self.token.decode("utf-8")}')
-            
-            self.assertEqual(404, response.status_code)
-            self.assertIn(b'Invalid or Expired Confirmation Link', response.data)
+      self.assertEqual(200, response.status_code)
+      self.assertIn(b'Email Confirmed Successfully', response.data)
+      self.assertIn(b'Test ZIM Schedule', response.data)
 
-    def test_unsubscribe_email_success(self):
-        """Test successful email unsubscribe."""
-        # Insert schedule with token
-        zim_schedules.insert_zim_schedule(self.wp10db, self.zim_schedule)
-        
-        with self.app.test_client() as client:
-            response = client.get(f'/v1/zim/unsubscribe-email?token={self.token.decode("utf-8")}')
-            
-            self.assertEqual(200, response.status_code)
-            self.assertIn(b'Successfully Unsubscribed', response.data)
-            self.assertIn(b'Test ZIM Schedule', response.data)
-        
-        # Verify both email and token were removed
-        fetched = zim_schedules.get_zim_schedule(self.wp10db, self.schedule_id)
-        self.assertIsNone(fetched.s_email_confirmation_token)
-        self.assertIsNone(fetched.s_email)
+    # Verify token was removed
+    fetched = zim_schedules.get_zim_schedule(self.wp10db, self.schedule_id)
+    self.assertIsNone(fetched.s_email_confirmation_token)
+    self.assertEqual(b'test@example.com', fetched.s_email)
 
-    def test_unsubscribe_email_missing_token(self):
-        """Test email unsubscribe with missing token."""
-        with self.app.test_client() as client:
-            response = client.get('/v1/zim/unsubscribe-email')
-            
-            self.assertEqual(400, response.status_code)
-            self.assertIn(b'Invalid Unsubscribe Link', response.data)
+  def test_confirm_email_missing_token(self):
+    """Test email confirmation with missing token."""
+    with self.app.test_client() as client:
+      response = client.get('/v1/zim/confirm-email')
 
-    def test_unsubscribe_email_invalid_token(self):
-        """Test email unsubscribe with invalid token."""
-        with self.app.test_client() as client:
-            response = client.get('/v1/zim/unsubscribe-email?token=invalid-token')
-            
-            self.assertEqual(404, response.status_code)
-            self.assertIn(b'Invalid or Expired Unsubscribe Link', response.data)
+      self.assertEqual(400, response.status_code)
+      self.assertIn(b'Invalid Confirmation Link', response.data)
 
-    def test_unsubscribe_email_already_unsubscribed(self):
-        """Test email unsubscribe with already used token."""
-        # Insert schedule and unsubscribe once
-        zim_schedules.insert_zim_schedule(self.wp10db, self.zim_schedule)
-        zim_schedules.unsubscribe_email(self.wp10db, self.token)
-        
-        with self.app.test_client() as client:
-            response = client.get(f'/v1/zim/unsubscribe-email?token={self.token.decode("utf-8")}')
-            
-            self.assertEqual(404, response.status_code)
-            self.assertIn(b'Invalid or Expired Unsubscribe Link', response.data)
+  def test_confirm_email_invalid_token(self):
+    """Test email confirmation with invalid token."""
+    with self.app.test_client() as client:
+      response = client.get('/v1/zim/confirm-email?token=invalid-token')
 
-    def test_unsubscribe_notification_success(self):
-        """Test notification unsubscribe success using schedule ID."""
-        # Insert confirmed schedule (no token)
-        confirmed_schedule = ZimSchedule(
-            s_id=self.schedule_id,
-            s_builder_id=str(uuid.uuid4()).encode('utf-8'),
-            s_rq_job_id=b'test-job-id',
-            s_last_updated_at=utcnow().strftime(TS_FORMAT_WP10).encode('utf-8'),
-            s_interval=3,
-            s_remaining_generations=5,
-            s_email=b'test@example.com',
-            s_title=b'Test ZIM Schedule',
-            s_description=b'Test description',
-            s_long_description=b'Test long description',
-            s_email_confirmation_token=None  # Confirmed email
-        )
-        zim_schedules.insert_zim_schedule(self.wp10db, confirmed_schedule)
-        
-        with self.app.test_client() as client:
-            response = client.get(f'/v1/zim/unsubscribe-notification?schedule_id={self.schedule_id.decode("utf-8")}')
-            
-            self.assertEqual(200, response.status_code)
-            self.assertIn(b'Successfully Unsubscribed', response.data)
-            self.assertIn(b'Test ZIM Schedule', response.data)
-            
-            # Verify email was removed from database
-            updated_schedule = zim_schedules.get_zim_schedule(self.wp10db, self.schedule_id)
-            self.assertIsNone(updated_schedule.s_email)
+      self.assertEqual(404, response.status_code)
+      self.assertIn(b'Invalid or Expired Confirmation Link', response.data)
 
-    def test_unsubscribe_notification_missing_schedule_id(self):
-        """Test notification unsubscribe without schedule_id parameter."""
-        with self.app.test_client() as client:
-            response = client.get('/v1/zim/unsubscribe-notification')
-            
-            self.assertEqual(400, response.status_code)
-            self.assertIn(b'Invalid Unsubscribe Link', response.data)
+  def test_confirm_email_already_confirmed(self):
+    """Test email confirmation with already used token."""
+    # Insert schedule and confirm once
+    zim_schedules.insert_zim_schedule(self.wp10db, self.zim_schedule)
+    zim_schedules.confirm_email_subscription(self.wp10db, self.token,
+                                             b'test@example.com')
 
-    def test_unsubscribe_notification_invalid_schedule_id(self):
-        """Test notification unsubscribe with invalid schedule ID."""
-        with self.app.test_client() as client:
-            response = client.get('/v1/zim/unsubscribe-notification?schedule_id=invalid-schedule-id')
-            
-            self.assertEqual(404, response.status_code)
-            self.assertIn(b'Invalid or Already Unsubscribed', response.data)
+    with self.app.test_client() as client:
+      response = client.get(
+          f'/v1/zim/confirm-email?token={self.token.decode("utf-8")}')
 
-    def test_unsubscribe_notification_no_email(self):
-        """Test notification unsubscribe for schedule without email."""
-        # Insert schedule without email
-        schedule_no_email = ZimSchedule(
-            s_id=self.schedule_id,
-            s_builder_id=str(uuid.uuid4()).encode('utf-8'),
-            s_rq_job_id=b'test-job-id',
-            s_last_updated_at=utcnow().strftime(TS_FORMAT_WP10).encode('utf-8'),
-            s_interval=3,
-            s_remaining_generations=5,
-            s_email=None,  # No email
-            s_title=b'Test ZIM Schedule',
-            s_description=b'Test description',
-            s_long_description=b'Test long description',
-            s_email_confirmation_token=None
-        )
-        zim_schedules.insert_zim_schedule(self.wp10db, schedule_no_email)
-        
-        with self.app.test_client() as client:
-            response = client.get(f'/v1/zim/unsubscribe-notification?schedule_id={self.schedule_id.decode("utf-8")}')
-            
-            self.assertEqual(404, response.status_code)
-            self.assertIn(b'Invalid or Already Unsubscribed', response.data)
+      self.assertEqual(404, response.status_code)
+      self.assertIn(b'Invalid or Expired Confirmation Link', response.data)
+
+  def test_unsubscribe_email_success(self):
+    """Test successful email unsubscribe."""
+    # Insert schedule with token
+    zim_schedules.insert_zim_schedule(self.wp10db, self.zim_schedule)
+
+    with self.app.test_client() as client:
+      response = client.get(
+          f'/v1/zim/unsubscribe-email?token={self.token.decode("utf-8")}')
+
+      self.assertEqual(200, response.status_code)
+      self.assertIn(b'Successfully Unsubscribed', response.data)
+      self.assertIn(b'Test ZIM Schedule', response.data)
+
+    # Verify both email and token were removed
+    fetched = zim_schedules.get_zim_schedule(self.wp10db, self.schedule_id)
+    self.assertIsNone(fetched.s_email_confirmation_token)
+    self.assertIsNone(fetched.s_email)
+
+  def test_unsubscribe_email_missing_token(self):
+    """Test email unsubscribe with missing token."""
+    with self.app.test_client() as client:
+      response = client.get('/v1/zim/unsubscribe-email')
+
+      self.assertEqual(400, response.status_code)
+      self.assertIn(b'Invalid Unsubscribe Link', response.data)
+
+  def test_unsubscribe_email_invalid_token(self):
+    """Test email unsubscribe with invalid token."""
+    with self.app.test_client() as client:
+      response = client.get('/v1/zim/unsubscribe-email?token=invalid-token')
+
+      self.assertEqual(404, response.status_code)
+      self.assertIn(b'Invalid or Expired Unsubscribe Link', response.data)
+
+  def test_unsubscribe_email_already_unsubscribed(self):
+    """Test email unsubscribe with already used token."""
+    # Insert schedule and unsubscribe once
+    zim_schedules.insert_zim_schedule(self.wp10db, self.zim_schedule)
+    zim_schedules.unsubscribe_email(self.wp10db, self.token)
+
+    with self.app.test_client() as client:
+      response = client.get(
+          f'/v1/zim/unsubscribe-email?token={self.token.decode("utf-8")}')
+
+      self.assertEqual(404, response.status_code)
+      self.assertIn(b'Invalid or Expired Unsubscribe Link', response.data)
+
+  def test_unsubscribe_notification_success(self):
+    """Test notification unsubscribe success using schedule ID."""
+    # Insert confirmed schedule (no token)
+    confirmed_schedule = ZimSchedule(
+        s_id=self.schedule_id,
+        s_builder_id=str(uuid.uuid4()).encode('utf-8'),
+        s_rq_job_id=b'test-job-id',
+        s_last_updated_at=utcnow().strftime(TS_FORMAT_WP10).encode('utf-8'),
+        s_interval=3,
+        s_remaining_generations=5,
+        s_email=b'test@example.com',
+        s_title=b'Test ZIM Schedule',
+        s_description=b'Test description',
+        s_long_description=b'Test long description',
+        s_email_confirmation_token=None  # Confirmed email
+    )
+    zim_schedules.insert_zim_schedule(self.wp10db, confirmed_schedule)
+
+    with self.app.test_client() as client:
+      response = client.get(
+          f'/v1/zim/unsubscribe-notification?schedule_id={self.schedule_id.decode("utf-8")}'
+      )
+
+      self.assertEqual(200, response.status_code)
+      self.assertIn(b'Successfully Unsubscribed', response.data)
+      self.assertIn(b'Test ZIM Schedule', response.data)
+
+      # Verify email was removed from database
+      updated_schedule = zim_schedules.get_zim_schedule(self.wp10db,
+                                                        self.schedule_id)
+      self.assertIsNone(updated_schedule.s_email)
+
+  def test_unsubscribe_notification_missing_schedule_id(self):
+    """Test notification unsubscribe without schedule_id parameter."""
+    with self.app.test_client() as client:
+      response = client.get('/v1/zim/unsubscribe-notification')
+
+      self.assertEqual(400, response.status_code)
+      self.assertIn(b'Invalid Unsubscribe Link', response.data)
+
+  def test_unsubscribe_notification_invalid_schedule_id(self):
+    """Test notification unsubscribe with invalid schedule ID."""
+    with self.app.test_client() as client:
+      response = client.get(
+          '/v1/zim/unsubscribe-notification?schedule_id=invalid-schedule-id')
+
+      self.assertEqual(404, response.status_code)
+      self.assertIn(b'Invalid or Already Unsubscribed', response.data)
+
+  def test_unsubscribe_notification_no_email(self):
+    """Test notification unsubscribe for schedule without email."""
+    # Insert schedule without email
+    schedule_no_email = ZimSchedule(
+        s_id=self.schedule_id,
+        s_builder_id=str(uuid.uuid4()).encode('utf-8'),
+        s_rq_job_id=b'test-job-id',
+        s_last_updated_at=utcnow().strftime(TS_FORMAT_WP10).encode('utf-8'),
+        s_interval=3,
+        s_remaining_generations=5,
+        s_email=None,  # No email
+        s_title=b'Test ZIM Schedule',
+        s_description=b'Test description',
+        s_long_description=b'Test long description',
+        s_email_confirmation_token=None)
+    zim_schedules.insert_zim_schedule(self.wp10db, schedule_no_email)
+
+    with self.app.test_client() as client:
+      response = client.get(
+          f'/v1/zim/unsubscribe-notification?schedule_id={self.schedule_id.decode("utf-8")}'
+      )
+
+      self.assertEqual(404, response.status_code)
+      self.assertIn(b'Invalid or Already Unsubscribed', response.data)


### PR DESCRIPTION
If a user schedules another ZIM with the same email address, we shouldn't have to send a confirmation email if they've already confirmed their email. This PR adds logic to check if there is any confirmed email that matches, and then skips confirmation in that case.

Also, if there are multiple rows with the same email that need to be confirmed, confirm all of them when one is confirmed. So if the user has multiple confirmation emails, clicking any of them will confirm all of the schedules with that email address.

Note: Unfortunately, these files were never formatted with yapf, so there are a lot of formatting changes. Sorry!