### PR TITLE
cleanup: exclude test suites from coverage metrics (#981)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,17 @@
+[run]
+source = .
+omit =
+    tests/*
+    wp1-frontend/tests/*
+    setup.py
+    conftest.py
+    */__init__.py
+    venv/*
+    .venv/*
+
+[report]
+show_missing = True
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if __name__ == .__main__.:


### PR DESCRIPTION
This PR addresses the issue of "artificially inflated" coverage numbers by excluding test code and non-production files from the coverage reports.

Changes:
Added .coveragerc to the root directory.
Configured omit patterns to exclude tests/, setup.py, and virtual environments.
This aligns with the "Quality Gate Finalization" phase of my GSoC proposal, ensuring that our 90% coverage target reflects 100% production logic.
@audiodude @rgaudin @legoktm @kelson42 @Jaifroid 