### PR TITLE
 Add combinator selection builder core functions

### DIFF
--- a/check_types.sh
+++ b/check_types.sh
@@ -26,6 +26,8 @@ TYPED_FILES=(
   wp1/selection/models/sparql.py
   wp1/selection/models/wikiproject.py
   wp1/selection/models/book.py
+  wp1/selection/models/combinator.py
+  wp1/selection/models/combinator_test.py
 )
 
 if [ "$#" -gt 0 ]; then

--- a/wp1/selection/abstract_builder.py
+++ b/wp1/selection/abstract_builder.py
@@ -65,6 +65,7 @@ class AbstractBuilder:
                 content_type,
                 project=builder.b_project.decode("utf-8"),
                 wp10db=wp10db,
+                s3=s3,
                 **params,
             )
             selection.s_article_count = selection.data.count(b"\n") + 1

--- a/wp1/selection/models/combinator.py
+++ b/wp1/selection/models/combinator.py
@@ -16,20 +16,17 @@ from wp1.selection.abstract_builder import AbstractBuilder
 logger = logging.getLogger(__name__)
 
 
-# as  abstract Metabuilder should be added later
-# some functions will be moved to it
+# TODO: move shared metabuilder helpers into a metaBuilder base class when that abstraction is introduced
 
 META_BUILDER_MODELS = {"wp1.selection.models.combinator"}
 
 
-# metabuilder
 def _as_text(value: bytes | str | int | None) -> str:
     if isinstance(value, bytes):
         return value.decode("utf-8")
     return str(value)
 
 
-# metabuilder
 def _builder_label(builder: Wp10Builder) -> str:
     name = getattr(builder, "b_name", None)
     builder_id = _as_text(getattr(builder, "b_id", ""))
@@ -38,18 +35,14 @@ def _builder_label(builder: Wp10Builder) -> str:
     return builder_id
 
 
-# metabuilder
 def _builder_model(builder: Wp10Builder) -> str:
     return _as_text(getattr(builder, "b_model", ""))
 
 
-# metabuilder
 def _is_meta_builder(builder: Wp10Builder) -> bool:
     return _builder_model(builder) in META_BUILDER_MODELS
 
 
-# metabuilder
-# just to preserve order
 def _dedupe(builder_ids: list[str]) -> list[str]:
     seen: set[str] = set()
     unique_ids: list[str] = []
@@ -72,25 +65,25 @@ def _validate_group_shape(
         return [], errors
 
     if not isinstance(group, dict):
-        return [], [f"The {name} group configuration is invalid"]
+        return [], [f"The {name} group must be a dictionary"]
 
     builder_values = group.get("builders", [])
     if builder_values is None:
         builder_values = []
     if not isinstance(builder_values, list):
-        errors.append(f"The {name} group builder list is invalid")
-        builder_values = []
-
-    builders = [
-        builder_id for builder_id in builder_values if isinstance(builder_id, str)
-    ]
+        return [], [f"The {name} group builder list must be a list"]
 
     if required and not builder_values:
         errors.append(f"Please add at least one builder to the {name} group")
 
-    if len(builders) != len(builder_values) or any(
-        not builder_id for builder_id in builders
-    ):
+    builders: list[str] = []
+    has_invalid_builder_id = False
+    for builder_id in builder_values:
+        if not isinstance(builder_id, str) or not builder_id:
+            has_invalid_builder_id = True
+            continue
+        builders.append(builder_id)
+    if has_invalid_builder_id:
         errors.append(f"The {name} group contains an invalid builder ID")
 
     operation = group.get("operation")
@@ -102,6 +95,7 @@ def _validate_group_shape(
     return builders, errors
 
 
+# TODO: extractt TSV title parsing helpers if more selection builders needs this behavior
 def _normalize(line: bytes) -> str | None:
     s = line.decode("utf-8", errors="replace").strip()
     if not s or s.startswith("#"):
@@ -131,7 +125,6 @@ def _apply_operation(operation: str, sets: list[set[str]]) -> set[str]:
     raise ValueError(f"Unsupported operation: {operation}")
 
 
-# metabuilder
 def _fetch_selection_data(wp10db, s3, builder_id: str) -> bytes:
     """Fetch the latest materialized TSV snapshot for a referenced builder."""
     selection = logic_builder.latest_selection_for(
@@ -144,23 +137,21 @@ def _fetch_selection_data(wp10db, s3, builder_id: str) -> bytes:
             f"(no selection found)"
         )
 
-    status = selection.s_status
-    if status == b"FAILED" or status == "FAILED":
+    status = _as_text(selection.s_status)
+    if status == "FAILED":
         raise Wp1FatalSelectionError(
-            f"Referenced builder {builder_id} has no usable selection "
-            f"(status={status!r})"
+            f"Referenced builder {builder_id} latest selection failed"
         )
 
-    if status != b"OK" and status != "OK":
+    if status != "OK":
         raise Wp1RetryableSelectionError(
-            f"Referenced builder {builder_id} has no usable selection "
+            f"Referenced builder {builder_id} latest selection is not ready "
             f"(status={status!r})"
         )
 
     if selection.s_object_key is None:
         raise Wp1RetryableSelectionError(
-            f"Referenced builder {builder_id} has no usable selection "
-            f"(s_object_key is None)"
+            f"Referenced builder {builder_id} latest selection has no object key"
         )
 
     object_key = selection.s_object_key
@@ -175,11 +166,6 @@ def _fetch_selection_data(wp10db, s3, builder_id: str) -> bytes:
         raise Wp1RetryableSelectionError(
             f"Failed to download selection for builder {builder_id} "
             f"from S3 key {object_key!r}: {code}"
-        ) from e
-    except Exception as e:
-        raise Wp1RetryableSelectionError(
-            f"Failed to download selection for builder {builder_id} "
-            f"from S3 key {object_key!r}: {e}"
         ) from e
 
     return buffer.getvalue()
@@ -225,11 +211,21 @@ class Builder(AbstractBuilder):
         if errors:
             return ([], [], errors)
 
-        if "wp10db" not in params or "user_id" not in params or "project" not in params:
+        missing_params = []
+        if params.get("wp10db") is None:
+            missing_params.append("wp10db")
+        if params.get("user_id") is None:
+            missing_params.append("user_id")
+        if params.get("project") is None:
+            missing_params.append("project")
+        if missing_params:
             return (
                 [],
                 [],
-                ["Configuration could not be validated. Please try saving again."],
+                [
+                    "Missing required validation parameters: "
+                    + ", ".join(missing_params)
+                ],
             )
 
         wp10db = params["wp10db"]
@@ -249,6 +245,7 @@ class Builder(AbstractBuilder):
             try:
                 builder = logic_builder.get_builder(wp10db, reference_id)
             except ObjectNotFoundError:
+                # TODO: https://github.com/openzim/wp1/issues/1178
                 errors.append(
                     f"Builder {reference_id!r} no longer exists. Please remove it "
                     "from this combinator."
@@ -288,18 +285,18 @@ class Builder(AbstractBuilder):
             raise Wp1FatalSelectionError(f"Unrecognized content type: {content_type!r}")
 
         wp10db = params.get("wp10db")
-        s3 = params.get("s3")
-
         if wp10db is None:
             raise Wp1FatalSelectionError("Combinator build requires 'wp10db' parameter")
+
+        s3 = params.get("s3")
         if s3 is None:
             raise Wp1FatalSelectionError("Combinator build requires 's3' parameter")
 
         include_group = params.get("include")
-        exclude_group = params.get("exclude")
-
         if include_group is None:
             raise Wp1FatalSelectionError("Missing required 'include' group")
+
+        exclude_group = params.get("exclude")
 
         include_set = _process_group(wp10db, s3, include_group)
 

--- a/wp1/selection/models/combinator.py
+++ b/wp1/selection/models/combinator.py
@@ -1,0 +1,317 @@
+import io
+import logging
+from typing import Any
+
+from botocore.exceptions import ClientError
+
+import wp1.logic.builder as logic_builder
+from wp1.exceptions import (
+    ObjectNotFoundError,
+    Wp1FatalSelectionError,
+    Wp1RetryableSelectionError,
+)
+from wp1.models.wp10.builder import Builder as Wp10Builder
+from wp1.selection.abstract_builder import AbstractBuilder
+
+logger = logging.getLogger(__name__)
+
+
+# as  abstract Metabuilder should be added later
+# some functions will be moved to it
+
+META_BUILDER_MODELS = {"wp1.selection.models.combinator"}
+
+
+# metabuilder
+def _as_text(value: bytes | str | int | None) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    return str(value)
+
+
+# metabuilder
+def _builder_label(builder: Wp10Builder) -> str:
+    name = getattr(builder, "b_name", None)
+    builder_id = _as_text(getattr(builder, "b_id", ""))
+    if name is not None:
+        return f"{_as_text(name)} ({builder_id})"
+    return builder_id
+
+
+# metabuilder
+def _builder_model(builder: Wp10Builder) -> str:
+    return _as_text(getattr(builder, "b_model", ""))
+
+
+# metabuilder
+def _is_meta_builder(builder: Wp10Builder) -> bool:
+    return _builder_model(builder) in META_BUILDER_MODELS
+
+
+# metabuilder
+# just to preserve order
+def _dedupe(builder_ids: list[str]) -> list[str]:
+    seen: set[str] = set()
+    unique_ids: list[str] = []
+    for builder_id in builder_ids:
+        if builder_id not in seen:
+            seen.add(builder_id)
+            unique_ids.append(builder_id)
+    return unique_ids
+
+
+def _validate_group_shape(
+    name: str, group: Any, required: bool
+) -> tuple[list[str], list[str]]:
+    errors: list[str] = []
+
+    # can we have empty groups?
+    if group is None:
+        if required:
+            errors.append(f"Please add at least one builder to the {name} group")
+        return [], errors
+
+    if not isinstance(group, dict):
+        return [], [f"The {name} group configuration is invalid"]
+
+    builder_values = group.get("builders", [])
+    if builder_values is None:
+        builder_values = []
+    if not isinstance(builder_values, list):
+        errors.append(f"The {name} group builder list is invalid")
+        builder_values = []
+
+    builders = [
+        builder_id for builder_id in builder_values if isinstance(builder_id, str)
+    ]
+
+    if required and not builder_values:
+        errors.append(f"Please add at least one builder to the {name} group")
+
+    if len(builders) != len(builder_values) or any(
+        not builder_id for builder_id in builders
+    ):
+        errors.append(f"The {name} group contains an invalid builder ID")
+
+    operation = group.get("operation")
+    if builder_values and operation not in ("union", "intersection"):
+        errors.append(
+            f"Please select a valid operation (union or intersection) for the {name} group"
+        )
+
+    return builders, errors
+
+
+def _normalize(line: bytes) -> str | None:
+    s = line.decode("utf-8", errors="replace").strip()
+    if not s or s.startswith("#"):
+        return None
+    return s.replace(" ", "_")
+
+
+def _parse_tsv_to_set(data: bytes) -> set[str]:
+    titles: set[str] = set()
+    for line in data.split(b"\n"):
+        normalized = _normalize(line)
+        if normalized is not None:
+            titles.add(normalized)
+    return titles
+
+
+def _apply_operation(operation: str, sets: list[set[str]]) -> set[str]:
+    if not sets:
+        return set()
+
+    if operation == "union":
+        return set.union(*sets)
+
+    if operation == "intersection":
+        return set.intersection(*sets)
+
+    raise ValueError(f"Unsupported operation: {operation}")
+
+
+# metabuilder
+def _fetch_selection_data(wp10db, s3, builder_id: str) -> bytes:
+    """Fetch the latest materialized TSV snapshot for a referenced builder."""
+    selection = logic_builder.latest_selection_for(
+        wp10db, builder_id, "text/tab-separated-values"
+    )
+
+    if selection is None:
+        raise Wp1RetryableSelectionError(
+            f"Referenced builder {builder_id} has no usable selection "
+            f"(no selection found)"
+        )
+
+    status = selection.s_status
+    if status == b"FAILED" or status == "FAILED":
+        raise Wp1FatalSelectionError(
+            f"Referenced builder {builder_id} has no usable selection "
+            f"(status={status!r})"
+        )
+
+    if status != b"OK" and status != "OK":
+        raise Wp1RetryableSelectionError(
+            f"Referenced builder {builder_id} has no usable selection "
+            f"(status={status!r})"
+        )
+
+    if selection.s_object_key is None:
+        raise Wp1RetryableSelectionError(
+            f"Referenced builder {builder_id} has no usable selection "
+            f"(s_object_key is None)"
+        )
+
+    object_key = selection.s_object_key
+    if isinstance(object_key, bytes):
+        object_key = object_key.decode("utf-8")
+
+    buffer = io.BytesIO()
+    try:
+        s3.download_fileobj(object_key, buffer)
+    except ClientError as e:
+        code = e.response.get("Error", {}).get("Code", "Unknown")
+        raise Wp1RetryableSelectionError(
+            f"Failed to download selection for builder {builder_id} "
+            f"from S3 key {object_key!r}: {code}"
+        ) from e
+    except Exception as e:
+        raise Wp1RetryableSelectionError(
+            f"Failed to download selection for builder {builder_id} "
+            f"from S3 key {object_key!r}: {e}"
+        ) from e
+
+    return buffer.getvalue()
+
+
+def _process_group(wp10db, s3, group: dict[str, Any]) -> set[str]:
+
+    builder_values = group.get("builders", [])
+
+    builder_ids = [
+        builder_id for builder_id in builder_values if isinstance(builder_id, str)
+    ]
+
+    operation = group.get("operation", "union")
+
+    sets: list[set[str]] = []
+    for builder_id in _dedupe(builder_ids):
+        data = _fetch_selection_data(wp10db, s3, builder_id)
+        title_set = _parse_tsv_to_set(data)
+        sets.append(title_set)
+
+    return _apply_operation(operation, sets)
+
+
+class Builder(AbstractBuilder):
+    """Combinator builder: combines other builders using set operations."""
+
+    def validate(
+        self, **params: Any
+    ) -> tuple[list[str] | str, list[str] | str, list[str]]:
+        errors: list[str] = []
+
+        include = params.get("include")
+        exclude = params.get("exclude")
+
+        include_builders, group_errors = _validate_group_shape("Include", include, True)
+        errors.extend(group_errors)
+        exclude_builders, group_errors = _validate_group_shape(
+            "Exclude", exclude, False
+        )
+        errors.extend(group_errors)
+
+        if errors:
+            return ([], [], errors)
+
+        if "wp10db" not in params or "user_id" not in params or "project" not in params:
+            return (
+                [],
+                [],
+                ["Configuration could not be validated. Please try saving again."],
+            )
+
+        wp10db = params["wp10db"]
+        user_id = params["user_id"]
+        project = params["project"]
+        builder_id = params.get("builder_id")
+
+        referenced_ids = _dedupe(include_builders + exclude_builders)
+
+        if builder_id is not None and _as_text(builder_id) in referenced_ids:
+            errors.append("This combinator cannot reference itself")
+
+        if errors:
+            return ([], [], errors)
+
+        for reference_id in referenced_ids:
+            try:
+                builder = logic_builder.get_builder(wp10db, reference_id)
+            except ObjectNotFoundError:
+                errors.append(
+                    f"Builder {reference_id!r} no longer exists. Please remove it "
+                    "from this combinator."
+                )
+                continue
+
+            # name + id is only for helping testing, in prod we dont show the id
+            # TODO : show the name only
+            label = _builder_label(builder)
+
+            if _as_text(builder.b_user_id) != _as_text(user_id):
+                errors.append(
+                    f"Builder {label} belongs to another user. You can only "
+                    "reference your own builders."
+                )
+            if _as_text(builder.b_project) != _as_text(project):
+                errors.append(
+                    f"Builder {label} belongs to project "
+                    f"{_as_text(builder.b_project)!r}. All referenced builders "
+                    "must use the same project."
+                )
+            if _is_meta_builder(builder):
+                errors.append(
+                    f"Builder {label} is a combinator. Combinators can only "
+                    "reference leaf builders such as Simple, SPARQL, PetScan, "
+                    "Book, or WikiProject."
+                )
+
+        if errors:
+            return ([], [], errors)
+
+        return ([], [], [])
+
+    def build(self, content_type: str, **params: Any) -> bytes:
+        """Build the combinator selection from referenced builders."""
+        if content_type != "text/tab-separated-values":
+            raise Wp1FatalSelectionError(f"Unrecognized content type: {content_type!r}")
+
+        wp10db = params.get("wp10db")
+        s3 = params.get("s3")
+
+        if wp10db is None:
+            raise Wp1FatalSelectionError("Combinator build requires 'wp10db' parameter")
+        if s3 is None:
+            raise Wp1FatalSelectionError("Combinator build requires 's3' parameter")
+
+        include_group = params.get("include")
+        exclude_group = params.get("exclude")
+
+        if include_group is None:
+            raise Wp1FatalSelectionError("Missing required 'include' group")
+
+        include_set = _process_group(wp10db, s3, include_group)
+
+        exclude_set: set[str] = set()
+        if exclude_group is not None:
+            exclude_builders = exclude_group.get("builders", [])
+            if exclude_builders:
+                exclude_set = _process_group(wp10db, s3, exclude_group)
+
+        result = include_set - exclude_set
+
+        if not result:
+            raise Wp1FatalSelectionError("Combinator produced no articles")
+
+        return "\n".join(sorted(result)).encode("utf-8")

--- a/wp1/selection/models/combinator.py
+++ b/wp1/selection/models/combinator.py
@@ -16,11 +16,10 @@ from wp1.selection.abstract_builder import AbstractBuilder
 logger = logging.getLogger(__name__)
 
 
-# TODO: move shared metabuilder helpers into a metaBuilder base class when that abstraction is introduced
-
 META_BUILDER_MODELS = {"wp1.selection.models.combinator"}
 
 
+# TODO: #1181 - Move shared helpers into AbstractBuilder.
 def _as_text(value: bytes | str | int | None) -> str:
     if isinstance(value, bytes):
         return value.decode("utf-8")
@@ -66,7 +65,6 @@ def _validate_group_shape(
 ) -> tuple[list[str], list[str]]:
     errors: list[str] = []
 
-    # can we have empty groups?
     if group is None:
         if required:
             errors.append(f"Please add at least one builder to the {name} group")
@@ -103,7 +101,7 @@ def _validate_group_shape(
     return builders, errors
 
 
-# TODO: extractt TSV title parsing helpers if more selection builders needs this behavior
+# TODO: #1181 - Move shared title parsing helpers into AbstractBuilder.
 def _normalize(line: bytes) -> str | None:
     s = line.decode("utf-8", errors="replace").strip()
     if not s or s.startswith("#"):
@@ -120,6 +118,7 @@ def _parse_tsv_to_set(data: bytes) -> set[str]:
     return titles
 
 
+# TODO: #1181 - Move shared set operation helpers into AbstractBuilder.
 def _apply_operation(operation: str, sets: list[set[str]]) -> set[str]:
     if not sets:
         return set()
@@ -160,6 +159,8 @@ def _fetch_selection_data(
             f"(status={status!r})"
         )
 
+    # OK selections can have no object key when materialization produced empty
+    # data, since AbstractBuilder only uploads filled selection.data.
     if selection.s_object_key is None:
         raise Wp1RetryableSelectionError(
             f"Referenced builder {label} latest selection has no object key"
@@ -193,6 +194,7 @@ def _process_group(wp10db, s3, group: dict[str, Any]) -> set[str]:
     operation = group.get("operation", "union")
 
     sets: list[set[str]] = []
+    # TODO: #1184 - Handle multiple bad referenced selections in combinator build.
     for builder_id in _dedupe(builder_ids):
         data = _fetch_selection_data(
             wp10db, s3, builder_id, _reference_label(wp10db, builder_id)
@@ -258,7 +260,7 @@ class Builder(AbstractBuilder):
             try:
                 builder = logic_builder.get_builder(wp10db, reference_id)
             except ObjectNotFoundError:
-                # TODO: https://github.com/openzim/wp1/issues/1178
+                # TODO: #1178 - Think more about broken referenced builders.
                 errors.append(
                     f"Builder {reference_id!r} no longer exists. Please remove it "
                     "from this combinator."

--- a/wp1/selection/models/combinator.py
+++ b/wp1/selection/models/combinator.py
@@ -35,6 +35,14 @@ def _builder_label(builder: Wp10Builder) -> str:
     return builder_id
 
 
+def _reference_label(wp10db, builder_id: str) -> str:
+    try:
+        builder = logic_builder.get_builder(wp10db, builder_id)
+    except ObjectNotFoundError:
+        return builder_id
+    return _builder_label(builder)
+
+
 def _builder_model(builder: Wp10Builder) -> str:
     return _as_text(getattr(builder, "b_model", ""))
 
@@ -125,33 +133,36 @@ def _apply_operation(operation: str, sets: list[set[str]]) -> set[str]:
     raise ValueError(f"Unsupported operation: {operation}")
 
 
-def _fetch_selection_data(wp10db, s3, builder_id: str) -> bytes:
+def _fetch_selection_data(
+    wp10db, s3, builder_id: str, reference_label: str | None = None
+) -> bytes:
     """Fetch the latest materialized TSV snapshot for a referenced builder."""
+    label = reference_label or builder_id
     selection = logic_builder.latest_selection_for(
         wp10db, builder_id, "text/tab-separated-values"
     )
 
     if selection is None:
         raise Wp1RetryableSelectionError(
-            f"Referenced builder {builder_id} has no usable selection "
+            f"Referenced builder {label} has no usable selection "
             f"(no selection found)"
         )
 
     status = _as_text(selection.s_status)
     if status == "FAILED":
         raise Wp1FatalSelectionError(
-            f"Referenced builder {builder_id} latest selection failed"
+            f"Referenced builder {label} latest selection failed"
         )
 
     if status != "OK":
         raise Wp1RetryableSelectionError(
-            f"Referenced builder {builder_id} latest selection is not ready "
+            f"Referenced builder {label} latest selection is not ready "
             f"(status={status!r})"
         )
 
     if selection.s_object_key is None:
         raise Wp1RetryableSelectionError(
-            f"Referenced builder {builder_id} latest selection has no object key"
+            f"Referenced builder {label} latest selection has no object key"
         )
 
     object_key = selection.s_object_key
@@ -164,7 +175,7 @@ def _fetch_selection_data(wp10db, s3, builder_id: str) -> bytes:
     except ClientError as e:
         code = e.response.get("Error", {}).get("Code", "Unknown")
         raise Wp1RetryableSelectionError(
-            f"Failed to download selection for builder {builder_id} "
+            f"Failed to download selection for builder {label} "
             f"from S3 key {object_key!r}: {code}"
         ) from e
 
@@ -183,7 +194,9 @@ def _process_group(wp10db, s3, group: dict[str, Any]) -> set[str]:
 
     sets: list[set[str]] = []
     for builder_id in _dedupe(builder_ids):
-        data = _fetch_selection_data(wp10db, s3, builder_id)
+        data = _fetch_selection_data(
+            wp10db, s3, builder_id, _reference_label(wp10db, builder_id)
+        )
         title_set = _parse_tsv_to_set(data)
         sets.append(title_set)
 

--- a/wp1/selection/models/combinator_test.py
+++ b/wp1/selection/models/combinator_test.py
@@ -1,8 +1,9 @@
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from wp1.base_db_test import BaseWpOneDbTest
 from wp1.exceptions import Wp1FatalSelectionError, Wp1RetryableSelectionError
+from wp1.models.wp10.builder import Builder
+from wp1.models.wp10.selection import Selection
 from wp1.selection.models.combinator import Builder as CombinatorBuilder
 from wp1.selection.models.combinator import _fetch_selection_data
 
@@ -14,12 +15,23 @@ def _reference_builder(
     project="en.wikipedia.org",
     model="wp1.selection.models.simple",
 ):
-    return SimpleNamespace(
+    return Builder(
         b_id=id_.encode("utf-8"),
         b_name=name.encode("utf-8"),
         b_user_id=str(user_id).encode("utf-8"),
         b_project=project.encode("utf-8"),
         b_model=model.encode("utf-8"),
+        b_params=b"{}",
+    )
+
+
+def _selection(status=b"OK", object_key=b"object-key"):
+    return Selection(
+        s_builder_id=b"builder-a",
+        s_content_type=b"text/tab-separated-values",
+        s_version=1,
+        s_status=status,
+        s_object_key=object_key,
     )
 
 
@@ -118,15 +130,13 @@ class CombinatorBuilderTest(BaseWpOneDbTest):
         )
         self.assertEqual(expected, actual)
 
-    def test_validate_ignores_empty_exclude_operation(self):
+    @patch("wp1.selection.models.combinator.logic_builder.get_builder")
+    def test_validate_ignores_empty_exclude_operation(self, mock_get_builder):
+        mock_get_builder.return_value = _reference_builder()
         params = dict(self.params)
         params["exclude"] = {"builders": [], "operation": "xor"}
 
-        with patch(
-            "wp1.selection.models.combinator.logic_builder.get_builder",
-            return_value=_reference_builder(),
-        ):
-            actual = self.builder.validate(**params)
+        actual = self.builder.validate(**params)
 
         self.assertEqual(([], [], []), actual)
 
@@ -177,16 +187,16 @@ class CombinatorBuilderTest(BaseWpOneDbTest):
         )
         self.assertEqual(expected, actual)
 
-    def test_build(self):
+    @patch("wp1.selection.models.combinator._fetch_selection_data")
+    def test_build(self, mock_fetch_selection_data):
         data = {
             "builder-a": b"first article\r\nsecond\n# ignored\n",
             "builder-b": b"second\nthird\n",
             "builder-c": b"third\n",
         }
-
-        def fetch_selection_data(_wp10db, _s3, builder_id):
-            return data[builder_id]
-
+        mock_fetch_selection_data.side_effect = lambda _wp10db, _s3, builder_id: data[
+            builder_id
+        ]
         params = dict(self.params)
         params.update(
             include={"builders": ["builder-a", "builder-b"], "operation": "union"},
@@ -194,23 +204,19 @@ class CombinatorBuilderTest(BaseWpOneDbTest):
             s3=MagicMock(),
         )
 
-        with patch(
-            "wp1.selection.models.combinator._fetch_selection_data",
-            fetch_selection_data,
-        ):
-            actual = self.builder.build("text/tab-separated-values", **params)
+        actual = self.builder.build("text/tab-separated-values", **params)
 
         self.assertEqual(b"first_article\nsecond", actual)
 
-    def test_build_intersection(self):
+    @patch("wp1.selection.models.combinator._fetch_selection_data")
+    def test_build_intersection(self, mock_fetch_selection_data):
         data = {
             "builder-a": b"first\nshared\n",
             "builder-b": b"second\nshared\n",
         }
-
-        def fetch_selection_data(_wp10db, _s3, builder_id):
-            return data[builder_id]
-
+        mock_fetch_selection_data.side_effect = lambda _wp10db, _s3, builder_id: data[
+            builder_id
+        ]
         params = dict(self.params)
         params.update(
             include={
@@ -220,30 +226,22 @@ class CombinatorBuilderTest(BaseWpOneDbTest):
             s3=MagicMock(),
         )
 
-        with patch(
-            "wp1.selection.models.combinator._fetch_selection_data",
-            fetch_selection_data,
-        ):
-            actual = self.builder.build("text/tab-separated-values", **params)
+        actual = self.builder.build("text/tab-separated-values", **params)
 
         self.assertEqual(b"shared", actual)
 
-    def test_build_empty_result(self):
+    @patch("wp1.selection.models.combinator._fetch_selection_data")
+    def test_build_empty_result(self, mock_fetch_selection_data):
+        mock_fetch_selection_data.return_value = b""
         params = dict(self.params)
         params.update(s3=MagicMock())
 
-        with patch(
-            "wp1.selection.models.combinator._fetch_selection_data",
-            return_value=b"",
-        ):
-            with self.assertRaises(Wp1FatalSelectionError):
-                self.builder.build("text/tab-separated-values", **params)
+        with self.assertRaises(Wp1FatalSelectionError):
+            self.builder.build("text/tab-separated-values", **params)
 
     @patch("wp1.selection.models.combinator.logic_builder.latest_selection_for")
     def test_fetch_selection_data(self, mock_latest_selection):
-        mock_latest_selection.return_value = SimpleNamespace(
-            s_status=b"OK", s_object_key=b"object-key"
-        )
+        mock_latest_selection.return_value = _selection()
         s3 = MagicMock()
         s3.download_fileobj.side_effect = lambda _key, buf: buf.write(b"first\n")
 
@@ -254,18 +252,14 @@ class CombinatorBuilderTest(BaseWpOneDbTest):
 
     @patch("wp1.selection.models.combinator.logic_builder.latest_selection_for")
     def test_fetch_selection_data_failed_selection(self, mock_latest_selection):
-        mock_latest_selection.return_value = SimpleNamespace(
-            s_status=b"FAILED", s_object_key=b"object-key"
-        )
+        mock_latest_selection.return_value = _selection(status=b"FAILED")
 
         with self.assertRaises(Wp1FatalSelectionError):
             _fetch_selection_data(MagicMock(), MagicMock(), "builder-a")
 
     @patch("wp1.selection.models.combinator.logic_builder.latest_selection_for")
     def test_fetch_selection_data_retryable_selection(self, mock_latest_selection):
-        mock_latest_selection.return_value = SimpleNamespace(
-            s_status=b"CAN_RETRY", s_object_key=b"object-key"
-        )
+        mock_latest_selection.return_value = _selection(status=b"CAN_RETRY")
 
         with self.assertRaises(Wp1RetryableSelectionError):
             _fetch_selection_data(MagicMock(), MagicMock(), "builder-a")

--- a/wp1/selection/models/combinator_test.py
+++ b/wp1/selection/models/combinator_test.py
@@ -1,0 +1,331 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from wp1.base_db_test import BaseWpOneDbTest
+from wp1.exceptions import Wp1FatalSelectionError, Wp1RetryableSelectionError
+from wp1.selection.models.combinator import Builder as CombinatorBuilder
+from wp1.selection.models.combinator import _fetch_selection_data
+
+
+def _reference_builder(
+    id_="builder-a",
+    name="Builder A",
+    user_id="1234",
+    project="en.wikipedia.org",
+    model="wp1.selection.models.simple",
+):
+    return SimpleNamespace(
+        b_id=id_.encode("utf-8"),
+        b_name=name.encode("utf-8"),
+        b_user_id=str(user_id).encode("utf-8"),
+        b_project=project.encode("utf-8"),
+        b_model=model.encode("utf-8"),
+    )
+
+
+class CombinatorBuilderTest(BaseWpOneDbTest):
+
+    def setUp(self):
+        super().setUp()
+        self.builder = CombinatorBuilder()
+        self.params = {
+            "project": "en.wikipedia.org",
+            "user_id": "1234",
+            "wp10db": MagicMock(),
+            "include": {"builders": ["builder-a"], "operation": "union"},
+        }
+
+    def _insert_builder(
+        self,
+        id_="builder-a",
+        name="Builder A",
+        user_id="1234",
+        project="en.wikipedia.org",
+        model="wp1.selection.models.simple",
+        current_version=0,
+    ):
+        with self.wp10db.cursor() as cursor:
+            cursor.execute(
+                """INSERT INTO builders
+                   (b_id, b_name, b_user_id, b_project, b_params, b_model,
+                    b_created_at, b_updated_at, b_current_version,
+                    b_selection_zim_version)
+                   VALUES
+                   (%s, %s, %s, %s, %s, %s,
+                    '20260329180000', '20260329180000', %s, 0)
+                """,
+                (
+                    id_.encode("utf-8"),
+                    name.encode("utf-8"),
+                    str(user_id).encode("utf-8"),
+                    project.encode("utf-8"),
+                    b'{"list": ["first"]}',
+                    model.encode("utf-8"),
+                    current_version,
+                ),
+            )
+        self.wp10db.commit()
+
+    def _insert_selection(self, id_, builder_id, object_key, version=1):
+        with self.wp10db.cursor() as cursor:
+            cursor.execute(
+                """INSERT INTO selections
+                   (s_id, s_builder_id, s_content_type, s_updated_at, s_version,
+                    s_object_key, s_status, s_article_count)
+                   VALUES
+                   (%s, %s, %s, '20260329180000', %s, %s, 'OK', 1)
+                """,
+                (
+                    id_.encode("utf-8"),
+                    builder_id.encode("utf-8"),
+                    b"text/tab-separated-values",
+                    version,
+                    object_key.encode("utf-8"),
+                ),
+            )
+        self.wp10db.commit()
+
+    @patch("wp1.selection.models.combinator.logic_builder.get_builder")
+    def test_validate(self, mock_get_builder):
+        mock_get_builder.return_value = _reference_builder()
+
+        actual = self.builder.validate(**self.params)
+
+        self.assertEqual(([], [], []), actual)
+
+    def test_validate_empty_include(self):
+        params = dict(self.params)
+        params["include"] = {"builders": [], "operation": "union"}
+
+        actual = self.builder.validate(**params)
+
+        self.assertEqual(
+            ([], [], ["Please add at least one builder to the Include group"]), actual
+        )
+
+    def test_validate_invalid_include_operation(self):
+        params = dict(self.params)
+        params["include"] = {"builders": ["builder-a"], "operation": "xor"}
+
+        actual = self.builder.validate(**params)
+
+        expected = (
+            [],
+            [],
+            [
+                "Please select a valid operation (union or intersection) for the Include group"
+            ],
+        )
+        self.assertEqual(expected, actual)
+
+    def test_validate_ignores_empty_exclude_operation(self):
+        params = dict(self.params)
+        params["exclude"] = {"builders": [], "operation": "xor"}
+
+        with patch(
+            "wp1.selection.models.combinator.logic_builder.get_builder",
+            return_value=_reference_builder(),
+        ):
+            actual = self.builder.validate(**params)
+
+        self.assertEqual(([], [], []), actual)
+
+    @patch("wp1.selection.models.combinator.logic_builder.get_builder")
+    def test_validate_cross_user_builder(self, mock_get_builder):
+        mock_get_builder.return_value = _reference_builder(user_id="5678")
+
+        actual = self.builder.validate(**self.params)
+
+        expected = (
+            [],
+            [],
+            [
+                "Builder Builder A (builder-a) belongs to another user. You can only reference your own builders."
+            ],
+        )
+        self.assertEqual(expected, actual)
+
+    @patch("wp1.selection.models.combinator.logic_builder.get_builder")
+    def test_validate_cross_project_builder(self, mock_get_builder):
+        mock_get_builder.return_value = _reference_builder(project="de.wikipedia.org")
+
+        actual = self.builder.validate(**self.params)
+
+        expected = (
+            [],
+            [],
+            [
+                "Builder Builder A (builder-a) belongs to project 'de.wikipedia.org'. All referenced builders must use the same project."
+            ],
+        )
+        self.assertEqual(expected, actual)
+
+    @patch("wp1.selection.models.combinator.logic_builder.get_builder")
+    def test_validate_meta_builder_reference(self, mock_get_builder):
+        mock_get_builder.return_value = _reference_builder(
+            model="wp1.selection.models.combinator"
+        )
+
+        actual = self.builder.validate(**self.params)
+
+        expected = (
+            [],
+            [],
+            [
+                "Builder Builder A (builder-a) is a combinator. Combinators can only reference leaf builders such as Simple, SPARQL, PetScan, Book, or WikiProject."
+            ],
+        )
+        self.assertEqual(expected, actual)
+
+    def test_build(self):
+        data = {
+            "builder-a": b"first article\r\nsecond\n# ignored\n",
+            "builder-b": b"second\nthird\n",
+            "builder-c": b"third\n",
+        }
+
+        def fetch_selection_data(_wp10db, _s3, builder_id):
+            return data[builder_id]
+
+        params = dict(self.params)
+        params.update(
+            include={"builders": ["builder-a", "builder-b"], "operation": "union"},
+            exclude={"builders": ["builder-c"], "operation": "union"},
+            s3=MagicMock(),
+        )
+
+        with patch(
+            "wp1.selection.models.combinator._fetch_selection_data",
+            fetch_selection_data,
+        ):
+            actual = self.builder.build("text/tab-separated-values", **params)
+
+        self.assertEqual(b"first_article\nsecond", actual)
+
+    def test_build_intersection(self):
+        data = {
+            "builder-a": b"first\nshared\n",
+            "builder-b": b"second\nshared\n",
+        }
+
+        def fetch_selection_data(_wp10db, _s3, builder_id):
+            return data[builder_id]
+
+        params = dict(self.params)
+        params.update(
+            include={
+                "builders": ["builder-a", "builder-b"],
+                "operation": "intersection",
+            },
+            s3=MagicMock(),
+        )
+
+        with patch(
+            "wp1.selection.models.combinator._fetch_selection_data",
+            fetch_selection_data,
+        ):
+            actual = self.builder.build("text/tab-separated-values", **params)
+
+        self.assertEqual(b"shared", actual)
+
+    def test_build_empty_result(self):
+        params = dict(self.params)
+        params.update(s3=MagicMock())
+
+        with patch(
+            "wp1.selection.models.combinator._fetch_selection_data",
+            return_value=b"",
+        ):
+            with self.assertRaises(Wp1FatalSelectionError):
+                self.builder.build("text/tab-separated-values", **params)
+
+    @patch("wp1.selection.models.combinator.logic_builder.latest_selection_for")
+    def test_fetch_selection_data(self, mock_latest_selection):
+        mock_latest_selection.return_value = SimpleNamespace(
+            s_status=b"OK", s_object_key=b"object-key"
+        )
+        s3 = MagicMock()
+        s3.download_fileobj.side_effect = lambda _key, buf: buf.write(b"first\n")
+
+        actual = _fetch_selection_data(MagicMock(), s3, "builder-a")
+
+        self.assertEqual(b"first\n", actual)
+        s3.download_fileobj.assert_called_once()
+
+    @patch("wp1.selection.models.combinator.logic_builder.latest_selection_for")
+    def test_fetch_selection_data_failed_selection(self, mock_latest_selection):
+        mock_latest_selection.return_value = SimpleNamespace(
+            s_status=b"FAILED", s_object_key=b"object-key"
+        )
+
+        with self.assertRaises(Wp1FatalSelectionError):
+            _fetch_selection_data(MagicMock(), MagicMock(), "builder-a")
+
+    @patch("wp1.selection.models.combinator.logic_builder.latest_selection_for")
+    def test_fetch_selection_data_retryable_selection(self, mock_latest_selection):
+        mock_latest_selection.return_value = SimpleNamespace(
+            s_status=b"CAN_RETRY", s_object_key=b"object-key"
+        )
+
+        with self.assertRaises(Wp1RetryableSelectionError):
+            _fetch_selection_data(MagicMock(), MagicMock(), "builder-a")
+
+    @patch("wp1.selection.models.combinator.logic_builder.latest_selection_for")
+    def test_fetch_selection_data_missing_selection(self, mock_latest_selection):
+        mock_latest_selection.return_value = None
+
+        with self.assertRaises(Wp1RetryableSelectionError):
+            _fetch_selection_data(MagicMock(), MagicMock(), "builder-a")
+
+    def test_validate_with_referenced_builder_in_db(self):
+        self._insert_builder()
+
+        actual = self.builder.validate(
+            project="en.wikipedia.org",
+            user_id="1234",
+            wp10db=self.wp10db,
+            include={"builders": ["builder-a"], "operation": "union"},
+        )
+
+        self.assertEqual(([], [], []), actual)
+
+    def test_validate_missing_builder_in_db(self):
+        actual = self.builder.validate(
+            project="en.wikipedia.org",
+            user_id="1234",
+            wp10db=self.wp10db,
+            include={"builders": ["builder-a"], "operation": "union"},
+        )
+
+        expected = (
+            [],
+            [],
+            [
+                "Builder 'builder-a' no longer exists. Please remove it from this combinator."
+            ],
+        )
+        self.assertEqual(expected, actual)
+
+    def test_build_with_latest_selections_in_db(self):
+        self._insert_builder(id_="builder-a", current_version=1)
+        self._insert_builder(id_="builder-b", current_version=1)
+        self._insert_selection("selection-a", "builder-a", "object-a")
+        self._insert_selection("selection-b", "builder-b", "object-b")
+        s3 = MagicMock()
+        objects = {
+            "object-a": b"first\nshared\n",
+            "object-b": b"second\nshared\n",
+        }
+        s3.download_fileobj.side_effect = lambda key, buf: buf.write(objects[key])
+
+        actual = self.builder.build(
+            "text/tab-separated-values",
+            wp10db=self.wp10db,
+            s3=s3,
+            include={
+                "builders": ["builder-a", "builder-b"],
+                "operation": "intersection",
+            },
+        )
+
+        self.assertEqual(b"shared", actual)

--- a/wp1/selection/models/combinator_test.py
+++ b/wp1/selection/models/combinator_test.py
@@ -187,16 +187,18 @@ class CombinatorBuilderTest(BaseWpOneDbTest):
         )
         self.assertEqual(expected, actual)
 
+    @patch("wp1.selection.models.combinator.logic_builder.get_builder")
     @patch("wp1.selection.models.combinator._fetch_selection_data")
-    def test_build(self, mock_fetch_selection_data):
+    def test_build(self, mock_fetch_selection_data, mock_get_builder):
+        mock_get_builder.return_value = _reference_builder()
         data = {
             "builder-a": b"first article\r\nsecond\n# ignored\n",
             "builder-b": b"second\nthird\n",
             "builder-c": b"third\n",
         }
-        mock_fetch_selection_data.side_effect = lambda _wp10db, _s3, builder_id: data[
-            builder_id
-        ]
+        mock_fetch_selection_data.side_effect = (
+            lambda _wp10db, _s3, builder_id, _label: data[builder_id]
+        )
         params = dict(self.params)
         params.update(
             include={"builders": ["builder-a", "builder-b"], "operation": "union"},
@@ -208,15 +210,17 @@ class CombinatorBuilderTest(BaseWpOneDbTest):
 
         self.assertEqual(b"first_article\nsecond", actual)
 
+    @patch("wp1.selection.models.combinator.logic_builder.get_builder")
     @patch("wp1.selection.models.combinator._fetch_selection_data")
-    def test_build_intersection(self, mock_fetch_selection_data):
+    def test_build_intersection(self, mock_fetch_selection_data, mock_get_builder):
+        mock_get_builder.return_value = _reference_builder()
         data = {
             "builder-a": b"first\nshared\n",
             "builder-b": b"second\nshared\n",
         }
-        mock_fetch_selection_data.side_effect = lambda _wp10db, _s3, builder_id: data[
-            builder_id
-        ]
+        mock_fetch_selection_data.side_effect = (
+            lambda _wp10db, _s3, builder_id, _label: data[builder_id]
+        )
         params = dict(self.params)
         params.update(
             include={
@@ -230,8 +234,10 @@ class CombinatorBuilderTest(BaseWpOneDbTest):
 
         self.assertEqual(b"shared", actual)
 
+    @patch("wp1.selection.models.combinator.logic_builder.get_builder")
     @patch("wp1.selection.models.combinator._fetch_selection_data")
-    def test_build_empty_result(self, mock_fetch_selection_data):
+    def test_build_empty_result(self, mock_fetch_selection_data, mock_get_builder):
+        mock_get_builder.return_value = _reference_builder()
         mock_fetch_selection_data.return_value = b""
         params = dict(self.params)
         params.update(s3=MagicMock())

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -46,9 +46,14 @@ def _create_or_update_builder(wp10db, data, builder_id=None):
         logger.warning(str(e))
         flask.abort(400)
 
+    user_id = flask.session["user"]["identity"]["sub"]
     builder_obj = builder_cls()
     valid_values, invalid_values, errors = builder_obj.validate(
-        project=project, wp10db=wp10db, **params
+        project=project,
+        wp10db=wp10db,
+        user_id=user_id,
+        builder_id=builder_id,
+        **params,
     )
     if invalid_values or errors:
         return flask.jsonify(
@@ -65,7 +70,6 @@ def _create_or_update_builder(wp10db, data, builder_id=None):
     wp10db = get_db("wp10db")
     redis = get_redis()
 
-    user_id = flask.session["user"]["identity"]["sub"]
     builder_id = logic_builder.create_or_update_builder(
         wp10db, list_name, user_id, project, params, model, builder_id=builder_id
     )


### PR DESCRIPTION

  Adds a new combinator selection builder that combines existing materialized builder selections using set operations.

  ## Changes

  - Add `combinator.py`
  - Add `combinator_test.py`
  - Support include/exclude groups with `union` and `intersection`
  - Read referenced builders' latest TSV selections from storage
  - Normalize article titles before combining
  - Produce deterministic sorted TSV output
  
  - Add save-time validation for:
    - required include group
    - valid operations
    - referenced builder existence
    - same user
    - same project
    - no meataBuilder-to-metaBuilder references
  - Add combinator tests

 Build-time checks are limited to materialization state, such as missing selections, failed selections, missing object keys, S3 download failures and empty final results.