### PR TITLE
chore: upgrade Python from 3.12 to 3.14 in Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.12.0
+      - name: Set up Python 3.14.4
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12.0'
+          python-version: '3.14.4'
 
       - name: Install Black
         run: |
@@ -53,10 +53,10 @@ jobs:
       - uses: actions/checkout@v4
         # Don't need lfs because we're not referencing the dev-db in this workflow.
 
-      - name: Set up Python 3.12.0
+      - name: Set up Python 3.14.4
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12.0'
+          python-version: '3.14.4'
 
       - name: Install dependencies
         run: |
@@ -96,10 +96,10 @@ jobs:
         with:
           lfs: true
 
-      - name: Set up Python 3.12.0
+      - name: Set up Python 3.14.4
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12.0'
+          python-version: '3.14.4'
 
       - uses: actions/cache@v4
         name: Cache pip dependencies

--- a/Pipfile
+++ b/Pipfile
@@ -44,4 +44,4 @@ yapf = "==0.28.0"
 black = "~=26.3"
 
 [requires]
-python_version = "3.12"
+python_version = "3.14.4"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "20af6141b9ed16fc7cb778c9dcf898c968d3e0681161bb3e81666f645ab0b7a3"
+            "sha256": "1c7bcdcb29ba34bb7bc23f84a4766801c2fc74293b2e45cf3fe629e0c60b65b0"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.12"
+            "python_version": "3.14.4"
         },
         "sources": [
             {

--- a/docker/dev-workers/Dockerfile
+++ b/docker/dev-workers/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM python:3.14.4
 
 # Meta
 LABEL maintainer="kiwix"

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM python:3.14.4
 
 # Meta
 LABEL maintainer="kiwix"

--- a/docker/workers/Dockerfile
+++ b/docker/workers/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.0
+FROM python:3.14.4
 
 # Meta
 LABEL maintainer="kiwix"


### PR DESCRIPTION
Update all Dockerfiles and Pipfile to use Python 3.14. Part of #1009.