### PR TITLE
Use builder id instead of selection id as key in v-for

### DIFF
--- a/wp1-frontend/src/components/MyLists.vue
+++ b/wp1-frontend/src/components/MyLists.vue
@@ -22,7 +22,7 @@
             </tr>
           </thead>
           <tbody>
-            <tr v-for="item in list" :key="item.s_id">
+            <tr v-for="item in list" :key="item.id">
               <td>{{ item.name }}</td>
               <td :data-order="item.created_at">
                 {{ localDate(item.created_at) }}


### PR DESCRIPTION
Fixes #986 

The `v-for` directive in Vue.js lets you iterate over an array. It is recommended to use the `:key` property to indicate that an item in the array is represented by a specific key, and allow for more granular updates. We were incorrectly using the _selection_ id instead of the _builder_ id, where the builder is the data model that represents the row. This meant that row was being updated inconsistently and the loading spinner wasn't being processed properly.

This only happened in production builds, because they are probably optimized for this row-level rendering.