### PR TITLE
Update img tag src attributes for class icons

### DIFF
--- a/wp1-frontend/src/components/ProjectTable.vue
+++ b/wp1-frontend/src/components/ProjectTable.vue
@@ -45,35 +45,87 @@
         <th :class="getClass(tableData.row_labels[row])">
           <span v-if="tableData.row_labels[row].text == 'FA'">
             <img
-              alt="Featured list"
-              src="//upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Featured_article_star.svg/16px-Featured_article_star.svg.png"
-              decoding="async"
-              width="16"
-              height="16"
-              srcset="
-                //upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Featured_article_star.svg/24px-Featured_article_star.svg.png 1.5x,
-                //upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Featured_article_star.svg/32px-Featured_article_star.svg.png 2x
-              "
-              data-file-width="180"
+              alt="Star icon"
               data-file-height="180"
+              data-file-width="180"
+              decoding="async"
+              height="16"
+              src="//upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Featured_article_star.svg/20px-Featured_article_star.svg.png"
+              srcset="
+                //upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Featured_article_star.svg/40px-Featured_article_star.svg.png 2.5x,
+                //upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Featured_article_star.svg/60px-Featured_article_star.svg.png 3.75x
+              "
               style="position: relative; top: -2px"
+              title="Featured article"
+              width="16"
+            />
+          </span>
+          <span v-if="tableData.row_labels[row].text == 'FL'">
+            <img
+              alt="Star icon"
+              data-file-height="180"
+              data-file-width="180"
+              decoding="async"
+              height="16"
+              src="//upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Featured_article_star.svg/20px-Featured_article_star.svg.png"
+              srcset="
+                //upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Featured_article_star.svg/40px-Featured_article_star.svg.png 2.5x,
+                //upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Featured_article_star.svg/60px-Featured_article_star.svg.png 3.75x
+              "
+              style="position: relative; top: -2px"
+              title="Featured list"
+              width="16"
+            />
+          </span>
+          <span v-if="tableData.row_labels[row].text == 'FM'">
+            <img
+              alt="Star icon"
+              data-file-height="180"
+              data-file-width="180"
+              decoding="async"
+              height="16"
+              src="//upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Featured_article_star.svg/20px-Featured_article_star.svg.png"
+              srcset="
+                //upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Featured_article_star.svg/40px-Featured_article_star.svg.png 2.5x,
+                //upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Featured_article_star.svg/60px-Featured_article_star.svg.png 3.75x
+              "
+              style="position: relative; top: -2px"
+              title="Featured media"
+              width="16"
             />
           </span>
           <span v-if="tableData.row_labels[row].text == 'GA'">
             <img
-              alt=""
-              src="//upload.wikimedia.org/wikipedia/en/thumb/9/94/Symbol_support_vote.svg/16px-Symbol_support_vote.svg.png"
+              alt="Green plus icon on white circle with green border"
+              data-file-height="185"
+              data-file-width="180"
               decoding="async"
+              height="16"
+              src="//upload.wikimedia.org/wikipedia/commons/thumb/9/94/Symbol_support_vote.svg/20px-Symbol_support_vote.svg.png"
+              srcset="
+                //upload.wikimedia.org/wikipedia/commons/thumb/9/94/Symbol_support_vote.svg/40px-Symbol_support_vote.svg.png 2.5x,
+                //upload.wikimedia.org/wikipedia/commons/thumb/9/94/Symbol_support_vote.svg/60px-Symbol_support_vote.svg.png 3.75x
+              "
+              style="position: relative; top: -2px"
               title="Good article"
               width="16"
-              height="16"
-              srcset="
-                //upload.wikimedia.org/wikipedia/en/thumb/9/94/Symbol_support_vote.svg/24px-Symbol_support_vote.svg.png 1.5x,
-                //upload.wikimedia.org/wikipedia/en/thumb/9/94/Symbol_support_vote.svg/32px-Symbol_support_vote.svg.png 2x
-              "
-              data-file-width="180"
+            />
+          </span>
+          <span v-if="tableData.row_labels[row].text == 'A'">
+            <img
+              alt="Light blue capital letter A over pale yellow star icon in white circle with light blue border"
               data-file-height="185"
+              data-file-width="180"
+              decoding="async"
+              height="16"
+              src="//upload.wikimedia.org/wikipedia/commons/thumb/2/25/Symbol_a_class.svg/20px-Symbol_a_class.svg.png"
+              srcset="
+                //upload.wikimedia.org/wikipedia/commons/thumb/2/25/Symbol_a_class.svg/40px-Symbol_a_class.svg.png 2.5x,
+                //upload.wikimedia.org/wikipedia/commons/thumb/2/25/Symbol_a_class.svg/60px-Symbol_a_class.svg.png 3.75x
+              "
               style="position: relative; top: -2px"
+              title="A-Class"
+              width="16"
             />
           </span>
           <WikiLink
@@ -201,8 +253,8 @@ export default {
 }
 
 table {
-  border-collapse: collapse;
   border: 1px solid #aaa;
+  border-collapse: collapse;
   margin: auto;
   text-align: right;
 }
@@ -234,9 +286,9 @@ td {
 }
 
 .timestamp {
-  text-align: center;
-  margin: 1rem 0;
   color: #666;
   font-size: 0.9rem;
+  margin: 1rem 0;
+  text-align: center;
 }
 </style>


### PR DESCRIPTION
Following the adoption and now complete implementation of the RfC entitled ["Standardized thumbnails sizes"][0], images hosted on Wikimedia project sites are only served in a set of standard sizes referenced in [`$wgThumbnailSteps`](https://www.mediawiki.org/wiki/Special:MyLanguage/Manual:$wgThumbnailSteps). This changeset updates the target URL values in the `<img>` tag `src` and `srcset` attributes to conform to those new sizes, corrects the `alt` attribute for the Featured article icon (from "Featured list" to "Featured article") and adds the absent `alt` and `title` attributes to the GA and FA icon `<img>` tags, respectively.

This should resolve the presentation issues in tables presented on the [Wikipedia 1.0 Server](https://wp1.openzim.org/) that are currently occurring, where the FA icon's alt text incorrectly identifying it as "Featured list" is shown and the GA icon is absent altogether (it currently lacks any alt text) due to the 429 errors, as seen in the screenshot of the [table for WikiProject California's San Francisco Bay Area task force](https://wp1.openzim.org/#/project/San%20Francisco%20Bay%20Area) below.

<details>
<summary>Screenshot</summary>
<img width="527" height="699" alt="20260613_0819-wp1 openzim org-403" src="https://github.com/user-attachments/assets/76ed39fa-8945-4c22-83d9-dc36e06a09de" />
</details>

Also added are `<img>` tags for the Featured list, Featured media and A-Class quality assessment categories, matching the style of the on-wiki tables, while I happened to be in the neighborhood. 😉

[0]: https://w.wiki/GHai
