### PR TITLE
Fix stale DB redirects appearing as new assessments in quality logs

### DIFF
--- a/wp1/logic/page.py
+++ b/wp1/logic/page.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import requests
 
 import wp1.logic.util as logic_util
-from wp1.constants import GLOBAL_TIMESTAMP, TS_FORMAT
+from wp1.constants import GLOBAL_TIMESTAMP, TS_FORMAT, TS_FORMAT_WP10
 from wp1.logic import log as logic_log
 from wp1.logic import move as logic_move
 from wp1.logic.api import page as api_page
@@ -90,7 +90,7 @@ def _get_redirects_from_db(wikidb, namespace, title, timestamp_dt):
     args_dict = {
         "title": wiki_db_title,
         "namespace": namespace,
-        "timestamp": timestamp_dt.strftime("%Y%m%d%H%M%S")
+        "timestamp": timestamp_dt.strftime(TS_FORMAT_WP10)
     }
     with wikidb.cursor() as cursor:
         cursor.execute(
@@ -108,7 +108,7 @@ def _get_redirects_from_db(wikidb, namespace, title, timestamp_dt):
                 "dest_ns": row["rd_namespace"],
                 "dest_title": row["rd_title"],
                 "timestamp_dt": datetime.strptime(
-                    row["page_touched"].decode("utf-8"), "%Y%m%d%H%M%S"
+                    row["page_touched"].decode("utf-8"), TS_FORMAT_WP10
                 ),
             }
         return None

--- a/wp1/logic/page.py
+++ b/wp1/logic/page.py
@@ -99,13 +99,15 @@ def _get_redirects_from_db(wikidb, namespace, title, timestamp_dt):
         )
         row = cursor.fetchone()
         if row:
-            timestamp_dt = datetime.strptime(
+            row_timestamp_dt = datetime.strptime(
                 row["page_touched"].decode("utf-8"), "%Y%m%d%H%M%S"
             )
+            if row_timestamp_dt <= timestamp_dt:
+                return None
             return {
                 "dest_ns": row["rd_namespace"],
                 "dest_title": row["rd_title"],
-                "timestamp_dt": timestamp_dt,
+                "timestamp_dt": row_timestamp_dt,
             }
         return None
 

--- a/wp1/logic/page.py
+++ b/wp1/logic/page.py
@@ -87,30 +87,31 @@ def update_page_moved(
 def _get_redirects_from_db(wikidb, namespace, title, timestamp_dt):
     wiki_db_title = title.decode("utf-8").replace(" ", "_")
     wikidb.ping()
-    args_dict = {"title": wiki_db_title, "namespace": namespace}
+    args_dict = {
+        "title": wiki_db_title,
+        "namespace": namespace,
+        "timestamp": timestamp_dt.strftime("%Y%m%d%H%M%S")
+    }
     with wikidb.cursor() as cursor:
         cursor.execute(
             """
         SELECT rd_namespace, rd_title, page_touched FROM page
         JOIN redirect ON page_id = rd_from AND
              page_title = %(title)s AND page_namespace = %(namespace)s
+        WHERE page_touched > %(timestamp)s
     """,
             args_dict,
         )
         row = cursor.fetchone()
         if row:
-            row_timestamp_dt = datetime.strptime(
-                row["page_touched"].decode("utf-8"), "%Y%m%d%H%M%S"
-            )
-            if row_timestamp_dt <= timestamp_dt:
-                return None
             return {
                 "dest_ns": row["rd_namespace"],
                 "dest_title": row["rd_title"],
-                "timestamp_dt": row_timestamp_dt,
+                "timestamp_dt": datetime.strptime(
+                    row["page_touched"].decode("utf-8"), "%Y%m%d%H%M%S"
+                ),
             }
         return None
-
 
 def _get_moves_from_api(wp10db, namespace, title, timestamp_dt):
     title_with_ns = logic_util.title_for_api(wp10db, namespace, title)

--- a/wp1/logic/page.py
+++ b/wp1/logic/page.py
@@ -90,7 +90,7 @@ def _get_redirects_from_db(wikidb, namespace, title, timestamp_dt):
     args_dict = {
         "title": wiki_db_title,
         "namespace": namespace,
-        "timestamp": timestamp_dt.strftime(TS_FORMAT_WP10)
+        "timestamp": timestamp_dt.strftime(TS_FORMAT_WP10),
     }
     with wikidb.cursor() as cursor:
         cursor.execute(
@@ -112,6 +112,7 @@ def _get_redirects_from_db(wikidb, namespace, title, timestamp_dt):
                 ),
             }
         return None
+
 
 def _get_moves_from_api(wp10db, namespace, title, timestamp_dt):
     title_with_ns = logic_util.title_for_api(wp10db, namespace, title)

--- a/wp1/logic/page_test.py
+++ b/wp1/logic/page_test.py
@@ -235,6 +235,46 @@ class LogicPageMovesTest(BaseCombinedDbTest):
         )
         self.assertIsNone(move_data)
 
+    def test_get_redirect_from_db_stale(self):
+    # Insert a redirect row with a 2016 timestamp which is older than last run
+        with self.wikidb.cursor() as cursor:
+            cursor.execute("""
+                INSERT INTO page (page_id, page_namespace, page_title, page_touched)
+                VALUES (200, 0, 'Some_Moved_Article', '20160315142300')
+            """)
+            cursor.execute("""
+                INSERT INTO redirect (rd_from, rd_namespace, rd_title)
+                VALUES (200, 0, 'Destination_Article')
+            """)
+        self.wikidb.commit()
+
+        # Last run was 2022, redirect is from 2016 so should be discarded
+        move_data = logic_page._get_redirects_from_db(
+            self.wikidb, 0, b"Some Moved Article", datetime(2022, 1, 1)
+        )
+        self.assertIsNone(move_data)
+
+    def test_get_redirect_from_db_fresh(self):
+        # Insert a redirect row with a 2023 timestamp which newer than last run
+        with self.wikidb.cursor() as cursor:
+            cursor.execute("""
+                INSERT INTO page (page_id, page_namespace, page_title, page_touched)
+                VALUES (201, 0, 'Some_Moved_Article', '20230315142300')
+            """)
+            cursor.execute("""
+                INSERT INTO redirect (rd_from, rd_namespace, rd_title)
+                VALUES (201, 0, 'Destination_Article')
+            """)
+        self.wikidb.commit()
+
+        # Last run was 2022, redirect is from 2023 so should return
+        move_data = logic_page._get_redirects_from_db(
+            self.wikidb, 0, b"Some Moved Article", datetime(2022, 1, 1)
+        )
+        self.assertIsNotNone(move_data)
+        self.assertEqual(0, move_data["dest_ns"])
+        self.assertEqual(b"Destination_Article", move_data["dest_title"])
+        self.assertEqual(datetime(2023, 3, 15, 14, 23, 0), move_data["timestamp_dt"])
 
 class LogicPageMoveDbTest(BaseWpOneDbTest):
 

--- a/wp1/logic/page_test.py
+++ b/wp1/logic/page_test.py
@@ -236,16 +236,20 @@ class LogicPageMovesTest(BaseCombinedDbTest):
         self.assertIsNone(move_data)
 
     def test_get_redirect_from_db_stale(self):
-    # Insert a redirect row with a 2016 timestamp which is older than last run
+        # Insert a redirect row with a 2016 timestamp which is older than last run
         with self.wikidb.cursor() as cursor:
-            cursor.execute("""
+            cursor.execute(
+                """
                 INSERT INTO page (page_id, page_namespace, page_title, page_touched)
                 VALUES (200, 0, 'Some_Moved_Article', '20160315142300')
-            """)
-            cursor.execute("""
+            """
+            )
+            cursor.execute(
+                """
                 INSERT INTO redirect (rd_from, rd_namespace, rd_title)
                 VALUES (200, 0, 'Destination_Article')
-            """)
+            """
+            )
         self.wikidb.commit()
 
         # Last run was 2022, redirect is from 2016 so should be discarded
@@ -257,14 +261,18 @@ class LogicPageMovesTest(BaseCombinedDbTest):
     def test_get_redirect_from_db_fresh(self):
         # Insert a redirect row with a 2023 timestamp which newer than last run
         with self.wikidb.cursor() as cursor:
-            cursor.execute("""
+            cursor.execute(
+                """
                 INSERT INTO page (page_id, page_namespace, page_title, page_touched)
                 VALUES (201, 0, 'Some_Moved_Article', '20230315142300')
-            """)
-            cursor.execute("""
+            """
+            )
+            cursor.execute(
+                """
                 INSERT INTO redirect (rd_from, rd_namespace, rd_title)
                 VALUES (201, 0, 'Destination_Article')
-            """)
+            """
+            )
         self.wikidb.commit()
 
         # Last run was 2022, redirect is from 2023 so should return
@@ -275,6 +283,7 @@ class LogicPageMovesTest(BaseCombinedDbTest):
         self.assertEqual(0, move_data["dest_ns"])
         self.assertEqual(b"Destination_Article", move_data["dest_title"])
         self.assertEqual(datetime(2023, 3, 15, 14, 23, 0), move_data["timestamp_dt"])
+
 
 class LogicPageMoveDbTest(BaseWpOneDbTest):
 


### PR DESCRIPTION
page_touched was being parsed into timestamp_dt directly, overwriting the project's last run cutoff before any comparison could be made. Now it Stores the parsed value in row_timestamp_dt and return None if not newer than last run

Fixes #462