### PR TITLE
Speed up Python unit tests ~22x by resetting DB data instead of recreating schema

### DIFF
--- a/wp1/base_db_test.py
+++ b/wp1/base_db_test.py
@@ -14,7 +14,20 @@ from wp1.redis_db import connect as redis_connect
 logger = logging.getLogger(__name__)
 
 
+_sql_cache = {}
+
+# Schemas (up.sql filenames) that have already been created in this process.
+_schemas_ready = set()
+
+# filename -> {table: AUTO_INCREMENT value expected right after a reset}.
+# Used to skip the (slow) ALTER TABLE for tests that never touched the table.
+_auto_increment_baselines = {}
+
+
 def parse_sql(filename):
+    if filename in _sql_cache:
+        return _sql_cache[filename]
+
     data = open(filename, "r").readlines()
     stmts = []
     DELIMITER = ";"
@@ -40,7 +53,93 @@ def parse_sql(filename):
             stmt = ""
         else:
             stmts.append(line.strip())
+    _sql_cache[filename] = stmts
     return stmts
+
+
+def _table_names(down_filename):
+    return [stmt.split("`")[1] for stmt in parse_sql(down_filename)]
+
+
+def _seed_stmts(up_filename):
+    return [
+        stmt
+        for stmt in parse_sql(up_filename)
+        if not stmt.upper().startswith("CREATE TABLE")
+    ]
+
+
+def _auto_increment_tables(up_filename):
+    tables = []
+    for stmt in parse_sql(up_filename):
+        if stmt.upper().startswith("CREATE TABLE") and "AUTO_INCREMENT" in stmt.upper():
+            tables.append(stmt.split("`")[1] if "`" in stmt else stmt.split()[2])
+    return tables
+
+
+def _read_auto_increments(cursor, tables):
+    if not tables:
+        return {}
+    placeholders = ", ".join(["%s"] * len(tables))
+    cursor.execute(
+        "SELECT TABLE_NAME, AUTO_INCREMENT FROM information_schema.TABLES "
+        "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN (%s)" % placeholders,
+        tables,
+    )
+    return {
+        row["TABLE_NAME"].decode("utf-8"): row["AUTO_INCREMENT"]
+        for row in cursor.fetchall()
+    }
+
+
+def _ensure_schema(conn, up_filename):
+    """Creates the test schema, once per process.
+
+    Tables are created only if they don't exist and are never dropped between
+    tests; instead each test starts by resetting the table *data* (see
+    _reset_tables), which is orders of magnitude faster than DDL.
+    """
+    if up_filename in _schemas_ready:
+        return
+    with conn.cursor() as cursor:
+        for stmt in parse_sql(up_filename):
+            if stmt.upper().startswith("CREATE TABLE"):
+                cursor.execute(
+                    "CREATE TABLE IF NOT EXISTS" + stmt[len("CREATE TABLE") :]
+                )
+    conn.commit()
+    _schemas_ready.add(up_filename)
+
+
+def _reset_tables(conn, up_filename, down_filename):
+    """Restores every table to its pristine post-up.sql state.
+
+    Deletes all rows, resets AUTO_INCREMENT counters that have moved, and
+    re-runs the seed INSERTs from the up.sql file.
+    """
+    auto_inc_tables = _auto_increment_tables(up_filename)
+    baseline = _auto_increment_baselines.get(up_filename)
+    with conn.cursor() as cursor:
+        if auto_inc_tables:
+            counters = _read_auto_increments(cursor, auto_inc_tables)
+
+        for table in _table_names(down_filename):
+            cursor.execute("DELETE FROM `%s`" % table)
+
+        for table in auto_inc_tables:
+            # ALTER is comparatively slow, skip it unless an insert into this
+            # table (by a previous test) actually moved the counter.
+            if baseline is None or counters[table] != baseline[table]:
+                cursor.execute("ALTER TABLE `%s` AUTO_INCREMENT = 1" % table)
+
+        for stmt in _seed_stmts(up_filename):
+            cursor.execute(stmt)
+
+        if auto_inc_tables and baseline is None:
+            _auto_increment_baselines[up_filename] = _read_auto_increments(
+                cursor, auto_inc_tables
+            )
+    conn.commit()
 
 
 class WpOneAssertions(unittest.TestCase):
@@ -76,20 +175,15 @@ class BaseWpOneDbTest(WpOneAssertions):
         )
 
     def _cleanup_wp_one_db(self):
-        stmts = parse_sql("wp10_test.down.sql")
-        with self.wp10db.cursor() as cursor:
-            for stmt in stmts:
-                cursor.execute(stmt)
-        self.wp10db.commit()
+        # Tables are intentionally left in place (with whatever data the test
+        # produced); the next test's setup resets them. This avoids paying for
+        # DROP/CREATE of the whole schema on every test.
         self.wp10db.close()
 
     def _setup_wp_one_db(self):
         self.wp10db = self.connect_wp_one_db()
-        stmts = parse_sql("wp10_test.up.sql")
-        with self.wp10db.cursor() as cursor:
-            for stmt in stmts:
-                cursor.execute(stmt)
-        self.wp10db.commit()
+        _ensure_schema(self.wp10db, "wp10_test.up.sql")
+        _reset_tables(self.wp10db, "wp10_test.up.sql", "wp10_test.down.sql")
 
     def connect_redis_db(self):
         if ENV != Environment.TEST:
@@ -133,20 +227,13 @@ class BaseWikiDbTest(WpOneAssertions):
         )
 
     def _cleanup_wiki_db(self):
-        stmts = parse_sql("wiki_test.down.sql")
-        with self.wikidb.cursor() as cursor:
-            for stmt in stmts:
-                cursor.execute(stmt)
-        self.wikidb.commit()
+        # See BaseWpOneDbTest._cleanup_wp_one_db: tables persist across tests.
         self.wikidb.close()
 
     def _setup_wiki_db(self):
         self.wikidb = self.connect_wiki_db()
-        stmts = parse_sql("wiki_test.up.sql")
-        with self.wikidb.cursor() as cursor:
-            for stmt in stmts:
-                cursor.execute(stmt)
-        self.wikidb.commit()
+        _ensure_schema(self.wikidb, "wiki_test.up.sql")
+        _reset_tables(self.wikidb, "wiki_test.up.sql", "wiki_test.down.sql")
 
     def setUp(self):
         self.addCleanup(self._cleanup_wiki_db)


### PR DESCRIPTION
The Python test suite spent nearly all of its time on MySQL DDL: every test case ran `up.sql` (21 `CREATE TABLE`s across the wp10 and wiki schemas) in `setUp` and `down.sql` (21 `DROP TABLE`s) in cleanup. Benchmarks against the test container:

- One CREATE+DROP cycle of the 16 wp10 tables: **784 ms**
- `DELETE FROM` those same 16 tables: **2 ms**
- A no-op DB test (setup/teardown only): **~1.03 s**

This PR creates the schema **once per process** (`CREATE TABLE IF NOT EXISTS`) and has each test reset the *data* instead:

1. `DELETE FROM` every table (table list parsed from `down.sql`)
2. Reset `AUTO_INCREMENT` counters — but only when a previous test actually moved them (checked via `information_schema`, ~1 ms), since `ALTER TABLE` costs ~20 ms. This keeps tests that assert generated IDs (e.g. `z_id=1`) deterministic.
3. Re-run the seed `INSERT`s from `up.sql`

Results (775-test suite, local):

| | before | after |
|---|---|---|
| no-op DB test | ~1.03 s | ~0.14 s |
| full suite | ~8 min | **~21 s** |

Notes:

- Dirty state from interrupted runs is no longer an issue: setup deletes rows rather than assuming tables don't exist.
- `run_tests.sh`'s pre-clean still drops tables outright, which also covers schema changes when switching branches. CI always starts from a fresh database service.
- No test files change — only `base_db_test.py`. Verified by running the full suite twice in a row (second run starts from leftover tables/data): 773 passed both times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)