### PR TITLE
Sync Black version between CI, pre-commit and Pipfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,11 @@ jobs:
           python-version: '3.14.4'
 
       - name: Install Black
+        # Install the exact version from Pipfile.lock so CI and local
+        # formatting can never disagree.
         run: |
           pip install --upgrade pip
-          pip install black~=25.12
+          pip install "black==$(jq -r '.develop.black.version | ltrimstr("==")' Pipfile.lock)"
 
       - name: Check formatting with Black
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,6 @@ repos:
             --trailing-comma all
 
   - repo: https://github.com/psf/black
-    rev: 25.12.0
+    rev: 26.5.1
     hooks:
       - id: black

--- a/db/migrations/20220818_01_5x0T9-add-object-key-column-to-selections.py
+++ b/db/migrations/20220818_01_5x0T9-add-object-key-column-to-selections.py
@@ -15,11 +15,9 @@ __depends__ = {"20220813_02_Yqp7y-add-version-column-to-selections"}
 
 def add_object_keys(conn):
     cursor = conn.cursor()
-    cursor.execute(
-        """SELECT s.s_id, s.s_content_type, b.b_model, b.b_name
+    cursor.execute("""SELECT s.s_id, s.s_content_type, b.b_model, b.b_name
                     FROM selections AS s JOIN builders AS b ON s.s_builder_id = b.b_id
-            """
-    )
+            """)
     data = cursor.fetchall()
     for row in data:
         object_key = logic_selection.object_key_for(

--- a/db/migrations/20250330_01_zaRQa-migrate-last-7-days-of-logs.py
+++ b/db/migrations/20250330_01_zaRQa-migrate-last-7-days-of-logs.py
@@ -27,13 +27,11 @@ def migrate_logs(conn):
     n = 0
     print(f"Fetching logs from {from_dt} to now")
     with conn.cursor() as cursor:
-        cursor.execute(
-            f"""
+        cursor.execute(f"""
         SELECT l_project, l_namespace, l_article, l_action,
             l_timestamp, l_old, l_new, l_revision_timestamp FROM logging
         WHERE l_timestamp >= '{from_dt}'
-    """
-        )
+    """)
         for log_db in cursor.fetchall():
             log = Log(
                 l_project=log_db[0],

--- a/wp1/custom_tables/init_test.py
+++ b/wp1/custom_tables/init_test.py
@@ -9,14 +9,12 @@ class CustomTablesInitTest(BaseWpOneDbTest):
 
     def test_all_custom_table_names(self):
         with self.wp10db.cursor() as cursor:
-            cursor.execute(
-                """
+            cursor.execute("""
         INSERT INTO custom (c_name, c_module, c_is_active) VALUES
           ("Apple", "wp1.custom_tables.apple", 1),
           ("Orange", "wp1.custom_tables.apple", 0),
           ("Banana", "wp1.custom_tables.apple", 1)
-      """
-            )
+      """)
 
         actual = all_custom_table_names(self.wp10db)
         self.assertEqual([b"Apple", b"Banana"], actual)
@@ -24,12 +22,10 @@ class CustomTablesInitTest(BaseWpOneDbTest):
     @patch("wp1.custom_tables.importlib")
     def test_upload_custom_table_by_name(self, patched_importlib):
         with self.wp10db.cursor() as cursor:
-            cursor.execute(
-                """
+            cursor.execute("""
         INSERT INTO custom (c_name, c_module, c_params, c_is_active) VALUES
           ("foo", "wp1.custom_tables.foo", '{"wiki_path": "Wiki/Path"}', 1)
-      """
-            )
+      """)
         self.wp10db.commit()
 
         module = MagicMock()
@@ -49,12 +45,10 @@ class CustomTablesInitTest(BaseWpOneDbTest):
     @patch("wp1.custom_tables.importlib")
     def test_upload_custom_table_by_name_no_entry(self, patched_importlib):
         with self.wp10db.cursor() as cursor:
-            cursor.execute(
-                """
+            cursor.execute("""
         INSERT INTO custom (c_name, c_module, c_params, c_is_active) VALUES
           ("foo", "wp1.custom_tables.foo", '{"wiki_path": "Wiki/Path"}', 1)
-      """
-            )
+      """)
         self.wp10db.commit()
 
         module = MagicMock()
@@ -73,12 +67,10 @@ class CustomTablesInitTest(BaseWpOneDbTest):
     @patch("wp1.custom_tables.importlib")
     def test_upload_custom_table_by_name_bad_json(self, patched_importlib):
         with self.wp10db.cursor() as cursor:
-            cursor.execute(
-                """
+            cursor.execute("""
         INSERT INTO custom (c_name, c_module, c_params, c_is_active) VALUES
           ("foo", "wp1.custom_tables.foo", '{foo123}', 1)
-      """
-            )
+      """)
         self.wp10db.commit()
 
         module = MagicMock()
@@ -97,12 +89,10 @@ class CustomTablesInitTest(BaseWpOneDbTest):
     @patch("wp1.custom_tables.importlib")
     def test_upload_custom_table_by_name_bad_module_path(self, patched_importlib):
         with self.wp10db.cursor() as cursor:
-            cursor.execute(
-                """
+            cursor.execute("""
         INSERT INTO custom (c_name, c_module, c_params, c_is_active) VALUES
           ("foo", "wp1.bar.foo", '{foo123}', 1)
-      """
-            )
+      """)
         self.wp10db.commit()
 
         module = MagicMock()

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -834,12 +834,10 @@ class BuilderTest(BaseWpOneDbTest):
     def test_latest_zim_file_url_for(self, mock_zimfarm_url_for):
         builder_id = self._insert_builder_with_multiple_version_selections()
         with self.wp10db.cursor() as cursor:
-            cursor.execute(
-                '''UPDATE zim_tasks z
+            cursor.execute('''UPDATE zim_tasks z
                           INNER JOIN selections s ON s.s_id = z.z_selection_id
                           INNER JOIN builders b ON b.b_selection_zim_version = s.s_version
-                        SET z_status = "FILE_READY"'''
-            )
+                        SET z_status = "FILE_READY"''')
 
         actual = logic_builder.latest_zim_file_url_for(self.wp10db, builder_id)
 
@@ -1506,13 +1504,11 @@ class BuilderTest(BaseWpOneDbTest):
         )
 
         with self.wp10db.cursor() as cursor:
-            cursor.execute(
-                """UPDATE zim_tasks z
+            cursor.execute("""UPDATE zim_tasks z
                         JOIN selections s
                           ON s.s_id = z.z_selection_id
                         SET z.z_status = "REQUESTED"
-                        WHERE s.s_id IN (2,3)"""
-            )
+                        WHERE s.s_id IN (2,3)""")
         logic_builder.auto_handle_zim_generation(redis, self.wp10db, builder_id)
 
         mock_cancel_zim.assert_has_calls(
@@ -1568,13 +1564,11 @@ class BuilderTest(BaseWpOneDbTest):
         )
 
         with self.wp10db.cursor() as cursor:
-            cursor.execute(
-                """UPDATE zim_tasks z
+            cursor.execute("""UPDATE zim_tasks z
                         JOIN selections s
                           ON s.s_id = z.z_selection_id
                         SET z.z_status = "REQUESTED"
-                        WHERE s.s_id IN (2,3)"""
-            )
+                        WHERE s.s_id IN (2,3)""")
 
         tasks = logic_builder.pending_zim_tasks_for(self.wp10db, builder_id)
         self.assertIsNotNone(tasks)

--- a/wp1/logic/page_test.py
+++ b/wp1/logic/page_test.py
@@ -238,18 +238,14 @@ class LogicPageMovesTest(BaseCombinedDbTest):
     def test_get_redirect_from_db_stale(self):
         # Insert a redirect row with a 2016 timestamp which is older than last run
         with self.wikidb.cursor() as cursor:
-            cursor.execute(
-                """
+            cursor.execute("""
                 INSERT INTO page (page_id, page_namespace, page_title, page_touched)
                 VALUES (200, 0, 'Some_Moved_Article', '20160315142300')
-            """
-            )
-            cursor.execute(
-                """
+            """)
+            cursor.execute("""
                 INSERT INTO redirect (rd_from, rd_namespace, rd_title)
                 VALUES (200, 0, 'Destination_Article')
-            """
-            )
+            """)
         self.wikidb.commit()
 
         # Last run was 2022, redirect is from 2016 so should be discarded
@@ -261,18 +257,14 @@ class LogicPageMovesTest(BaseCombinedDbTest):
     def test_get_redirect_from_db_fresh(self):
         # Insert a redirect row with a 2023 timestamp which newer than last run
         with self.wikidb.cursor() as cursor:
-            cursor.execute(
-                """
+            cursor.execute("""
                 INSERT INTO page (page_id, page_namespace, page_title, page_touched)
                 VALUES (201, 0, 'Some_Moved_Article', '20230315142300')
-            """
-            )
-            cursor.execute(
-                """
+            """)
+            cursor.execute("""
                 INSERT INTO redirect (rd_from, rd_namespace, rd_title)
                 VALUES (201, 0, 'Destination_Article')
-            """
-            )
+            """)
         self.wikidb.commit()
 
         # Last run was 2022, redirect is from 2023 so should return

--- a/wp1/logic/project.py
+++ b/wp1/logic/project.py
@@ -157,11 +157,9 @@ def project_names_to_update(wikidb):
 
 def list_all_projects(wp10db):
     with wp10db.cursor() as cursor:
-        cursor.execute(
-            """
+        cursor.execute("""
       SELECT p_project, p_timestamp, p_count, p_qcount, p_icount FROM projects
-      """
-        )
+      """)
         return [Project(**db_project) for db_project in cursor.fetchall()]
 
 

--- a/wp1/logic/rating.py
+++ b/wp1/logic/rating.py
@@ -19,9 +19,7 @@ logger = logging.getLogger(__name__)
 def get_project_ratings(wp10db, project_name):
     with wp10db.cursor() as cursor:
         cursor.execute(
-            "SELECT * FROM "
-            + Rating.table_name
-            + """
+            "SELECT * FROM " + Rating.table_name + """
       WHERE r_project = %(r_project)s
     """,
             {"r_project": project_name},
@@ -336,8 +334,7 @@ def insert_or_update(wp10db, rating, kind):
           (%(r_project)s, %(r_namespace)s, %(r_article)s, %(r_score)s,
            %(r_quality)s, %(r_quality_timestamp)s, %(r_importance)s,
            %(r_importance_timestamp)s)
-    """
-            + duplicate_clause,
+    """ + duplicate_clause,
             attr.asdict(rating),
         )
 

--- a/wp1/scores.py
+++ b/wp1/scores.py
@@ -164,15 +164,13 @@ def pageview_components():
 
 def reset_missing_articles_pageviews(wp10db):
     with wp10db.cursor() as cursor:
-        cursor.execute(
-            """
+        cursor.execute("""
       UPDATE page_scores
       LEFT JOIN temp_pageviews
       ON page_scores.ps_article = temp_pageviews.tp_article
       SET page_scores.ps_views = 0
       WHERE temp_pageviews.tp_article IS NULL;
-      """
-        )
+      """)
     wp10db.commit()
 
 

--- a/wp1/tables.py
+++ b/wp1/tables.py
@@ -96,8 +96,7 @@ def get_global_categories():
 def get_global_stats(wp10db):
     wp10db.ping()
     with wp10db.cursor() as cursor:
-        cursor.execute(
-            """
+        cursor.execute("""
         SELECT count(distinct a_article) AS n,
                grq.gr_rating AS q, gri.gr_rating AS i
         FROM global_articles
@@ -106,8 +105,7 @@ def get_global_stats(wp10db):
           JOIN global_rankings AS gri
             ON gri.gr_type = 'importance' AND gri.gr_ranking = a_importance
         GROUP BY grq.gr_rating, gri.gr_rating
-    """
-        )
+    """)
         return cursor.fetchall()
 
 

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -1284,11 +1284,9 @@ class BuildersTest(BaseWebTestcase):
                  VALUES (1, %s, 'text/tab-separated-values', '20201225105544', 1, 'object_key')""",
                 (builder_id,),
             )
-            cursor.execute(
-                """INSERT INTO zim_tasks
+            cursor.execute("""INSERT INTO zim_tasks
                    (z_id, z_selection_id, z_task_id, z_status, z_zim_schedule_id)
-                 VALUES (1, 1, 'task-id-non-zim', 'REQUESTED', 'schedule_456')"""
-            )
+                 VALUES (1, 1, 'task-id-non-zim', 'REQUESTED', 'schedule_456')""")
 
         self._insert_zim_schedule(
             schedule_id=b"schedule_456",

--- a/wp1/web/emails.py
+++ b/wp1/web/emails.py
@@ -8,7 +8,6 @@ from wp1.models.wp10.zim_file import ZimTask
 from wp1.models.wp10.zim_schedule import ZimSchedule
 from wp1.templates import env as jinja_env
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/wp1/web/emails_confirmation.py
+++ b/wp1/web/emails_confirmation.py
@@ -4,7 +4,6 @@ import logging
 from wp1.credentials import CREDENTIALS, ENV
 from wp1.templates import env as jinja_env
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/wp1/web/selection_test.py
+++ b/wp1/web/selection_test.py
@@ -222,12 +222,10 @@ class SelectionTest(BaseWebTestcase):
         self.app = create_app()
         with self.override_db(self.app), self.app.test_client() as client:
             with self.wp10db.cursor() as cursor:
-                cursor.execute(
-                    """INSERT INTO builders
+                cursor.execute("""INSERT INTO builders
         (b_id, b_name, b_user_id, b_project, b_model, b_created_at, b_updated_at, b_current_version)
         VALUES ('1a-2b-3c-4d', 'name', '1234', 'project_name', 'model', '20201225105544', '20201225105544', 1)
-      """
-                )
+      """)
             self.wp10db.commit()
             with client.session_transaction() as sess:
                 sess["user"] = self.USER
@@ -241,14 +239,12 @@ class SelectionTest(BaseWebTestcase):
         self.app = create_app()
         with self.override_db(self.app), self.app.test_client() as client:
             with self.wp10db.cursor() as cursor:
-                cursor.execute(
-                    """
+                cursor.execute("""
           INSERT INTO selections
             (s_id, s_builder_id, s_content_type, s_updated_at, s_version, s_object_key)
           VALUES
             (2, \'1a-2b-3c-4d\', "application/vnd.ms-excel", '20201225105544', 1, "object_key")
-        """
-                )
+        """)
             self.wp10db.commit()
             with client.session_transaction() as sess:
                 sess["user"] = self.USER


### PR DESCRIPTION
CI was installing `black~=25.12` while the Pipfile pins `~=26.3` (locked at 26.5.1), so running Black locally via pipenv and the CI format check disagreed — 13 files in the repo were formatted per 25.12 and failed a 26.5.1 check.

This PR:

- Makes the CI `black-format-check` job install the **exact version from `Pipfile.lock`** (extracted with `jq`), so CI and local formatting can never drift again.
- Bumps the pre-commit Black hook from `25.12.0` to `26.5.1` to match.
- Reformats the 13 affected files with Black 26.5.1 (mechanical 2026-stable-style changes, no functional changes — full test suite passes: 773 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)