### PR TITLE
Add zim flavour selection for content format choice

### DIFF
--- a/db/migrations/20260324_01_add_flavour_to_zim_schedules.py
+++ b/db/migrations/20260324_01_add_flavour_to_zim_schedules.py
@@ -1,0 +1,14 @@
+"""
+Add flavour column to zim_schedules table for ZIM format selection
+"""
+
+from yoyo import step
+
+__depends__ = {"20250821_01_add_email_confirmation_token_to_zim_schedules"}
+
+steps = [
+    step(
+        "ALTER TABLE zim_schedules " "  ADD COLUMN s_flavour VARBINARY(50) NULL",
+        "ALTER TABLE zim_schedules " "  DROP COLUMN s_flavour",
+    )
+]

--- a/wp1-frontend/src/components/ZimFile.vue
+++ b/wp1-frontend/src/components/ZimFile.vue
@@ -106,6 +106,17 @@
             this was a transient or external error, you can try requesting your
             ZIM file again below.
           </p>
+          <p
+            v-if="
+              flavour &&
+              (status === 'FILE_READY' ||
+                status === 'REQUESTED' ||
+                status === 'FAILED')
+            "
+            class="text-muted"
+          >
+            <strong>Content:</strong> {{ selectedFlavourDescription }}
+          </p>
         </div>
       </div>
       <div
@@ -212,6 +223,18 @@
               <div class="invalid-feedback">
                 Long description must differ from description and not be shorter
               </div>
+            </div>
+            <div id="flavour-group" class="form-group">
+              <label for="flavour">What to include</label>
+              <select id="flavour" class="form-control" v-model="flavour">
+                <option
+                  v-for="opt in flavourOptions"
+                  :key="opt.value"
+                  :value="opt.value"
+                >
+                  {{ opt.description }}
+                </option>
+              </select>
             </div>
             <!-- Scheduling options -->
             <div class="form-group form-check mt-3">
@@ -372,6 +395,29 @@ export default {
       numberOfRepetitions: 1,
       scheduleEmail: '',
       forceExpiredDisplay: false,
+      flavour: '',
+      flavourOptions: [
+        {
+          value: '',
+          label: 'All',
+          description: 'Everything including videos',
+        },
+        {
+          value: 'maxi',
+          label: 'Maxi',
+          description: 'All except article videos',
+        },
+        {
+          value: 'nopic',
+          label: 'Nopic',
+          description: 'No article pictures or videos',
+        },
+        {
+          value: 'mini',
+          label: 'Mini',
+          description: 'No article details or pictures or videos',
+        },
+      ],
     };
   },
   created: async function () {
@@ -437,6 +483,9 @@ export default {
       this.status = data.status;
       this.isDeleted = data.is_deleted;
       this.activeSchedule = data.active_schedule;
+      if (data.flavour) {
+        this.flavour = data.flavour;
+      }
       if (this.status === 'FILE_READY') {
         this.stopProgressPolling();
       } else if (this.status === 'FAILED') {
@@ -482,6 +531,9 @@ export default {
         description: this.description,
         long_description: this.longDescription,
       };
+      if (this.flavour) {
+        payload.flavour = this.flavour;
+      }
       if (this.schedulingEnabled) {
         const scheduled = {
           repetition_period_in_months: this.repetitionPeriodInMonths,
@@ -647,6 +699,10 @@ export default {
           ? !this.isValidEmail(this.scheduleEmail)
           : false;
       return baseInvalid || scheduleInvalid;
+    },
+    selectedFlavourDescription: function () {
+      const opt = this.flavourOptions.find((o) => o.value === this.flavour);
+      return opt ? opt.description : '';
     },
   },
   watch: {

--- a/wp1/exceptions.py
+++ b/wp1/exceptions.py
@@ -30,6 +30,10 @@ class InvalidZimLongDescriptionError(ZimFarmError):
     pass
 
 
+class InvalidZimFlavourError(ZimFarmError):
+    pass
+
+
 class ZimFarmTooManyArticlesError(ZimFarmError):
 
     def user_message(self):

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -311,6 +311,11 @@ def auto_handle_zim_generation(redis, wp10db, builder_id):
         if zim_schedule.s_long_description is not None
         else None
     )
+    flavour = (
+        zim_schedule.s_flavour.decode("utf-8")
+        if zim_schedule.s_flavour is not None
+        else None
+    )
     handle_zim_generation(
         redis,
         wp10db,
@@ -318,6 +323,7 @@ def auto_handle_zim_generation(redis, wp10db, builder_id):
         title=title,
         description=description,
         long_description=long_description,
+        flavour=flavour,
     )
 
 
@@ -670,6 +676,7 @@ def handle_zim_generation(
     builder_id,
     title,
     description,
+    flavour,
     long_description=None,
     user_id=None,
     scheduled_repetitions=None,
@@ -694,7 +701,7 @@ def handle_zim_generation(
             )
 
     zim_schedule = zimfarm.create_or_update_zimfarm_schedule(
-        redis, wp10db, builder, title, description, long_description
+        redis, wp10db, builder, title, description, long_description, flavour
     )
     zim_file: ZimTask = request_zim_file_task_for_builder(
         redis, wp10db, builder, zim_schedule.s_id
@@ -716,6 +723,7 @@ def zim_file_status_for(wp10db, builder_id):
         "is_deleted": None,
         "description": None,
         "long_description": None,
+        "flavour": None,
         "active_schedule": None,
     }
     zim_file = zim_file_for_latest_selection(wp10db, builder_id)
@@ -756,6 +764,11 @@ def zim_file_status_for(wp10db, builder_id):
     data["long_description"] = (
         zim_schedule.s_long_description.decode("utf-8")
         if zim_schedule and zim_schedule.s_long_description
+        else None
+    )
+    data["flavour"] = (
+        zim_schedule.s_flavour.decode("utf-8")
+        if zim_schedule and zim_schedule.s_flavour
         else None
     )
 

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -195,13 +195,14 @@ class BuilderTest(BaseWpOneDbTest):
         description=None,
         long_description=None,
         remaining_generations=3,
+        flavour=None,
     ):
         if builder_id is None:
             builder_id = b"1a-2b-3c-4d"
         with self.wp10db.cursor() as cursor:
             cursor.execute(
-                """INSERT INTO zim_schedules (s_id, s_builder_id, s_rq_job_id, s_remaining_generations, s_last_updated_at, s_title, s_description, s_long_description)
-             VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                """INSERT INTO zim_schedules (s_id, s_builder_id, s_rq_job_id, s_remaining_generations, s_last_updated_at, s_title, s_description, s_long_description, s_flavour)
+             VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
           """,
                 (
                     schedule_id,
@@ -212,6 +213,7 @@ class BuilderTest(BaseWpOneDbTest):
                     title,
                     description,
                     long_description,
+                    flavour,
                 ),
             )
         self.wp10db.commit()
@@ -508,6 +510,7 @@ class BuilderTest(BaseWpOneDbTest):
                 title=None,
                 description=None,
                 long_description=None,
+                flavour=None,
             )
         finally:
             self.wp10db.close = orig_close
@@ -1091,11 +1094,18 @@ class BuilderTest(BaseWpOneDbTest):
         )
 
         logic_builder.handle_zim_generation(
-            redis, self.wp10db, builder_id, "test_title", "a", "zz", user_id=1234
+            redis,
+            self.wp10db,
+            builder_id,
+            "test_title",
+            "a",
+            None,
+            long_description="zz",
+            user_id=1234,
         )
 
         mock_create_zimfarm_schedule.assert_called_once_with(
-            redis, self.wp10db, self.builder, "test_title", "a", "zz"
+            redis, self.wp10db, self.builder, "test_title", "a", "zz", None
         )
         mock_request_zimfarm_task.assert_called_once_with(
             redis, self.wp10db, self.builder
@@ -1110,6 +1120,45 @@ class BuilderTest(BaseWpOneDbTest):
         self.assertEqual(b"1234-a", data["z_task_id"])
         self.assertEqual(b"REQUESTED", data["z_status"])
         self.assertEqual(b"20221225000102", data["z_requested_at"])
+
+    @patch("wp1.logic.builder.zimfarm.create_or_update_zimfarm_schedule")
+    @patch("wp1.logic.builder.zimfarm.request_zimfarm_task")
+    @patch(
+        "wp1.logic.builder.utcnow",
+        return_value=datetime.datetime(2022, 12, 25, 0, 1, 2),
+    )
+    def test_handle_zim_generation_with_flavour(
+        self, mock_utcnow, mock_request_zimfarm_task, mock_create_zimfarm_schedule
+    ):
+
+        redis = MagicMock()
+        mock_request_zimfarm_task.return_value = "1234-a"
+        mock_create_zimfarm_schedule.return_value = ZimSchedule(
+            s_id=b"schedule_123",
+            s_builder_id=b"1a-2b-3c-4d",
+            s_rq_job_id=b"rq_job_id_123",
+            s_last_updated_at=b"20191225044444",
+        )
+
+        builder_id = self._insert_builder()
+        self._insert_selection(
+            1, "text/tab-separated-values", builder_id=builder_id, has_errors=False
+        )
+
+        logic_builder.handle_zim_generation(
+            redis,
+            self.wp10db,
+            builder_id,
+            "test_title",
+            "a",
+            "nopic",
+            long_description="zz",
+            user_id=1234,
+        )
+
+        mock_create_zimfarm_schedule.assert_called_once_with(
+            redis, self.wp10db, self.builder, "test_title", "a", "zz", "nopic"
+        )
 
     @patch(
         "wp1.logic.builder.utcnow",
@@ -1126,7 +1175,14 @@ class BuilderTest(BaseWpOneDbTest):
 
         with self.assertRaises(InvalidZimTitleError):
             logic_builder.handle_zim_generation(
-                redis, self.wp10db, builder_id, "A" * 31, "a", "z", user_id=1234
+                redis,
+                self.wp10db,
+                builder_id,
+                "A" * 31,
+                "a",
+                None,
+                long_description="z",
+                user_id=1234,
             )
 
     @patch("wp1.logic.builder.zimfarm.request_zimfarm_task")
@@ -1137,7 +1193,13 @@ class BuilderTest(BaseWpOneDbTest):
 
         with self.assertRaises(ObjectNotFoundError):
             logic_builder.handle_zim_generation(
-                redis, self.wp10db, "404builder", "Title", "Description", user_id=1234
+                redis,
+                self.wp10db,
+                "404builder",
+                "Title",
+                "Description",
+                None,
+                user_id=1234,
             )
 
     @patch("wp1.logic.builder.zimfarm.request_zimfarm_task")
@@ -1152,7 +1214,13 @@ class BuilderTest(BaseWpOneDbTest):
 
         with self.assertRaises(UserNotAuthorizedError):
             logic_builder.handle_zim_generation(
-                redis, self.wp10db, builder_id, "Title", "Description", user_id=5678
+                redis,
+                self.wp10db,
+                builder_id,
+                "Title",
+                "Description",
+                None,
+                user_id=5678,
             )
 
     @patch("wp1.logic.builder.zimfarm.create_or_update_zimfarm_schedule")
@@ -1196,10 +1264,11 @@ class BuilderTest(BaseWpOneDbTest):
             redis,
             self.wp10db,
             builder_id,
-            user_id=1234,
-            title="Updated Title",
-            description="Updated Description",
+            "Updated Title",
+            "Updated Description",
+            None,
             long_description="Updated Long Description",
+            user_id=1234,
             scheduled_repetitions=5,
         )
 
@@ -1210,6 +1279,7 @@ class BuilderTest(BaseWpOneDbTest):
             "Updated Title",
             "Updated Description",
             "Updated Long Description",
+            None,
         )
         mock_request_zimfarm_task.assert_called_once_with(
             redis, self.wp10db, self.builder
@@ -1252,10 +1322,11 @@ class BuilderTest(BaseWpOneDbTest):
             redis,
             self.wp10db,
             builder_id,
-            user_id=1234,
-            title="New Title",
-            description="New Description",
+            "New Title",
+            "New Description",
+            None,
             long_description="New Long Description",
+            user_id=1234,
         )
 
         mock_create_schedule.assert_called_once_with(
@@ -1265,6 +1336,7 @@ class BuilderTest(BaseWpOneDbTest):
             "New Title",
             "New Description",
             "New Long Description",
+            None,
         )
         mock_request_zimfarm_task.assert_called_once_with(
             redis, self.wp10db, self.builder
@@ -1326,6 +1398,38 @@ class BuilderTest(BaseWpOneDbTest):
             title=None,
             description=None,
             long_description=None,
+            flavour=None,
+        )
+
+    @patch("wp1.logic.builder.handle_zim_generation")
+    def test_auto_handle_zim_generation_with_flavour(self, mock_handle_zim_generation):
+        redis = MagicMock()
+        builder_id = self._insert_builder(zim_version=1)
+        self._insert_selection(
+            1,
+            "text/tab-separated-values",
+            version=1,
+            builder_id=builder_id,
+            has_errors=False,
+            zim_file_ready=True,
+        )
+        self._insert_zim_schedule(
+            b"schedule_123",
+            builder_id,
+            b"rq_job_id_123",
+            flavour=b"nopic",
+        )
+
+        logic_builder.auto_handle_zim_generation(redis, self.wp10db, builder_id)
+
+        mock_handle_zim_generation.assert_called_once_with(
+            redis,
+            self.wp10db,
+            builder_id,
+            title=None,
+            description=None,
+            long_description=None,
+            flavour="nopic",
         )
 
     @patch("wp1.logic.builder.handle_zim_generation")
@@ -1355,6 +1459,7 @@ class BuilderTest(BaseWpOneDbTest):
             title=None,
             description=None,
             long_description=None,
+            flavour=None,
         )
 
     @patch("wp1.logic.builder.handle_zim_generation")
@@ -1421,6 +1526,7 @@ class BuilderTest(BaseWpOneDbTest):
             title="Title",
             description="A desc",
             long_description="Long desc",
+            flavour=None,
         )
 
         with self.wp10db.cursor() as cursor:

--- a/wp1/logic/zim_schedules.py
+++ b/wp1/logic/zim_schedules.py
@@ -16,11 +16,13 @@ def insert_zim_schedule(wp10db, zim_schedule: ZimSchedule):
         cursor.execute(
             """INSERT INTO zim_schedules
          (s_id, s_builder_id, s_rq_job_id, s_last_updated_at,
-          s_interval, s_remaining_generations, s_email, s_title, s_description, s_long_description, s_email_confirmation_token)
+          s_interval, s_remaining_generations, s_email, s_title, s_description,
+          s_long_description, s_email_confirmation_token, s_flavour)
          VALUES
          (%(s_id)s, %(s_builder_id)s,  %(s_rq_job_id)s,
           %(s_last_updated_at)s, %(s_interval)s, %(s_remaining_generations)s,
-          %(s_email)s, %(s_title)s, %(s_description)s, %(s_long_description)s, %(s_email_confirmation_token)s)
+          %(s_email)s, %(s_title)s, %(s_description)s, %(s_long_description)s,
+          %(s_email_confirmation_token)s, %(s_flavour)s)
       """,
             attr.asdict(zim_schedule),
         )
@@ -39,7 +41,8 @@ def update_zim_schedule(wp10db, zim_schedule: ZimSchedule):
          s_title = %(s_title)s,
          s_description = %(s_description)s,
          s_long_description = %(s_long_description)s,
-         s_email_confirmation_token = %(s_email_confirmation_token)s
+         s_email_confirmation_token = %(s_email_confirmation_token)s,
+         s_flavour = %(s_flavour)s
          WHERE s_id = %(s_id)s
       """,
             attr.asdict(zim_schedule),

--- a/wp1/logic/zim_schedules_email_test.py
+++ b/wp1/logic/zim_schedules_email_test.py
@@ -38,10 +38,10 @@ class ZimSchedulesEmailConfirmationTest(BaseWpOneDbTest):
             cursor.execute(
                 """INSERT INTO zim_schedules
                    (s_id, s_builder_id, s_rq_job_id, s_last_updated_at,
-                    s_interval, s_remaining_generations, s_email, s_title, s_description, s_long_description, s_email_confirmation_token)
+                    s_interval, s_remaining_generations, s_email, s_title, s_description, s_long_description, s_email_confirmation_token, s_flavour)
                    VALUES
                    (%(s_id)s, %(s_builder_id)s, %(s_rq_job_id)s, %(s_last_updated_at)s,
-                    %(s_interval)s, %(s_remaining_generations)s, %(s_email)s, %(s_title)s, %(s_description)s, %(s_long_description)s, %(s_email_confirmation_token)s)
+                    %(s_interval)s, %(s_remaining_generations)s, %(s_email)s, %(s_title)s, %(s_description)s, %(s_long_description)s, %(s_email_confirmation_token)s, %(s_flavour)s)
                 """,
                 attr.asdict(zim_schedule),
             )

--- a/wp1/models/wp10/zim_schedule.py
+++ b/wp1/models/wp10/zim_schedule.py
@@ -35,6 +35,9 @@ class ZimSchedule:
     s_email_confirmation_token: bytes = attr.ib(
         default=None
     )  # Token for email confirmation, removed after confirmation
+    s_flavour: bytes = attr.ib(
+        default=None
+    )  # mwoffliner --format value ('mini', 'nopic', 'maxi'). None = full content
 
     def set_id(self):
         self.s_id = str(uuid.uuid4()).encode("utf-8")

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -12,6 +12,7 @@ from wp1.constants import EXT_TO_CONTENT_TYPE
 from wp1.credentials import CREDENTIALS, ENV
 from wp1.exceptions import (
     InvalidZimDescriptionError,
+    InvalidZimFlavourError,
     InvalidZimLongDescriptionError,
     InvalidZimTitleError,
     ObjectNotFoundError,
@@ -223,6 +224,7 @@ def create_zim_file_for_builder(builder_id):
     title = data.get("title")
     desc = data.get("description")
     long_desc = data.get("long_description")
+    flavour = data.get("flavour")
     scheduled_repetitions = data.get("scheduled_repetitions")
 
     error_messages = []
@@ -261,6 +263,7 @@ def create_zim_file_for_builder(builder_id):
             title=title,
             description=desc,
             long_description=long_desc,
+            flavour=flavour,
             scheduled_repetitions=scheduled_repetitions,
         )
     except ObjectNotFoundError:
@@ -287,6 +290,7 @@ def create_zim_file_for_builder(builder_id):
         InvalidZimTitleError,
         InvalidZimDescriptionError,
         InvalidZimLongDescriptionError,
+        InvalidZimFlavourError,
     ) as e:
         return flask.jsonify({"error_messages": [str(e)]}), 400
     except ZimFarmError as e:

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -153,12 +153,13 @@ class BuildersTest(BaseWebTestcase):
         description=None,
         long_description=None,
         remaining_generations=3,
+        flavour=None,
     ):
         with self.wp10db.cursor() as cursor:
             cursor.execute(
                 """INSERT INTO zim_schedules (s_id, s_builder_id, s_rq_job_id, s_remaining_generations,
-                                        s_last_updated_at, s_title, s_description, s_long_description, s_email)
-             VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                                        s_last_updated_at, s_title, s_description, s_long_description, s_email, s_flavour)
+             VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
           """,
                 (
                     schedule_id,
@@ -170,6 +171,7 @@ class BuildersTest(BaseWebTestcase):
                     description,
                     long_description,
                     email,
+                    flavour,
                 ),
             )
         self.wp10db.commit()
@@ -593,6 +595,68 @@ class BuildersTest(BaseWebTestcase):
 
         self.assertEqual(b"1234-a", data["z_task_id"])
         self.assertEqual(b"REQUESTED", data["z_status"])
+
+    @patch("wp1.zimfarm.request_zimfarm_task")
+    @patch("wp1.zimfarm.create_or_update_zimfarm_schedule")
+    def test_create_zim_file_for_builder_with_flavour(
+        self, patched_create_zimfarm_schedule, patched_request_zimfarm_task
+    ):
+        builder_id = self._insert_builder()
+        self._insert_selections(builder_id)
+
+        patched_request_zimfarm_task.return_value = "1234-a"
+        patched_create_zimfarm_schedule.return_value = ZimSchedule(
+            s_id=b"schedule_123",
+            s_builder_id=b"1a-2b-3c-4d",
+            s_rq_job_id=b"rq_job_id_123",
+            s_last_updated_at=b"20240101000000",
+            s_email_confirmation_token=None,
+        )
+
+        self.app = create_app()
+        with self.override_db(self.app), self.app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess["user"] = self.USER
+            rv = client.post(
+                "/v1/builders/%s/zim" % builder_id,
+                json={
+                    "title": "Test title",
+                    "description": "Test description",
+                    "flavour": "nopic",
+                },
+            )
+            self.assertEqual("204 NO CONTENT", rv.status)
+
+        patched_create_zimfarm_schedule.assert_called_once()
+        args, kwargs = patched_create_zimfarm_schedule.call_args
+        self.assertEqual("nopic", args[6])
+
+    @patch("wp1.zimfarm.request_zimfarm_task")
+    @patch("wp1.zimfarm.requests")
+    @patch("wp1.zimfarm.get_zimfarm_token")
+    def test_create_zim_file_for_builder_invalid_flavour(
+        self, mock_get_token, mock_requests, mock_request_zimfarm_task
+    ):
+        builder_id = self._insert_builder()
+        self._insert_selections(builder_id)
+
+        mock_get_token.return_value = "test-token"
+
+        self.app = create_app()
+        with self.override_db(self.app), self.app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess["user"] = self.USER
+            rv = client.post(
+                "/v1/builders/%s/zim" % builder_id,
+                json={
+                    "title": "Test title",
+                    "description": "Test description",
+                    "flavour": "invalid_flavour",
+                },
+            )
+            self.assertEqual("400 BAD REQUEST", rv.status)
+            data = rv.get_json()
+            self.assertIn("error_messages", data)
 
     @patch("wp1.zimfarm.request_zimfarm_task")
     @patch("wp1.zimfarm.create_or_update_zimfarm_schedule")
@@ -1277,6 +1341,34 @@ class BuildersTest(BaseWebTestcase):
                 "title": None,
                 "description": None,
                 "long_description": None,
+                "flavour": None,
+                "is_deleted": None,
+                "active_schedule": ANY,
+            },
+            rv.get_json(),
+        )
+
+    def test_zimfarm_status_with_flavour(self):
+        builder_id = self._insert_builder()
+        self._insert_selections(builder_id)
+        self._insert_zim_schedule(
+            schedule_id=b"schedule_123",
+            builder_id=builder_id.encode("utf-8"),
+            rq_job_id=b"task-id-1234",
+            last_updated_at="20240101000000",
+            flavour=b"nopic",
+        )
+        with self.app.test_client() as client:
+            rv = client.get("/v1/builders/%s/zim/status" % builder_id)
+        self.assertEqual("200 OK", rv.status)
+        self.assertEqual(
+            {
+                "error_url": "https://fake.farm/v2/tasks/task-id-1234",
+                "status": "FILE_READY",
+                "title": None,
+                "description": None,
+                "long_description": None,
+                "flavour": "nopic",
                 "is_deleted": None,
                 "active_schedule": ANY,
             },

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -14,6 +14,7 @@ from wp1.constants import WP1_USER_AGENT
 from wp1.credentials import CREDENTIALS, ENV
 from wp1.exceptions import (
     InvalidZimDescriptionError,
+    InvalidZimFlavourError,
     InvalidZimLongDescriptionError,
     InvalidZimTitleError,
     ObjectNotFoundError,
@@ -39,6 +40,22 @@ logger = logging.getLogger(__name__)
 # wishes to create a ZIM file for it. For Selections with more than this
 # number, we perform validation in the frontend, as well as the API layer.
 MAX_ZIMFARM_ARTICLE_COUNT = 50_000
+
+ALLOWED_FLAVOURS = {
+    "mini": "nodet,nopic:mini",
+    "nopic": "nopic:nopic",
+    "maxi": "novid:maxi",
+}
+
+
+def validate_flavour(flavour):
+    if not flavour:
+        return  # none or empty string means default (full content)
+    if flavour not in ALLOWED_FLAVOURS:
+        allowed = ", ".join(sorted(ALLOWED_FLAVOURS.keys()))
+        raise InvalidZimFlavourError(
+            f"Invalid ZIM flavour: '{flavour}'. Allowed values: {allowed}"
+        )
 
 
 def store_zimfarm_token(redis, data):
@@ -219,6 +236,7 @@ def _get_params(
     title: str,
     description: str,
     long_description: str,
+    flavour: str = None,
 ) -> dict:
     if builder is None:
         raise ValueError("Given builder was None: %r" % builder)
@@ -233,6 +251,28 @@ def _get_params(
         )
     image_name, image_tag = image.split(":")
 
+    offliner_config = {
+        "offliner_id": "mwoffliner",
+        "mwUrl": "https://%s/" % project,
+        "adminEmail": "contact+wp1@kiwix.org",
+        "forceRender": "ActionParse",
+        "articleList": logic_builder.latest_zimfarm_url_for(
+            builder.b_id.decode("utf-8"), selection.s_content_type.decode("utf-8")
+        ),
+        "customZimTitle": title,
+        "customZimDescription": description,
+        "customZimLongDescription": (
+            long_description
+            if long_description
+            else f"ZIM file created from a WP1 Selection. {description}"
+        ),
+        "filenamePrefix": get_zim_filename_prefix(builder, selection),
+    }
+
+    # Add the format flag for mwoffliner if a flavour is specified.
+    if flavour:
+        offliner_config["format"] = [ALLOWED_FLAVOURS[flavour]]
+
     config = {
         "warehouse_path": "/wikipedia",
         "image": {
@@ -242,23 +282,7 @@ def _get_params(
         "resources": logic_selection.get_resource_profile(selection),
         "platform": "wikimedia",
         "monitor": False,
-        "offliner": {
-            "offliner_id": "mwoffliner",
-            "mwUrl": "https://%s/" % project,
-            "adminEmail": "contact+wp1@kiwix.org",
-            "forceRender": "ActionParse",
-            "articleList": logic_builder.latest_zimfarm_url_for(
-                builder.b_id.decode("utf-8"), selection.s_content_type.decode("utf-8")
-            ),
-            "customZimTitle": title,
-            "customZimDescription": description,
-            "customZimLongDescription": (
-                long_description
-                if long_description
-                else f"ZIM file created from a WP1 Selection. {description}"
-            ),
-            "filenamePrefix": get_zim_filename_prefix(builder, selection),
-        },
+        "offliner": offliner_config,
     }
     cache_url = CREDENTIALS[ENV].get("ZIMFARM", {}).get("cache_url")
     if cache_url is not None:
@@ -334,7 +358,7 @@ def find_existing_schedule_in_db(wp10db, builder_b_id):
 
 
 def create_or_update_zimfarm_schedule(
-    redis, wp10db, builder, title, description, long_description
+    redis, wp10db, builder, title, description, long_description, flavour
 ):
     """
     Requests a ZIM file schedule from the Zimfarm for the given builder.
@@ -347,6 +371,7 @@ def create_or_update_zimfarm_schedule(
         raise ObjectNotFoundError("Cannot schedule for None builder")
 
     _validate_zim_metadata(title, description, long_description)
+    validate_flavour(flavour)
 
     selection = logic_builder.latest_selection_for(
         wp10db, builder.b_id, "text/tab-separated-values"
@@ -361,7 +386,9 @@ def create_or_update_zimfarm_schedule(
             )
         )
 
-    params = _get_params(builder, selection, title, description, long_description)
+    params = _get_params(
+        builder, selection, title, description, long_description, flavour=flavour
+    )
     base_url = get_zimfarm_url()
     headers = _get_zimfarm_headers(token)
 
@@ -387,6 +414,7 @@ def create_or_update_zimfarm_schedule(
                 long_description.encode("utf-8") if long_description else None
             )
             zim_schedule.s_remaining_generations = None
+            zim_schedule.s_flavour = flavour
             logic_zim_schedules.update_zim_schedule(wp10db, zim_schedule)
             zim_schedule_id_to_set = zim_schedule.s_id.decode("utf-8")
         else:
@@ -404,6 +432,7 @@ def create_or_update_zimfarm_schedule(
                 s_long_description=(
                     long_description.encode("utf-8") if long_description else None
                 ),
+                s_flavour=flavour,
             )
             logic_zim_schedules.insert_zim_schedule(wp10db, zim_schedule)
             zim_schedule_id_to_set = zim_schedule_id

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -9,6 +9,7 @@ from wp1.base_db_test import BaseWpOneDbTest
 from wp1.environment import Environment
 from wp1.exceptions import (
     InvalidZimDescriptionError,
+    InvalidZimFlavourError,
     InvalidZimLongDescriptionError,
     InvalidZimTitleError,
     ObjectNotFoundError,
@@ -113,13 +114,14 @@ class ZimFarmTest(BaseWpOneDbTest):
         description=None,
         long_description=None,
         remaining_generations=3,
+        flavour=None,
     ):
         if builder_id is None:
             builder_id = b"1a-2b-3c-4d"
         with self.wp10db.cursor() as cursor:
             cursor.execute(
-                """INSERT INTO zim_schedules (s_id, s_builder_id, s_rq_job_id, s_remaining_generations, s_last_updated_at, s_title, s_description, s_long_description)
-             VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                """INSERT INTO zim_schedules (s_id, s_builder_id, s_rq_job_id, s_remaining_generations, s_last_updated_at, s_title, s_description, s_long_description, s_flavour)
+             VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
           """,
                 (
                     schedule_id,
@@ -130,6 +132,7 @@ class ZimFarmTest(BaseWpOneDbTest):
                     title,
                     description,
                     long_description,
+                    flavour,
                 ),
             )
         self.wp10db.commit()
@@ -395,9 +398,10 @@ class ZimFarmTest(BaseWpOneDbTest):
                 redis,
                 self.wp10db,
                 self.builder,
-                title="a",
-                description="b",
-                long_description=None,
+                "a",
+                "b",
+                None,
+                None,
             )
 
     @patch("wp1.zimfarm.get_zimfarm_token")
@@ -410,9 +414,10 @@ class ZimFarmTest(BaseWpOneDbTest):
                 redis,
                 self.wp10db,
                 None,
-                title="a",
-                description="b",
-                long_description=None,
+                "a",
+                "b",
+                None,
+                None,
             )
 
     @patch("wp1.zimfarm.requests")
@@ -434,9 +439,10 @@ class ZimFarmTest(BaseWpOneDbTest):
             redis,
             self.wp10db,
             self.builder,
-            title="Test Title",
-            description="Test Description",
-            long_description=long_desc,
+            "Test Title",
+            "Test Description",
+            long_desc,
+            None,
         )
 
         mock_requests.post.assert_called_once_with(
@@ -488,9 +494,10 @@ class ZimFarmTest(BaseWpOneDbTest):
             redis,
             self.wp10db,
             self.builder,
-            title="New Title",
-            description="New Description",
-            long_description="New Long Description",
+            "New Title",
+            "New Description",
+            "New Long Description",
+            None,
         )
 
         # Actually check that the schedule was updated in the DB
@@ -529,6 +536,7 @@ class ZimFarmTest(BaseWpOneDbTest):
                 "Test Title",
                 "Test Description",
                 None,
+                None,
             )
 
     @patch("wp1.zimfarm.get_zimfarm_token")
@@ -539,7 +547,13 @@ class ZimFarmTest(BaseWpOneDbTest):
         wrong_title = "a" * (ZIM_TITLE_MAX_LENGTH + 1)
         with self.assertRaises(InvalidZimTitleError):
             zimfarm.create_or_update_zimfarm_schedule(
-                redis, self.wp10db, self.builder, wrong_title, "Test Description", None
+                redis,
+                self.wp10db,
+                self.builder,
+                wrong_title,
+                "Test Description",
+                None,
+                None,
             )
 
     @patch("wp1.zimfarm.get_zimfarm_token")
@@ -558,6 +572,7 @@ class ZimFarmTest(BaseWpOneDbTest):
                 "Test Title",
                 too_long_description,
                 None,
+                None,
             )
 
     @patch("wp1.zimfarm.get_zimfarm_token")
@@ -573,9 +588,10 @@ class ZimFarmTest(BaseWpOneDbTest):
                 redis,
                 self.wp10db,
                 self.builder,
-                title="Test Title",
-                description="Test Description",
-                long_description=too_long_long_description,
+                "Test Title",
+                "Test Description",
+                too_long_long_description,
+                None,
             )
 
     @patch("wp1.zimfarm.get_zimfarm_token")
@@ -592,7 +608,8 @@ class ZimFarmTest(BaseWpOneDbTest):
                 self.builder,
                 "Test Title",
                 "Test Description",
-                long_description="z",
+                "z",
+                None,
             )
 
     @patch("wp1.zimfarm.requests")
@@ -613,6 +630,7 @@ class ZimFarmTest(BaseWpOneDbTest):
             "Test Title",
             "Test Description",
             "",
+            None,
         )
 
         with self.wp10db.cursor() as cursor:
@@ -643,6 +661,7 @@ class ZimFarmTest(BaseWpOneDbTest):
             "Test Title",
             "Test Description",
             None,
+            None,
         )
 
         with self.wp10db.cursor() as cursor:
@@ -665,9 +684,10 @@ class ZimFarmTest(BaseWpOneDbTest):
                 redis,
                 self.wp10db,
                 self.builder,
-                title="Test Title",
-                description="Same description",
-                long_description="Same description",
+                "Test Title",
+                "Same description",
+                "Same description",
+                None,
             )
 
     @patch("wp1.zimfarm.get_zimfarm_token")
@@ -690,6 +710,7 @@ class ZimFarmTest(BaseWpOneDbTest):
                 "Test Title",
                 "Test Description",
                 None,
+                None,
             )
 
     @patch("wp1.zimfarm.get_zimfarm_token")
@@ -709,9 +730,10 @@ class ZimFarmTest(BaseWpOneDbTest):
                 redis,
                 self.wp10db,
                 self.builder,
-                title="Test Title",
-                description="Test Description",
-                long_description=None,
+                "Test Title",
+                "Test Description",
+                None,
+                None,
             )
 
     @patch("wp1.zimfarm.requests")
@@ -734,6 +756,7 @@ class ZimFarmTest(BaseWpOneDbTest):
             self.builder,
             valid_title,
             "Test Description",
+            None,
             None,
         )
         mock_requests.post.assert_called_once()
@@ -1181,3 +1204,140 @@ class ZimFarmTest(BaseWpOneDbTest):
 
         with self.assertRaises(ZimFarmError):
             zimfarm.delete_zimfarm_schedule_by_builder_id(redis, "1a-2b-3c-4d")
+
+    def test_validate_flavour_none(self):
+        zimfarm.validate_flavour(None)
+
+    def test_validate_flavour_empty_string(self):
+        zimfarm.validate_flavour("")
+
+    def test_validate_flavour_valid_nopic(self):
+        zimfarm.validate_flavour("nopic")
+
+    def test_validate_flavour_valid_mini(self):
+        zimfarm.validate_flavour("mini")
+
+    def test_validate_flavour_valid_maxi(self):
+        zimfarm.validate_flavour("maxi")
+
+    def test_validate_flavour_invalid(self):
+        with self.assertRaises(InvalidZimFlavourError):
+            zimfarm.validate_flavour("innvalid_flavour")
+
+    def test_get_params_with_flavour_nopic(self):
+        from wp1.zimfarm import CREDENTIALS
+
+        CREDENTIALS[Environment.TEST]["ZIMFARM"][
+            "cache_url"
+        ] = "https://wasabi.fake/bucket"
+
+        actual = zimfarm._get_params(
+            self.builder,
+            self.selection,
+            title="My Builder",
+            description="short description",
+            long_description="longgggggggg description",
+            flavour="nopic",
+        )
+
+        self.assertEqual(["nopic:nopic"], actual["config"]["offliner"]["format"])
+
+    def test_get_params_with_flavour_mini(self):
+        from wp1.zimfarm import CREDENTIALS
+
+        CREDENTIALS[Environment.TEST]["ZIMFARM"][
+            "cache_url"
+        ] = "https://wasabi.fake/bucket"
+
+        actual = zimfarm._get_params(
+            self.builder,
+            self.selection,
+            title="My Builder",
+            description="short description",
+            long_description="longgggggggg description",
+            flavour="mini",
+        )
+
+        self.assertEqual(["nodet,nopic:mini"], actual["config"]["offliner"]["format"])
+
+    def test_get_params_with_flavour_maxi(self):
+        from wp1.zimfarm import CREDENTIALS
+
+        CREDENTIALS[Environment.TEST]["ZIMFARM"][
+            "cache_url"
+        ] = "https://wasabi.fake/bucket"
+
+        actual = zimfarm._get_params(
+            self.builder,
+            self.selection,
+            title="My Builder",
+            description="short description",
+            long_description="longgggggggg description",
+            flavour="maxi",
+        )
+
+        self.assertEqual(["novid:maxi"], actual["config"]["offliner"]["format"])
+
+    def test_get_params_without_flavour_no_format(self):
+        from wp1.zimfarm import CREDENTIALS
+
+        CREDENTIALS[Environment.TEST]["ZIMFARM"][
+            "cache_url"
+        ] = "https://wasabi.fake/bucket"
+
+        actual = zimfarm._get_params(
+            self.builder,
+            self.selection,
+            title="My Builder",
+            description="short description",
+            long_description="longgggggggg description",
+        )
+
+        self.assertNotIn("format", actual["config"]["offliner"])
+
+    @patch("wp1.zimfarm.requests")
+    @patch("wp1.zimfarm.get_zimfarm_token")
+    @patch("wp1.zimfarm._get_params")
+    def test_create_or_update_zimfarm_schedule_with_flavour(
+        self, get_params_mock, get_token_mock, mock_requests
+    ):
+        redis = MagicMock()
+        get_params_mock.return_value = {"name": "bar"}
+        get_token_mock.return_value = "abcdef"
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"requested": ["9876"]}
+        mock_requests.post.side_effect = (MagicMock(), mock_response)
+
+        zimfarm.create_or_update_zimfarm_schedule(
+            redis,
+            self.wp10db,
+            self.builder,
+            "Test Title",
+            "Test Description",
+            None,
+            "nopic",
+        )
+
+        with self.wp10db.cursor() as cursor:
+            cursor.execute(
+                "SELECT * FROM zim_schedules WHERE s_title = %s", (b"Test Title",)
+            )
+            result = cursor.fetchone()
+            self.assertIsNotNone(result)
+            self.assertEqual(b"nopic", result["s_flavour"])
+
+    @patch("wp1.zimfarm.get_zimfarm_token")
+    def test_create_or_update_zimfarm_schedule_invalid_flavour(self, get_token_mock):
+        redis = MagicMock()
+        get_token_mock.return_value = "test-token"
+
+        with self.assertRaises(InvalidZimFlavourError):
+            zimfarm.create_or_update_zimfarm_schedule(
+                redis,
+                self.wp10db,
+                self.builder,
+                "Test Title",
+                "Test Description",
+                None,
+                "invalid_flavour",
+            )

--- a/wp10_test.up.sql
+++ b/wp10_test.up.sql
@@ -138,7 +138,8 @@ CREATE TABLE zim_schedules (
   s_long_description mediumblob,
   s_description blob,
   s_title blob,
-  s_email_confirmation_token VARBINARY(255) NULL
+  s_email_confirmation_token VARBINARY(255) NULL,
+  s_flavour VARBINARY(50) NULL
 );
 
 CREATE TABLE `temp_pageviews` (


### PR DESCRIPTION
Allow users to choose a content flavour when creating a ZIM file, controlling what content is included (nopic,novid, lead sections , mini,maxi , nopdf).

changes:

Add flavour selection support across the system (database , backend , Zimfarm integration)
Add a dropdown in the UI to choose the desired flavour when creating a ZIM

here is some outputs 
full
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/161ea992-62b1-4081-8ba9-e477f5f1e756" />

nopic
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/0b19d225-7e2e-42ff-a5d4-db492201ff87" />


fixes #919 , #1117
