### PR TITLE
Fixed syntax for imports at Credentials

### DIFF
--- a/wp1/time.py
+++ b/wp1/time.py
@@ -5,5 +5,5 @@ This wrapper class exists so that the current time can be mocked in tests.
 from datetime import datetime
 
 
-def get_current_datetime():
+def get_current_datetime() -> datetime:
     return datetime.now()

--- a/wp1/timestamp.py
+++ b/wp1/timestamp.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
 
 
-def utcnow():
+def utcnow() -> datetime:
     return datetime.now(timezone.utc)


### PR DESCRIPTION
Am extremely exhausted when am trying to setup `minio_key` container from 2 days finding throughout the repo an documentation, it's just a "+" this is not valid right? and i don't know how this change can be merged : 

```
'STORAGE': {
      +     'url': 'http://localhost:9000/',
            'key': 'minio_key', #username
            'secret': 'minio_secret', #password
            'bucket': 'org-kiwix-dev-wp1',
        }
```

am new contributer if theirs any mistake from me, am ready to accept it.

thank you