### PR TITLE
Exclude tests themselves from coverage calculations

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,12 +1,11 @@
 coverage:
   status:
-    patch:
-      default:
-        target: 90%
-        threshold: 1%
     project:
       default:
         target: 90%
         threshold: 1%
+    patch:
+      default:
+        informational: true
 ignore:
   - '**/*_test.py'

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+source = wp1/
+omit =
+    *_test.py
+
+[report]
+show_missing = True

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,13 +79,14 @@ jobs:
 
       - name: Test with pytest, with coverage
         run: |
-          pipenv run pytest --cov=wp1
+          pipenv run pytest --cov --cov-config=.coveragerc --cov-report=xml
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
+          files: ./coverage.xml
           fail_ci_if_error: false
 
   frontend-cypress:


### PR DESCRIPTION
This is probably going to mean changes to our coverage workflow checks