### PR TITLE
Also pass a context when creating schedules

### DIFF
--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -277,6 +277,7 @@ def _get_params(
         "name": get_zimfarm_schedule_name(builder.b_id.decode("utf-8")),
         "language": "eng",
         "category": "wikipedia",
+        "context": "wikimedia",
         "periodicity": "manually",
         "tags": [],
         "enabled": True,

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -29,6 +29,7 @@ class ZimFarmTest(BaseWpOneDbTest):
         "name": "wp1_selection_3c4d",
         "language": "eng",
         "category": "wikipedia",
+        "context": "wikimedia",
         "periodicity": "manually",
         "tags": [],
         "enabled": True,


### PR DESCRIPTION
In order to ensure Zimfarm tasks are ran on specific workers, we now have the concept of contexts, which allow to target workers to use.

We should use wikimedia context so that wp1 tasks are ran only on wikimedia workers, ensuring optimal results.

Nota: 
- Wikimedia Zimfarm workers already have the `wikimedia` context associated in prod, so it is safe to merge this
- once merged, I will manually fix existing schedules to add the `wikimedia` context
- this is not a pressing need, more a "cleanup" ; issue is that we have a new big worker we wanna onboard on both Zimfarms but we can't enable `mwoffliner` scraper on it for now because otherwise it will process wp1 tasks