### PR TITLE
Fix OAuth tests to work locally and in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         # Some unit tests also try to write to Redis
         image: redis
         ports:
-          - 6379:6379
+          - 9777:6379
         options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:

--- a/wp1/credentials.py.e2e
+++ b/wp1/credentials.py.e2e
@@ -67,7 +67,7 @@ CREDENTIALS = {
         },
         'REDIS': {
             'host': 'localhost',
-            'port': 6379,  # Specified in docker-compose-dev.yml
+            'port': 9777,  # Specified in docker-compose-dev.yml
         },
         'CLIENT_URL': {
             'api': 'http://test.server.fake'

--- a/wp1/web/app.py
+++ b/wp1/web/app.py
@@ -1,23 +1,25 @@
-from datetime import datetime
-from functools import wraps, update_wrapper
-from flask_session import Session
 import os
+from datetime import datetime
+from functools import update_wrapper, wraps
+
 import flask
 import flask_cors
 import flask_gzip
 import redis
 
 import wp1.logic.project as logic_project
+from flask_session import Session
 from wp1 import environment
-from wp1.web.db import get_db, has_db
+from wp1.credentials import CREDENTIALS, ENV
 from wp1.web.articles import articles
 from wp1.web.builders import builders
+from wp1.web.db import get_db, has_db
+from wp1.web.dev.projects import dev_projects
+from wp1.web.oauth import oauth
 from wp1.web.projects import projects
 from wp1.web.selection import selection
-from wp1.web.zim_emails import zim_emails
-from wp1.credentials import ENV, CREDENTIALS
 from wp1.web.sites import sites
-from wp1.web.dev.projects import dev_projects
+from wp1.web.zim_emails import zim_emails
 
 
 def get_redis_creds():
@@ -53,13 +55,11 @@ def nocache(view):
   return update_wrapper(no_cache, view)
 
 
-def create_app():
+def create_app(session_type='redis'):
   app = flask.Flask(__name__)
-  missing_credentials = CREDENTIALS is None or ENV is None
 
   cors_origins = None
-  if not missing_credentials:
-    cors_origins = CREDENTIALS[ENV].get('CLIENT_URL', {}).get('domains')
+  cors_origins = CREDENTIALS[ENV].get('CLIENT_URL', {}).get('domains')
   if cors_origins is None:
     cors_origins = '*'
 
@@ -76,7 +76,7 @@ def create_app():
         redis_creds['host'], redis_creds['port']))
 
   app.config['SECRET_KEY'] = get_secret_key()
-  app.config['SESSION_TYPE'] = 'redis'
+  app.config['SESSION_TYPE'] = session_type
   Session(app)
 
   @app.teardown_request
@@ -107,12 +107,7 @@ def create_app():
   app.register_blueprint(selection, url_prefix='/v1/selection')
   app.register_blueprint(builders, url_prefix='/v1/builders')
   app.register_blueprint(zim_emails, url_prefix='/v1/zim')
+  app.register_blueprint(oauth, url_prefix='/v1/oauth')
 
-  if not missing_credentials:
-    mwoauth = CREDENTIALS.get(ENV, {}).get('MWOAUTH', {})
-  if not (missing_credentials or mwoauth.get('consumer_key') is None or
-          mwoauth.get('consumer_secret') is None):
-    from wp1.web.oauth import oauth
-    app.register_blueprint(oauth, url_prefix='/v1/oauth')
-
+  return app
   return app

--- a/wp1/web/oauth_test.py
+++ b/wp1/web/oauth_test.py
@@ -1,17 +1,38 @@
 import unittest
+from unittest.mock import Mock, patch
+
+from wp1.credentials import CREDENTIALS
 from wp1.environment import Environment
-from unittest.mock import patch, Mock
 from wp1.web.app import create_app
 from wp1.web.base_web_testcase import BaseWebTestcase
 from wp1.web.db import get_db
 
+USER = {
+    'access_token': 'access_token',
+    'identity': {
+        'username': 'WP1_user',
+        'email': 'wp1user@email.ch',
+        'sub': '1234'
+    }
+}
+REQUEST_TOKEN = {'key': 'request_token', 'secret': 'request_token_secret'}
+REDIRECT = 'https://en.wikipedia.org/w/index.php?oauth_token=token&oauth_consumer_key=key'
+handshaker = Mock(
+    **{
+        'initiate.return_value': (REDIRECT, REQUEST_TOKEN),
+        'complete.return_value': {
+            'key': 'access_token',
+            'secret': 'access_secret'
+        },
+        'identify.return_value': USER['identity']
+    })
+
 
 class IdentifyTest(BaseWebTestcase):
-
-  ENV = Environment.DEVELOPMENT
+  ENV = Environment.TEST
   TEST_OAUTH_CREDS = {
-      Environment.DEVELOPMENT: {
-          'API': {},
+      Environment.TEST: {
+          **CREDENTIALS[Environment.TEST], 'API': {},
           'MWOAUTH': {
               'consumer_key': 'consumer_key',
               'consumer_secret': 'consumer_secret'
@@ -26,89 +47,59 @@ class IdentifyTest(BaseWebTestcase):
       },
       Environment.PRODUCTION: {}
   }
-  REDIRECT = 'https://en.wikipedia.org/w/index.php?oauth_token=token&oauth_consumer_key=key'
-  USER = {
-      'access_token': 'access_token',
-      'identity': {
-          'username': 'WP1_user',
-          'email': 'wp1user@email.ch',
-          'sub': '1234'
-      }
-  }
-  
-  REQUEST_TOKEN = {'key': 'request_token', 'secret': 'request_token_secret'}
-  handshaker = Mock(
-      **{
-          'initiate.return_value': (REDIRECT, REQUEST_TOKEN),
-          'complete.return_value': {
-              'key': 'access_token',
-              'secret': 'access_secret'
-          },
-          'identify.return_value': USER['identity']
-      })
 
-  @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
-  @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
-  @patch('wp1.web.oauth.homepage_url',
-         TEST_OAUTH_CREDS[ENV]['CLIENT_URL']['homepage'])
+  @patch('wp1.web.oauth.CREDENTIALS', TEST_OAUTH_CREDS)
+  @patch('wp1.web.oauth.get_handshaker', lambda: handshaker)
   def test_initiate_authorized_user(self):
-    self.app = create_app()
+    self.app = create_app(session_type='filesystem')
     with self.app.test_client() as client:
       with client.session_transaction() as sess:
-        sess['user'] = self.USER
+        sess['user'] = USER
       rv = client.get('/v1/oauth/initiate')
-      self.assertEqual(
-          self.TEST_OAUTH_CREDS[self.ENV]['CLIENT_URL']['homepage'],
-          rv.location)
+      self.assertEqual('302 FOUND', rv.status)
+      self.assertEqual('http://localhost:5173/#/', rv.location)
 
-  @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
-  @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
-  @patch('wp1.web.oauth.handshaker', handshaker)
+  @patch('wp1.web.oauth.CREDENTIALS', TEST_OAUTH_CREDS)
+  @patch('wp1.web.oauth.get_handshaker', lambda: handshaker)
   def test_initiate_unauthorized_user(self):
     self.app = create_app()
     with self.app.test_client() as client:
       with client.session_transaction() as sess:
-        sess['request_token'] = self.REQUEST_TOKEN
+        sess['request_token'] = REQUEST_TOKEN
       rv = client.get('/v1/oauth/initiate')
-      self.assertEqual(self.REDIRECT, rv.location)
+      self.assertEqual(REDIRECT, rv.location)
 
-  @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
-  @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
-  @patch('wp1.web.oauth.homepage_url',
-         TEST_OAUTH_CREDS[ENV]['CLIENT_URL']['homepage'])
+  @patch('wp1.web.oauth.CREDENTIALS', TEST_OAUTH_CREDS)
   def test_initiate_authorized_user_with_next_path(self):
     self.app = create_app()
     with self.app.test_client() as client:
       with client.session_transaction() as sess:
-        sess['user'] = self.USER
+        sess['user'] = USER
       rv = client.get('/v1/oauth/initiate?next=update')
-      self.assertEqual(
-          f"{self.TEST_OAUTH_CREDS[self.ENV]['CLIENT_URL']['homepage']}update",
-          rv.location)
+      self.assertEqual('302 FOUND', rv.status)
+      self.assertEqual(f"http://localhost:5173/#/update", rv.location)
 
-  @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
-  @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
+  @patch('wp1.web.oauth.CREDENTIALS', TEST_OAUTH_CREDS)
   def test_complete_unauthorized_user(self):
     self.app = create_app()
     with self.app.test_client() as client:
       rv = client.get('/v1/oauth/complete')
       self.assertEqual('404 NOT FOUND', rv.status)
 
-  @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
-  @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
-  @patch('wp1.web.oauth.homepage_url',
-         TEST_OAUTH_CREDS[ENV]['CLIENT_URL']['homepage'])
-  @patch('wp1.web.oauth.handshaker', handshaker)
+  @patch('wp1.web.oauth.CREDENTIALS', TEST_OAUTH_CREDS)
+  @patch('wp1.web.oauth.get_handshaker', lambda: handshaker)
   def test_complete_authorized_user_email(self):
     self.app = create_app()
-    user_id = self.USER['identity']['sub']
+    user_id = USER['identity']['sub']
     with self.override_db(self.app), self.app.test_client() as client:
       with self.app.app_context():
         with self.wp10db.cursor() as cursor:
-          cursor.execute('INSERT INTO users (u_id, u_username, u_email) VALUES (%s, %s, %s)', (user_id, 'overwrite', 'test@test.it'))
+          cursor.execute(
+              'INSERT INTO users (u_id, u_username, u_email) VALUES (%s, %s, %s)',
+              (user_id, 'overwrite', 'test@test.it'))
           self.wp10db.commit()
       with client.session_transaction() as sess:
-        sess['request_token'] = self.REQUEST_TOKEN
+        sess['request_token'] = REQUEST_TOKEN
       client.get('/v1/oauth/complete?query_string')
 
       with self.wp10db.cursor() as cursor:
@@ -119,141 +110,124 @@ class IdentifyTest(BaseWebTestcase):
         self.assertEqual('WP1_user', row['u_username'].decode('utf-8'))
         self.assertEqual('wp1user@email.ch', row['u_email'].decode('utf-8'))
 
-  @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
-  @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
-  @patch('wp1.web.oauth.homepage_url',
-         TEST_OAUTH_CREDS[ENV]['CLIENT_URL']['homepage'])
-  @patch('wp1.web.oauth.handshaker', handshaker)
+  @patch('wp1.web.oauth.CREDENTIALS', TEST_OAUTH_CREDS)
+  @patch('wp1.web.oauth.get_handshaker', lambda: handshaker)
   def test_complete_authorized_user(self):
     self.app = create_app()
-    user_id = self.USER['identity']['sub']
+    user_id = USER['identity']['sub']
     with self.override_db(self.app), self.app.test_client() as client:
       with client.session_transaction() as sess:
-        sess['request_token'] = self.REQUEST_TOKEN
+        sess['request_token'] = REQUEST_TOKEN
       client.get('/v1/oauth/complete?query_string')
 
       with self.wp10db.cursor() as cursor:
         cursor.execute('SELECT * FROM users WHERE u_id = %s', (user_id))
         row = cursor.fetchone()
         self.assertIsNotNone(row)
-        self.assertEqual('wp1user@email.ch', row['u_email'].decode('utf-8')) 
+        self.assertEqual('wp1user@email.ch', row['u_email'].decode('utf-8'))
 
-  @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
-  @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
-  @patch('wp1.web.oauth.homepage_url',
-         TEST_OAUTH_CREDS[ENV]['CLIENT_URL']['homepage'])
-  @patch('wp1.web.oauth.handshaker', handshaker)
+  @patch('wp1.web.oauth.CREDENTIALS', TEST_OAUTH_CREDS)
+  @patch('wp1.web.oauth.get_handshaker', lambda: handshaker)
   def test_complete_authorized_user_with_next_path(self):
+    print(self.TEST_OAUTH_CREDS)
     self.app = create_app()
     with self.override_db(self.app), self.app.test_client() as client:
       with client.session_transaction() as sess:
-        sess['request_token'] = self.REQUEST_TOKEN
+        sess['request_token'] = REQUEST_TOKEN
         sess['next_path'] = 'update'
       rv = client.get('/v1/oauth/complete?query_string')
-      self.assertEqual(
-          f"{self.TEST_OAUTH_CREDS[self.ENV]['CLIENT_URL']['homepage']}update",
-          rv.location)
+      self.assertEqual('302 FOUND', rv.status)
+      self.assertEqual(f"http://localhost:5173/#/update", rv.location)
       wp10db = get_db('wp10db')
       with wp10db.cursor() as cursor:
         cursor.execute('SELECT * FROM users WHERE u_id = 1234')
         self.assertNotEqual(None, cursor.fetchone())
 
-  @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
-  @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
+  @patch('wp1.web.oauth.CREDENTIALS', TEST_OAUTH_CREDS)
   def test_identify_authorized_user(self):
     self.app = create_app()
     with self.app.test_client() as client:
       with client.session_transaction() as sess:
-        sess['user'] = self.USER
+        sess['user'] = USER
       rv = client.get('/v1/oauth/identify')
       self.assertEqual({"username": 'WP1_user'}, rv.get_json())
 
-  @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
-  @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
+  @patch('wp1.web.oauth.CREDENTIALS', TEST_OAUTH_CREDS)
   def test_identify_unauthorized_user(self):
     self.app = create_app()
     with self.app.test_client() as client:
       rv = client.get('/v1/oauth/identify')
       self.assertEqual('401 UNAUTHORIZED', rv.status)
 
-  @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
-  @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
+  @patch('wp1.web.oauth.CREDENTIALS', TEST_OAUTH_CREDS)
   def test_logout_authorized_user(self):
     self.app = create_app()
     with self.app.test_client() as client:
       with client.session_transaction() as sess:
-        sess['user'] = self.USER
+        sess['user'] = USER
         sess['next_path'] = '/'
       rv = client.get('/v1/oauth/logout')
       self.assertEqual({'status': '204'}, rv.get_json())
 
-  @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
-  @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
+  @patch('wp1.web.oauth.CREDENTIALS', TEST_OAUTH_CREDS)
   def test_logout_unauthorized_user(self):
     self.app = create_app()
     with self.app.test_client() as client:
       rv = client.get('/v1/oauth/logout')
       self.assertEqual('404 NOT FOUND', rv.status)
 
-  @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
-  @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
+  @patch('wp1.web.oauth.CREDENTIALS', TEST_OAUTH_CREDS)
   def test_email_unauthorized_user(self):
-      self.app = create_app()
-      with self.app.test_client() as client:
-          rv = client.get('/v1/oauth/email')
-          self.assertEqual('401 UNAUTHORIZED', rv.status)
+    self.app = create_app()
+    with self.app.test_client() as client:
+      rv = client.get('/v1/oauth/email')
+      self.assertEqual('401 UNAUTHORIZED', rv.status)
 
-  @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
-  @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
+  @patch('wp1.web.oauth.CREDENTIALS', TEST_OAUTH_CREDS)
   def test_email_authorized_user_with_email_in_session(self):
-      self.app = create_app()
-      with self.app.test_client() as client:
-          with client.session_transaction() as sess:
-              sess['user'] = self.USER
-          rv = client.get('/v1/oauth/email')
-          self.assertEqual({'email': self.USER['identity']['email']},
-                            rv.get_json())
+    self.app = create_app()
+    with self.app.test_client() as client:
+      with client.session_transaction() as sess:
+        sess['user'] = USER
+      rv = client.get('/v1/oauth/email')
+      self.assertEqual({'email': USER['identity']['email']}, rv.get_json())
 
-  @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
-  @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
+  @patch('wp1.web.oauth.CREDENTIALS', TEST_OAUTH_CREDS)
   def test_email_authorized_user_without_session_exists_in_db(self):
-      self.app = create_app()
-      user_id = self.USER['identity']['sub']
-      with self.override_db(self.app), self.app.test_client() as client:
-          # seed database with an email
-          with self.app.app_context():
-              with self.wp10db.cursor() as cursor:
-                  cursor.execute(
-                    'INSERT INTO users (u_id, u_username, u_email) VALUES (%s, %s, %s)',
-                    (user_id, 'someuser', 'dbemail@domain.com')
-                  )
-                  self.wp10db.commit()
-          with client.session_transaction() as sess:
-              sess['user'] = {
-                  'access_token': self.USER['access_token'],
-                  'identity': {
-                      'username': self.USER['identity']['username'],
-                      'sub': user_id
-                  }
-              }
-          rv = client.get('/v1/oauth/email')
-          self.assertEqual({'email': 'dbemail@domain.com'},
-                            rv.get_json())
+    self.app = create_app()
+    user_id = USER['identity']['sub']
+    with self.override_db(self.app), self.app.test_client() as client:
+      # seed database with an email
+      with self.app.app_context():
+        with self.wp10db.cursor() as cursor:
+          cursor.execute(
+              'INSERT INTO users (u_id, u_username, u_email) VALUES (%s, %s, %s)',
+              (user_id, 'someuser', 'dbemail@domain.com'))
+          self.wp10db.commit()
+      with client.session_transaction() as sess:
+        sess['user'] = {
+            'access_token': USER['access_token'],
+            'identity': {
+                'username': USER['identity']['username'],
+                'sub': user_id
+            }
+        }
+      rv = client.get('/v1/oauth/email')
+      self.assertEqual({'email': 'dbemail@domain.com'}, rv.get_json())
 
-  @patch('wp1.web.app.CREDENTIALS', TEST_OAUTH_CREDS)
-  @patch('wp1.web.app.ENV', Environment.DEVELOPMENT)
+  @patch('wp1.web.oauth.CREDENTIALS', TEST_OAUTH_CREDS)
   def test_email_authorized_user_without_session_not_in_db(self):
-      self.app = create_app()
-      user_id = self.USER['identity']['sub']
-      with self.override_db(self.app), self.app.test_client() as client:
-          # do not insert any user row
-          with client.session_transaction() as sess:
-              sess['user'] = {
-                  'access_token': self.USER['access_token'],
-                  'identity': {
-                      'username': self.USER['identity']['username'],
-                      'sub': user_id
-                  }
-              }
-          rv = client.get('/v1/oauth/email')
-          self.assertEqual({'email': None}, rv.get_json())
+    self.app = create_app()
+    user_id = USER['identity']['sub']
+    with self.override_db(self.app), self.app.test_client() as client:
+      # do not insert any user row
+      with client.session_transaction() as sess:
+        sess['user'] = {
+            'access_token': USER['access_token'],
+            'identity': {
+                'username': USER['identity']['username'],
+                'sub': user_id
+            }
+        }
+      rv = client.get('/v1/oauth/email')
+      self.assertEqual({'email': None}, rv.get_json())


### PR DESCRIPTION
Fixes #1019

Reworked the OAuth web module itself to defer loading of credentials, and make the handshaker more easily mockable. Also removed extraneous code in `app.py` that would silently not load OAuth.

Changed the port for Redis in CI to match the values in `docker-compose-test.yml`.

Update the tests to use this new mocking strategy.