### PR TITLE
Speed up the frontend-cypress CI job (6m07s → 4m09s)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,33 +140,13 @@ jobs:
           cp wp1/credentials.py.e2e wp1/credentials.py
           cp wp1/credentials.py.dev.e2e wp1/credentials.py.dev
 
-      - uses: docker/setup-buildx-action@v4
-
-      - name: Build Docker images (with layer cache)
-        uses: docker/bake-action@v7
-        with:
-          source: .
-          files: docker-compose-dev.yml
-          targets: |
-            dev-database
-            dev-workers
-            dev-web
-          load: true
-          set: |
-            dev-database.cache-from=type=gha,scope=dev-database
-            dev-database.cache-to=type=gha,scope=dev-database,mode=max
-            dev-workers.cache-from=type=gha,scope=dev-workers
-            dev-workers.cache-to=type=gha,scope=dev-workers,mode=max
-            dev-web.cache-from=type=gha,scope=dev-web
-            dev-web.cache-to=type=gha,scope=dev-web,mode=max
-
       # This is the dev database, the dev redis, the dev workers, the dev
       # minio and the dev web server (Flask, port 5000). The dev-frontend
       # container is deliberately not started: the tests run against the
       # built frontend bundle, served below on port 5173.
       - name: Start Docker dev services
         run: |
-          docker compose -f docker-compose-dev.yml up -d --no-build \
+          docker compose -f docker-compose-dev.yml up -d --build \
             redis dev-database minio createbuckets dev-workers dev-web
 
       - name: Build frontend server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,26 +119,6 @@ jobs:
         with:
           lfs: true
 
-      - name: Set up Python 3.14.4
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.14.4'
-
-      - uses: actions/cache@v4
-        name: Cache pip dependencies
-        id: pip-cache
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/Pipfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install Python dependencies
-        run: |
-          pip install --upgrade pip
-          pip install pipenv
-          pipenv install --system --deploy --dev
-
       - name: Get yarn cache directory path
         id: yarn-dep-cache-dir-path
         run: cd wp1-frontend && echo "YARN_CACHE_DIR=$(yarn cache dir)" >> $GITHUB_OUTPUT
@@ -160,14 +140,34 @@ jobs:
           cp wp1/credentials.py.e2e wp1/credentials.py
           cp wp1/credentials.py.dev.e2e wp1/credentials.py.dev
 
-      # This is the dev database, the dev redis, and the dev workers, as
-      # well as the dev minio and the dev web server (Flask, port 5000).
-      - name: Start Docker dev services
-        run: docker compose -f docker-compose-dev.yml up -d --build
+      - uses: docker/setup-buildx-action@v4
 
-      - name: Wait for Docker dev services to be up (30s)
-        run: sleep 30s
-        shell: bash
+      - name: Build Docker images (with layer cache)
+        uses: docker/bake-action@v7
+        with:
+          source: .
+          files: docker-compose-dev.yml
+          targets: |
+            dev-database
+            dev-workers
+            dev-web
+          load: true
+          set: |
+            dev-database.cache-from=type=gha,scope=dev-database
+            dev-database.cache-to=type=gha,scope=dev-database,mode=max
+            dev-workers.cache-from=type=gha,scope=dev-workers
+            dev-workers.cache-to=type=gha,scope=dev-workers,mode=max
+            dev-web.cache-from=type=gha,scope=dev-web
+            dev-web.cache-to=type=gha,scope=dev-web,mode=max
+
+      # This is the dev database, the dev redis, the dev workers, the dev
+      # minio and the dev web server (Flask, port 5000). The dev-frontend
+      # container is deliberately not started: the tests run against the
+      # built frontend bundle, served below on port 5173.
+      - name: Start Docker dev services
+        run: |
+          docker compose -f docker-compose-dev.yml up -d --no-build \
+            redis dev-database minio createbuckets dev-workers dev-web
 
       - name: Build frontend server
         run: |
@@ -177,21 +177,19 @@ jobs:
       - name: Start frontend server
         run: |
           cd wp1-frontend
-          pipenv run python -m http.server 5173 --directory dist/ &
+          python3 -m http.server 5173 --directory dist/ &
 
-      - name: Wait for API and frontend server to be up (10s)
-        run: sleep 10s
-        shell: bash
+      - name: Wait for API and frontend server to be up
+        run: |
+          timeout 120 bash -c \
+            'until curl -sf http://localhost:5000/v1/projects/count > /dev/null; do sleep 2; done'
+          timeout 30 bash -c \
+            'until curl -sf http://localhost:5173/ > /dev/null; do sleep 1; done'
 
       - name: Run frontend tests
         run: |
           cd wp1-frontend
           $(yarn bin)/cypress run
-
-      - name: Stop containers
-        continue-on-error: true
-        if: always()
-        run: docker compose -f "docker-compose-dev.yml" down
 
       - uses: actions/upload-artifact@v4
         continue-on-error: true

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -10,13 +10,13 @@ services:
     restart: always
     healthcheck:
       test: ['CMD', 'redis-cli', 'ping']
-      start_period: 1m30s
-      interval: 1m
+      interval: 5s
       timeout: 15s
-      retries: 10
+      retries: 30
 
   dev-database:
     build: docker/dev-db/
+    image: wp1bot-db-dev
     container_name: wp1bot-db-dev
     ports:
       - 6300:3306
@@ -41,10 +41,9 @@ services:
     restart: always
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:9000/minio/health/live']
-      start_period: 30s
-      interval: 30s
+      interval: 5s
       timeout: 10s
-      retries: 5
+      retries: 30
 
   createbuckets:
     image: minio/mc
@@ -62,6 +61,7 @@ services:
     build:
       context: .
       dockerfile: docker/dev-workers/Dockerfile
+    image: wp1bot-workers-dev
     container_name: wp1bot-workers-dev
     volumes:
       - ./wp1:/usr/src/app/wp1/
@@ -82,6 +82,7 @@ services:
     build:
       context: .
       dockerfile: docker/web/Dockerfile
+    image: wp1bot-web-dev
     container_name: wp1bot-web-dev
     environment:
       - FLASK_DEBUG=1
@@ -105,6 +106,7 @@ services:
     build:
       context: .
       dockerfile: docker/dev-frontend/Dockerfile
+    image: wp1bot-frontend-dev
     container_name: wp1bot-frontend-dev
     environment:
       - VITE_API_URL=http://localhost:5000/v1


### PR DESCRIPTION
The Cypress tests themselves are healthy (167 tests in ~2 min, proper network-alias waits) — but a third of the ~6-minute `frontend-cypress` job was harness overhead, some of it literally dead code. Measured result on this PR's CI run: **6m07s → 4m09s**.

**Dead code discovered:** the "Start frontend server" step has been crashing on every CI run with "address already in use" (visible in the step logs as a `server_bind` traceback) because the `dev-frontend` docker container already holds port 5173. Tests have therefore been running against the Vite dev server in docker, while the staging build — and the 41s pipenv install that existed only to serve it with stdlib `http.server` — were dead weight.

Changes:

- **Don't start `dev-frontend` in CI** — tests now run against the actual built staging bundle, served by `python3 -m http.server` (no pipenv needed; the Python setup, pip cache and pipenv install steps are removed). This also makes the test more honest: it exercises the production build pipeline instead of the dev server.
- **Tighten redis/minio healthcheck intervals** (1m/30s → 5s): with `interval: 1m`, `dev-web`/`dev-workers` waited up to a full minute for redis's *first* health probe before starting — that wait was most of the old 89s "Start Docker dev services" step, not build time. This speeds up local `docker compose up` too.
- **Replace 40s of fixed sleeps** with polling: `/v1/projects/count` (exercises Flask *and* the MariaDB dump load) and the frontend port.
- **Drop the teardown step** — the runner is ephemeral.
- Compose build-services get explicit `image:` tags (cosmetic/stable naming; no behavior change).

**What was tried and rejected:** docker buildx bake with a GHA layer cache (`type=gha`). Measured on this PR: 107s cold, 83s warm — *slower* than the plain `docker compose up -d --build` (75s), because the time is dominated by cache transfer and tarball-loading the ~2.2GB images into docker, not by building (the `pipenv install` layer builds in ~10s). The commit history documents the measurements.

Remaining time is the Cypress run itself (~2.5 min including browser startup) and the ~75s image build+start. Next levers, if ever needed: sharding specs across a 2-way matrix (halves wall time, doubles runner minutes) or slimming the worker/web images.

**Verification:** replicated the new CI flow end-to-end locally — compose service subset (no dev-frontend), readiness polls, staging build on 5173, full `cypress run`: **166/167 passed**. The one failure (`zimFile.cy.js` "shows the next generation date") is a pre-existing timezone-dependent test: the fixture's `"next_generation_date": "2026-06-01"` is parsed as UTC midnight and renders as "May 31" in non-UTC timezones; it passes with `TZ=UTC`, which is what CI uses (and what this PR's green run confirms). Happy to fix that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)