### PR TITLE
Added Cache-Control headers for CSS/JS assets (#241)

### DIFF
--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -8,5 +8,6 @@ RUN yarn install && yarn run build
 FROM nginx:stable-alpine as production-stage
 COPY --from=build-stage /app/dist /usr/share/nginx/html
 COPY docker/frontend/gzip.conf /etc/nginx/conf.d/
+COPY docker/frontend/cache.conf /etc/nginx/conf.d/
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker/frontend/cache.conf
+++ b/docker/frontend/cache.conf
@@ -1,0 +1,4 @@
+location ~* \.(css|js)$ {
+    expires 1y;
+    add_header Cache-Control "public, max-age=31536000, immutable";
+}


### PR DESCRIPTION
Added cache.conf to nginx config to serve CSS and JS assets with
proper Cache-Control headers, allowing browsers to cache them
for 1 year. Follows same pattern as existing gzip.conf.

Fixes #241