### PR TITLE
Check  s3 delete_object response and return failure on errors

### DIFF
--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -144,7 +144,7 @@ def delete_keys_from_storage(keys):
     )
 
     fully_successful = True
-    errors = []
+
     # TODO: Check for errors in the response. For now, just pretend
     # it's always successful.
     # for e in (resp if resp is not None else {}).get('Errors', []):
@@ -154,13 +154,15 @@ def delete_keys_from_storage(keys):
 
     if isinstance(resp, dict):
         errors = resp.get("Errors", [])
-    if errors:
-        fully_successful = False
-        for e in errors:
-            logger.warning(
-                "Error deleting %r:[code=%r, msg=%r]",
-                (e["Key"], e["Code"], e["Message"]),
-            )
+        if errors:
+            fully_successful = False
+            for e in errors:
+                logger.warning(
+                    "Error deleting %r: [code=%r, msg=%r]",
+                    e["Key"],
+                    e["Code"],
+                    e["Message"],
+                )
 
     return fully_successful
 


### PR DESCRIPTION
**DESCRIPTION**

This PR fixes the behavior of  'delete_keys_from_storage' so that it correctly interprets the response returned by S3 'delete_objects' and returns an accurate success status.

Specifically, it preserves the intended behavior of existing tests: when delete_objects returns no response or a response without an Errors key, the operation is treated as successful. Additionally, the function was updated to safely handle cases where the S3 response is not a dictionary, ensuring consistent behavior across all scenarios.

**CHANGES IMPLEMENTED**

1. Parse the 'Errors' field when present in S3 response.
2. Return 'False' where one or more deletion operation fails.
3. Log S3 deletion errors with key,error code, and message.
4. Handle cases where 'delete_objects' returns a non dictionary response.

**TESTS**

All existing tests in selection_test.py now pass.
Added tests for new behavior:
 1. delete_objects returns none.
 2. delete_objects returns non dictionary.
