### PR TITLE
register zimfarm worker without email

### DIFF
--- a/docker/zimfarm/create_worker.sh
+++ b/docker/zimfarm/create_worker.sh
@@ -53,7 +53,6 @@ curl -s -X 'POST' \
   -d '{
   "role":"worker",
   "username": "test_worker",
-  "email":"test_worker@acme.com",
   "password":"test_worker"
 }'
 


### PR DESCRIPTION
## Rationale
openzim/zimfarm#1720 propoes to drop email column in DB. This PR removes the user email during registration of worker account to signify that emails aren't used during registration anymore in zimfarm.