### PR TITLE
remove category field from recipe create payload

### DIFF
--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -368,10 +368,9 @@ def _get_params(
     return {
         "name": get_zimfarm_schedule_name(builder.b_id.decode("utf-8")),
         "language": "eng",
-        "category": "wikipedia",
         "context": "wikimedia",
         "periodicity": "manually",
-        "tags": [],
+        "tags": ["wikipedia"],
         "enabled": True,
         "notification": {
             "ended": {

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -30,10 +30,9 @@ class ZimFarmTest(BaseWpOneDbTest):
     expected_params = {
         "name": "wp1_selection_3c4d",
         "language": "eng",
-        "category": "wikipedia",
         "context": "wikimedia",
         "periodicity": "manually",
-        "tags": [],
+        "tags": ["wikipedia"],
         "enabled": True,
         "notification": {
             "ended": {


### PR DESCRIPTION
## Changes
- remove category field from recipe creation payload and use it's value in tags since `wikipedia` is one of the desired tags

This closes #1179