### PR TITLE
fix: on-demand zimfarm status sync for stuck REQUESTED tasks

### DIFF
--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -488,6 +488,22 @@ def _get_task_by_id(task_id):
     return r.json()
 
 
+def get_task_status(task_id):
+    """Query the Zimfarm API for a task's current status.
+
+    Returns a dict with 'status' and 'files' keys, or None if the
+    API call fails (graceful degradation).
+    """
+    data = _get_task_by_id(task_id)
+    if data is None:
+        return None
+
+    return {
+        "status": data.get("status"),
+        "files": data.get("files", {}),
+    }
+
+
 def zim_file_url_for_task_id(task_id):
     data = _get_task_by_id(task_id)
 


### PR DESCRIPTION
Fixes #1013 

Overview:

When the Zimfarm webhook fails to deliver, ZIM tasks get stuck in REQUESTED forever. This is also a blocker for #991 (changing "Create ZIM" to "Manage ZIM"), since accurate status is needed to show the right UI state.

Approach:

Basically tried to solve this by adding an on-demand Zimfarm API check , whenever WP1 serves ZIM status and the task is still REQUESTED, it queries the Zimfarm API directly and updates the DB if the task has actually completed.

Added proper documentation for easy review.

Testing:

Ran full existing test suite locally