### PR TITLE
Fix Redis Token Decoding for Zimfarm Authentication

### DIFF
--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -109,8 +109,13 @@ def refresh_zimfarm_token(redis, refresh_token):
 
 
 def get_zimfarm_token(redis):
-    data = redis.hgetall(REDIS_AUTH_KEY)
-    if data is None or data.get("refresh_token") is None:
+    data = redis.hgetall(REDIS_AUTH_KEY) or {}
+    data = {
+        k.decode() if isinstance(k, bytes) else k:
+        v.decode() if isinstance(v, bytes) else v
+        for k, v in data.items()
+    }
+    if "refresh_token" not in data:
         logger.debug("No saved zimfarm refresh_token, requesting")
         return request_zimfarm_token(redis)
 


### PR DESCRIPTION
So i was going through this file and I felt this is a big missing part here. Please have a look

Problem
1. Incorrect Token Lookup
- Redis returns data as "bytes" in many clients
- Code was accessing using "str" keys ("refresh_token")
- so the Result: token was never found

2.. Repeated Unnecessary Authentication Calls
- Because "refresh_token" was never detected, the system will continue requesting new tokens This will mean:
- Extra API calls
- Inefficient performance

3. Runtime Errors 
- Direct ".decode()" could fail if Redis already returned strings