### PR TITLE
Add table for all assessed/unassessed counts by project

### DIFF
--- a/schedule-cache-warming.py
+++ b/schedule-cache-warming.py
@@ -1,0 +1,18 @@
+import logging
+
+from wp1 import app_logging, queues
+from wp1.redis_db import connect as redis_connect
+
+logger = logging.getLogger(__name__)
+
+
+def main():
+    app_logging.configure_logging()
+
+    redis = redis_connect()
+    queues.schedule_assessment_cache_warming(redis)
+    logger.info("Registered recurring assessment-cache warming schedule")
+
+
+if __name__ == "__main__":
+    main()

--- a/supervisord-dev.conf
+++ b/supervisord-dev.conf
@@ -113,3 +113,42 @@ stdout_logfile_backups=5
 stopsignal=TERM
 autostart=true
 autorestart=true
+
+; One-shot: idempotently (re)register the recurring assessment-cache warming
+; schedule on container boot. Exits immediately; the [scheduler] program above
+; enqueues the job onto the 'assessment-cache' queue when it comes due.
+[program:assessment-cache-schedule]
+command=/usr/local/bin/python schedule-cache-warming.py
+directory=/usr/src/app
+autostart=true
+; Not a long-running process: don't restart on a clean (0) exit, but do retry
+; if it fails (e.g. a transient Redis hiccup at startup).
+autorestart=unexpected
+startsecs=0
+exitcodes=0
+startretries=3
+redirect_stderr=true
+stdout_logfile=/var/log/wp1bot/%(program_name)s.log
+stdout_logfile_maxbytes=100MB
+stdout_logfile_backups=5
+
+[program:wp1-assessment-cache]
+; In the docker-compose world, the redis host is just 'redis'
+command=/usr/local/bin/rq worker -u redis://redis assessment-cache
+process_name=assessment-cache-%(process_num)s
+numprocs=1
+
+; This is the directory from which RQ is run. Be sure to point this to the
+; directory where your source code is importable from
+directory=/usr/src/app
+
+redirect_stderr=true
+stdout_logfile=/var/log/wp1bot/%(program_name)s-%(process_num)s.log
+stdout_logfile_maxbytes=100MB
+stdout_logfile_backups=5
+
+; RQ requires the TERM signal to perform a warm shutdown. If RQ does not die
+; within 10 seconds, supervisor will forcefully kill it
+stopsignal=TERM
+autostart=true
+autorestart=true

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -243,3 +243,42 @@ stdout_logfile_backups=5
 stopsignal=TERM
 autostart=true
 autorestart=true
+
+; One-shot: idempotently (re)register the recurring assessment-cache warming
+; schedule on container boot. Exits immediately; the [scheduler] program above
+; enqueues the job onto the 'assessment-cache' queue when it comes due.
+[program:assessment-cache-schedule]
+command=/usr/local/bin/python schedule-cache-warming.py
+directory=/usr/src/app
+autostart=true
+; Not a long-running process: don't restart on a clean (0) exit, but do retry
+; if it fails (e.g. a transient Redis hiccup at startup).
+autorestart=unexpected
+startsecs=0
+exitcodes=0
+startretries=3
+redirect_stderr=true
+stdout_logfile=/var/log/wp1bot/%(program_name)s.log
+stdout_logfile_maxbytes=100MB
+stdout_logfile_backups=5
+
+[program:wp1-assessment-cache]
+; In the docker-compose world, the redis host is just 'redis'
+command=/usr/local/bin/rq worker -u redis://redis assessment-cache
+process_name=assessment-cache-%(process_num)s
+numprocs=1
+
+; This is the directory from which RQ is run. Be sure to point this to the
+; directory where your source code is importable from
+directory=/usr/src/app
+
+redirect_stderr=true
+stdout_logfile=/var/log/wp1bot/%(program_name)s-%(process_num)s.log
+stdout_logfile_maxbytes=100MB
+stdout_logfile_backups=5
+
+; RQ requires the TERM signal to perform a warm shutdown. If RQ does not die
+; within 10 seconds, supervisor will forcefully kill it
+stopsignal=TERM
+autostart=true
+autorestart=true

--- a/wp1-frontend/cypress/e2e/assessmentsByProject.cy.js
+++ b/wp1-frontend/cypress/e2e/assessmentsByProject.cy.js
@@ -1,0 +1,59 @@
+/// <reference types="Cypress" />
+
+describe('the assessments by project page', () => {
+  beforeEach(() => {
+    cy.intercept('v1/projects/assessments', { fixture: 'assessments.json' });
+  });
+
+  it('is reachable from the nav bar', () => {
+    cy.visit('/');
+    cy.get('.navbar').contains('a', 'Assessments by Project').click();
+    cy.url().should('include', '/assessments');
+  });
+
+  it('lists the assessment numbers in a DataTable', () => {
+    cy.visit('/#/assessments');
+
+    // The table is enhanced by jQuery DataTables.
+    cy.get('.dataTables_wrapper').should('exist');
+    cy.get('.dataTables_filter input').should('exist');
+
+    cy.get('table').find('thead th').eq(0).should('contain.text', 'Project');
+    cy.get('table').find('thead th').eq(1).should('contain.text', 'Unassessed');
+    cy.get('table').find('thead th').eq(2).should('contain.text', 'Assessed');
+
+    // Rows default-sort by unassessed descending, matching the API order.
+    cy.get('table tbody tr').should('have.length', 3);
+
+    cy.get('table tbody tr')
+      .eq(0)
+      .within(() => {
+        cy.get('td').eq(0).should('contain.text', 'Primate');
+        cy.get('td').eq(1).should('contain.text', '349');
+        cy.get('td').eq(2).should('contain.text', '1,594');
+      });
+
+    // Underscores in project names are displayed as spaces.
+    cy.get('table tbody tr')
+      .eq(1)
+      .find('td')
+      .eq(0)
+      .should('contain.text', 'WikiProject East Timor');
+  });
+
+  it('filters rows via the DataTable search box', () => {
+    cy.visit('/#/assessments');
+
+    cy.get('.dataTables_filter input').type('Water');
+
+    cy.get('table tbody tr').should('have.length', 1);
+    cy.get('table tbody tr').eq(0).should('contain.text', 'Water');
+  });
+
+  it('links each project to its project page', () => {
+    cy.visit('/#/assessments');
+
+    cy.get('table tbody tr').contains('a', 'Water').click();
+    cy.url().should('include', '/project/Water');
+  });
+});

--- a/wp1-frontend/cypress/fixtures/assessments.json
+++ b/wp1-frontend/cypress/fixtures/assessments.json
@@ -1,0 +1,5 @@
+[
+  ["Primate", 349, 1594],
+  ["WikiProject_East_Timor", 178, 1441],
+  ["Water", 116, 808]
+]

--- a/wp1-frontend/src/App.vue
+++ b/wp1-frontend/src/App.vue
@@ -31,6 +31,7 @@
               'nav-item ' +
               (!this.$route.path.startsWith('/update') &&
               !this.$route.path.startsWith('/compare') &&
+              !this.$route.path.startsWith('/assessments') &&
               !this.$route.path.startsWith('/selections')
                 ? 'active'
                 : '')
@@ -68,6 +69,16 @@
               >Compare Projects</router-link
             >
           </li>
+          <li
+            :class="
+              'nav-item ' +
+              (this.$route.path.startsWith('/assessments') ? 'active' : '')
+            "
+          >
+            <router-link class="nav-link" to="/assessments"
+              >Assessments by Project</router-link
+            >
+          </li>
         </ul>
         <div>
           <div v-if="this.username">
@@ -88,7 +99,11 @@
     <footer class="footer bg-light border-top">
       <div class="container-fluid py-3">
         <div class="text-right">
-          <a href="https://kiwix.org/privacy-policy/" target="_blank" rel="noopener noreferrer">
+          <a
+            href="https://kiwix.org/privacy-policy/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Privacy Policy
           </a>
         </div>
@@ -123,7 +138,7 @@ export default {
         `${import.meta.env.VITE_API_URL}/oauth/identify`,
         {
           credentials: 'include',
-        },
+        }
       )
         .then((response) => {
           if (response.ok) {
@@ -155,8 +170,8 @@ export default {
 </script>
 
 <style>
-
-html, body {
+html,
+body {
   height: 100%;
 }
 

--- a/wp1-frontend/src/components/AssessmentsByProject.vue
+++ b/wp1-frontend/src/components/AssessmentsByProject.vue
@@ -1,0 +1,99 @@
+<template>
+  <div class="container">
+    <div class="row p-4">
+      <div class="col-lg-10">
+        <p>
+          The number of assessed and unassessed articles in each WikiProject,
+          ordered by the number of unassessed articles.
+        </p>
+        <pulse-loader
+          class="loader"
+          :loading="loading"
+          :color="loaderColor"
+          :size="loaderSize"
+        ></pulse-loader>
+        <table v-if="!loading" id="assessments-table">
+          <thead>
+            <tr>
+              <th>Project</th>
+              <th>Unassessed</th>
+              <th>Assessed</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in assessments" :key="row[0]">
+              <td>
+                <router-link :to="`/project/${displayName(row[0])}`">{{
+                  displayName(row[0])
+                }}</router-link>
+              </td>
+              <td class="num" :data-order="row[1]">
+                {{ row[1].toLocaleString() }}
+              </td>
+              <td class="num" :data-order="row[2]">
+                {{ row[2].toLocaleString() }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import $ from 'jquery';
+$.noConflict();
+
+import PulseLoader from 'vue-spinner/src/PulseLoader.vue';
+
+export default {
+  name: 'assessments-by-project',
+  components: {
+    PulseLoader,
+  },
+  data: function () {
+    return {
+      assessments: [],
+      loading: false,
+      loaderColor: '#007bff',
+      loaderSize: '1rem',
+    };
+  },
+  methods: {
+    displayName: function (name) {
+      return name.replace(/_/g, ' ');
+    },
+  },
+  created: async function () {
+    this.loading = true;
+    try {
+      const response = await fetch(
+        `${import.meta.env.VITE_API_URL}/projects/assessments`
+      );
+      this.assessments = await response.json();
+    } catch (err) {
+      console.error(err);
+    }
+    this.loading = false;
+    this.$nextTick(function () {
+      $('#assessments-table').DataTable({
+        // Default sort matches the API: most unassessed articles first.
+        order: [[1, 'desc']],
+        iDisplayLength: 25,
+      });
+    });
+  },
+};
+</script>
+
+<style scoped>
+.loader {
+  margin: auto;
+  text-align: center;
+}
+
+.num {
+  text-align: right;
+}
+</style>

--- a/wp1-frontend/src/main.js
+++ b/wp1-frontend/src/main.js
@@ -17,6 +17,7 @@ import PetscanBuilder from './components/PetscanBuilder.vue';
 import SimpleBuilder from './components/SimpleBuilder.vue';
 import SparqlBuilder from './components/SparqlBuilder.vue';
 import ComparePage from './components/ComparePage.vue';
+import AssessmentsByProject from './components/AssessmentsByProject.vue';
 import IndexPage from './components/IndexPage.vue';
 import MyLists from './components/MyLists.vue';
 import ProjectPage from './components/ProjectPage.vue';
@@ -91,6 +92,13 @@ const routes = [
         route.params.projectNameA +
         ' and ' +
         route.params.projectNameB,
+    },
+  },
+  {
+    path: '/assessments/',
+    component: AssessmentsByProject,
+    meta: {
+      title: () => BASE_TITLE + ' - Assessments by Project',
     },
   },
   {

--- a/wp1/logic/rating.py
+++ b/wp1/logic/rating.py
@@ -69,6 +69,32 @@ def get_all_assessment_numbers(wp10db, redis: Redis = None):
     return results
 
 
+def update_assessment_cache():
+    """Recompute the assessment numbers and refresh the cache.
+
+    This is the entry point for the recurring cache-warming job (registered by
+    wp1.queues.schedule_assessment_cache_warming). It runs in its own RQ worker,
+    so it opens its own database and Redis connections. The underlying query is
+    slow (minutes in production), which is exactly why it runs here on a
+    schedule rather than in a web request.
+
+    It passes no Redis handle to get_all_assessment_numbers so that the
+    read-through cache is bypassed and the numbers are always recomputed, then
+    writes the fresh result to the cache.
+    """
+    from wp1.redis_db import connect as redis_connect
+    from wp1.wp10_db import connect as wp10_connect
+
+    wp10db = wp10_connect()
+    redis = redis_connect()
+
+    logger.info("Refreshing cached assessment numbers")
+    data = get_all_assessment_numbers(wp10db)
+    cache_assessment_numbers(redis, data)
+    logger.info("Refreshed cached assessment numbers for %d projects", len(data))
+    return data
+
+
 def get_project_ratings(wp10db, project_name):
     with wp10db.cursor() as cursor:
         cursor.execute(

--- a/wp1/logic/rating.py
+++ b/wp1/logic/rating.py
@@ -1,7 +1,9 @@
 import logging
-import random
+import pickle
+from datetime import timedelta
 
 import attr
+from redis import Redis
 
 from wp1.conf import get_conf
 from wp1.constants import GLOBAL_TIMESTAMP, AssessmentKind
@@ -12,8 +14,59 @@ from wp1.models.wp10.rating import Rating
 config = get_conf()
 NOT_A_CLASS = config["NOT_A_CLASS"]
 UNASSESSED_CLASS = config["UNASSESSED_CLASS"]
+ALL_ASSESSMENTS_CACHE_KEY = "all_assessment_numbers"
 
 logger = logging.getLogger(__name__)
+
+
+def get_cached_assessment_numbers(redis):
+    if redis is None:
+        return
+
+    pkl = redis.get(ALL_ASSESSMENTS_CACHE_KEY)
+    if pkl is None:
+        return None
+    return pickle.loads(pkl)  # nosec
+
+
+def cache_assessment_numbers(redis, data):
+    if redis is None:
+        return
+
+    pkl = pickle.dumps(data)
+    redis.setex(ALL_ASSESSMENTS_CACHE_KEY, timedelta(hours=2), value=pkl)
+
+
+def get_all_assessment_numbers(wp10db, redis: Redis = None):
+    """
+    Get the number of assessed/unassessed articles for every project.
+    Returns a list of (project, unassessed, assessed) tuples, ordered by the
+    number of unassessed articles descending (as returned by the database).
+    """
+    if redis is not None:
+        cached = get_cached_assessment_numbers(redis)
+        if cached is not None:
+            return cached
+
+    with wp10db.cursor() as cursor:
+        cursor.execute("""
+              SELECT r_project,
+                CAST(SUM(r_quality = 'NotA-Class' OR r_quality = 'Unassessed-Class') AS UNSIGNED) as unassessed,
+                CAST(SUM(r_quality != 'NotA-Class' AND r_quality != 'Unassessed-Class') AS UNSIGNED) as assessed
+              FROM ratings
+              GROUP BY r_project
+              ORDER BY unassessed DESC;
+            """)
+        results = cursor.fetchall()
+
+    results = [
+        (row["r_project"].decode("utf-8"), row["unassessed"], row["assessed"])
+        for row in results
+    ]
+    if redis is not None:
+        cache_assessment_numbers(redis, results)
+
+    return results
 
 
 def get_project_ratings(wp10db, project_name):
@@ -40,7 +93,6 @@ def _project_rating_query(
     limit=100,
 ):
     if count:
-
         query = "SELECT COUNT(*) as count FROM " + Rating.table_name + " as rating_a"
     else:
         if project_b_name is None:
@@ -245,6 +297,7 @@ def get_random_article(
     efficient index usage without requiring additional indices.
     """
     import random
+
     from wp1.models.wp10.rating import Rating
 
     # Build WHERE clause

--- a/wp1/logic/rating.py
+++ b/wp1/logic/rating.py
@@ -34,7 +34,11 @@ def cache_assessment_numbers(redis, data):
         return
 
     pkl = pickle.dumps(data)
-    redis.setex(ALL_ASSESSMENTS_CACHE_KEY, timedelta(hours=2), value=pkl)
+    # The warming job (see wp1.queues.schedule_assessment_cache_warming) refreshes
+    # this once a day at noon UTC. The TTL is a bit over 24h so the entry never
+    # expires before the next day's run overwrites it (which would otherwise open
+    # a daily window where a web request hits the slow query directly).
+    redis.setex(ALL_ASSESSMENTS_CACHE_KEY, timedelta(hours=25), value=pkl)
 
 
 def get_all_assessment_numbers(wp10db, redis: Redis = None):

--- a/wp1/logic/rating_test.py
+++ b/wp1/logic/rating_test.py
@@ -659,8 +659,9 @@ class GetAllAssessmentNumbersTest(BaseWpOneDbTest):
     def test_cache_sets_expiry(self):
         logic_rating.cache_assessment_numbers(self.redis, [("Alpha", 0, 1)])
         ttl = self.redis.ttl(logic_rating.ALL_ASSESSMENTS_CACHE_KEY)
-        self.assertGreater(ttl, 0)
-        self.assertLessEqual(ttl, 2 * 60 * 60)
+        # A bit over 24h, so the daily refresh overwrites before expiry.
+        self.assertGreater(ttl, 24 * 60 * 60)
+        self.assertLessEqual(ttl, 25 * 60 * 60)
 
     def test_update_assessment_cache_populates_cache(self):
         # update_assessment_cache() opens its own connections (it's the recurring

--- a/wp1/logic/rating_test.py
+++ b/wp1/logic/rating_test.py
@@ -661,3 +661,30 @@ class GetAllAssessmentNumbersTest(BaseWpOneDbTest):
         ttl = self.redis.ttl(logic_rating.ALL_ASSESSMENTS_CACHE_KEY)
         self.assertGreater(ttl, 0)
         self.assertLessEqual(ttl, 2 * 60 * 60)
+
+    def test_update_assessment_cache_populates_cache(self):
+        # update_assessment_cache() opens its own connections (it's the recurring
+        # job entry point), which in the test env are the same test DB/Redis.
+        self._add_ratings("Alpha", ("FA-Class", "Unassessed-Class"))
+        self.assertIsNone(logic_rating.get_cached_assessment_numbers(self.redis))
+
+        result = logic_rating.update_assessment_cache()
+
+        self.assertEqual([("Alpha", 1, 1)], result)
+        self.assertEqual(
+            [("Alpha", 1, 1)],
+            logic_rating.get_cached_assessment_numbers(self.redis),
+        )
+
+    def test_update_assessment_cache_overwrites_stale_cache(self):
+        # A read-through call would return this stale value; the warming job must
+        # bypass it and recompute from the database.
+        logic_rating.cache_assessment_numbers(self.redis, [("Stale", 5, 6)])
+        self._add_ratings("Alpha", ("FA-Class",))
+
+        logic_rating.update_assessment_cache()
+
+        self.assertEqual(
+            [("Alpha", 0, 1)],
+            logic_rating.get_cached_assessment_numbers(self.redis),
+        )

--- a/wp1/logic/rating_test.py
+++ b/wp1/logic/rating_test.py
@@ -528,3 +528,136 @@ class GetRandomArticleTest(BaseWpOneDbTest):
         self._add_ratings()
         article = logic_rating.get_random_article(self.wp10db, b"Nonexistent Project")
         self.assertIsNone(article)
+
+
+class GetAllAssessmentNumbersTest(BaseWpOneDbTest):
+
+    # A rating is "unassessed" iff its quality is one of these; everything else
+    # counts as "assessed".
+    UNASSESSED = ("NotA-Class", "Unassessed-Class")
+
+    def _add_ratings(self, project, qualities):
+        ratings = []
+        for i, quality in enumerate(qualities):
+            ratings.append(
+                {
+                    "r_project": project,
+                    "r_namespace": 0,
+                    "r_article": "Article_%s" % i,
+                    "r_score": 0,
+                    "r_quality": quality,
+                    "r_quality_timestamp": "20191225T00:00:00",
+                    "r_importance": "Low-Class",
+                    "r_importance_timestamp": "20191226T00:00:00",
+                }
+            )
+        with self.wp10db.cursor() as cursor:
+            cursor.executemany(
+                "INSERT INTO ratings "
+                "(r_project, r_namespace, r_article, r_score, r_quality, "
+                " r_quality_timestamp, r_importance, r_importance_timestamp) "
+                "VALUES "
+                "(%(r_project)s, %(r_namespace)s, %(r_article)s, %(r_score)s, "
+                " %(r_quality)s, %(r_quality_timestamp)s, %(r_importance)s, "
+                " %(r_importance_timestamp)s)",
+                ratings,
+            )
+        self.wp10db.commit()
+
+    def test_counts_assessed_and_unassessed(self):
+        self._add_ratings(
+            "Alpha",
+            ("FA-Class", "A-Class", "B-Class", "NotA-Class", "Unassessed-Class"),
+        )
+        self._add_ratings("Beta", ("GA-Class", "Unassessed-Class"))
+
+        result = logic_rating.get_all_assessment_numbers(self.wp10db)
+
+        # Tuples of (project, unassessed, assessed), ordered by unassessed desc.
+        self.assertEqual(
+            [
+                ("Alpha", 2, 3),
+                ("Beta", 1, 1),
+            ],
+            result,
+        )
+
+    def test_orders_by_unassessed_descending(self):
+        self._add_ratings("Few", ("FA-Class", "Unassessed-Class"))
+        self._add_ratings(
+            "Many", ("Unassessed-Class", "NotA-Class", "Unassessed-Class")
+        )
+
+        result = logic_rating.get_all_assessment_numbers(self.wp10db)
+
+        self.assertEqual([p for p, _, _ in result], ["Many", "Few"])
+
+    def test_returns_plain_ints_not_decimal(self):
+        # Regression test: the query casts SUM() to UNSIGNED so values come back
+        # as ints. Without the cast, the DECIMAL result is handed to pymysql as
+        # raw bytes on a use_unicode=False connection and Decimal(bytes) raises
+        # "conversion from bytes to Decimal is not supported" on Python 3.14.
+        self._add_ratings("Alpha", ("FA-Class", "Unassessed-Class"))
+
+        result = logic_rating.get_all_assessment_numbers(self.wp10db)
+
+        _, unassessed, assessed = result[0]
+        self.assertIsInstance(unassessed, int)
+        self.assertIsInstance(assessed, int)
+
+    def test_decodes_project_name_to_str(self):
+        self._add_ratings("Alpha", ("FA-Class",))
+
+        result = logic_rating.get_all_assessment_numbers(self.wp10db)
+
+        self.assertEqual([("Alpha", 0, 1)], result)
+
+    def test_no_ratings_returns_empty_list(self):
+        result = logic_rating.get_all_assessment_numbers(self.wp10db)
+        self.assertEqual([], result)
+
+    def test_caches_result_in_redis(self):
+        self._add_ratings("Alpha", ("FA-Class", "Unassessed-Class"))
+
+        result = logic_rating.get_all_assessment_numbers(self.wp10db, self.redis)
+
+        self.assertEqual(result, logic_rating.get_cached_assessment_numbers(self.redis))
+
+    def test_returns_cached_value_without_querying_db(self):
+        sentinel = [("Cached Project", 9, 99)]
+        logic_rating.cache_assessment_numbers(self.redis, sentinel)
+        # The DB has different (in fact, no) ratings, so a cache miss would
+        # return [] instead of the sentinel.
+        self._add_ratings("Alpha", ("FA-Class",))
+
+        result = logic_rating.get_all_assessment_numbers(self.wp10db, self.redis)
+
+        self.assertEqual(sentinel, result)
+
+    def test_no_redis_skips_cache(self):
+        self._add_ratings("Alpha", ("FA-Class",))
+
+        result = logic_rating.get_all_assessment_numbers(self.wp10db, None)
+
+        self.assertEqual([("Alpha", 0, 1)], result)
+
+    def test_get_cached_returns_none_when_empty(self):
+        self.assertIsNone(logic_rating.get_cached_assessment_numbers(self.redis))
+
+    def test_get_cached_returns_none_for_none_redis(self):
+        self.assertIsNone(logic_rating.get_cached_assessment_numbers(None))
+
+    def test_cache_roundtrips_through_redis(self):
+        data = [("Alpha", 2, 3)]
+        logic_rating.cache_assessment_numbers(self.redis, data)
+        self.assertEqual(data, logic_rating.get_cached_assessment_numbers(self.redis))
+
+    def test_cache_none_redis_is_noop(self):
+        # Should not raise.
+        logic_rating.cache_assessment_numbers(None, [("Alpha", 0, 0)])
+
+    def test_cache_sets_expiry(self):
+        logic_rating.cache_assessment_numbers(self.redis, [("Alpha", 0, 1)])
+        ttl = self.redis.ttl(logic_rating.ALL_ASSESSMENTS_CACHE_KEY)
+        self.assertGreater(ttl, 0)
+        self.assertLessEqual(ttl, 2 * 60 * 60)

--- a/wp1/queues.py
+++ b/wp1/queues.py
@@ -23,11 +23,13 @@ from wp1.credentials import ENV
 logger = logging.getLogger(__name__)
 
 # Recurring job that keeps the (slow) all-projects assessment-numbers query
-# warm in the cache. Runs in its own queue every 90 minutes. The interval is
-# kept below the cache TTL (see logic.rating.cache_assessment_numbers) so the
-# cache is refreshed before it can expire.
+# warm in the cache. The underlying ratings data is rebuilt once per day by the
+# update that starts at midnight UTC and takes ~8 hours, so there's no point
+# recomputing more than daily. We run at noon UTC, comfortably after that update
+# finishes. The cache TTL (see logic.rating.cache_assessment_numbers) is a bit
+# over 24h so each day's run refreshes the entry before it can expire.
 ASSESSMENT_CACHE_JOB_ID = "warm-assessment-cache"
-ASSESSMENT_CACHE_INTERVAL_SECONDS = 90 * 60
+ASSESSMENT_CACHE_CRON = "0 12 * * *"  # noon UTC, daily
 
 
 def _get_queues(redis, manual=False):
@@ -56,18 +58,16 @@ def schedule_assessment_cache_warming(redis: Redis):
 
     Safe to call on every deploy/worker boot: any previously registered
     schedule with the same id is cancelled first, so the schedule never stacks
-    up into duplicates. The job runs immediately (warming the cache right after
-    a deploy) and then every ASSESSMENT_CACHE_INTERVAL_SECONDS thereafter.
+    up into duplicates. The job runs once a day at noon UTC (cron times are UTC
+    by default in rq-scheduler).
     """
     queue = _get_assessment_cache_queue(redis)
     scheduler = Scheduler(connection=queue.connection, queue=queue)
 
     scheduler.cancel(ASSESSMENT_CACHE_JOB_ID)
-    return scheduler.schedule(
-        scheduled_time=utcnow(),
+    return scheduler.cron(
+        ASSESSMENT_CACHE_CRON,
         func=logic_rating.update_assessment_cache,
-        interval=ASSESSMENT_CACHE_INTERVAL_SECONDS,
-        repeat=None,
         id=ASSESSMENT_CACHE_JOB_ID,
         queue_name="assessment-cache",
         # Without this, the job inherits RQ's 180s default timeout, but the

--- a/wp1/queues.py
+++ b/wp1/queues.py
@@ -12,6 +12,7 @@ from wp1 import custom_tables
 from wp1.environment import Environment
 import wp1.logic.builder as logic_builder
 import wp1.logic.project as logic_project
+import wp1.logic.rating as logic_rating
 from wp1.models.wp10.zim_schedule import ZimSchedule
 from wp1.wiki_db import connect as wiki_connect
 from wp1 import logs
@@ -20,6 +21,13 @@ from wp1.timestamp import utcnow
 from wp1.credentials import ENV
 
 logger = logging.getLogger(__name__)
+
+# Recurring job that keeps the (slow) all-projects assessment-numbers query
+# warm in the cache. Runs in its own queue every 90 minutes. The interval is
+# kept below the cache TTL (see logic.rating.cache_assessment_numbers) so the
+# cache is refreshed before it can expire.
+ASSESSMENT_CACHE_JOB_ID = "warm-assessment-cache"
+ASSESSMENT_CACHE_INTERVAL_SECONDS = 90 * 60
 
 
 def _get_queues(redis, manual=False):
@@ -37,6 +45,35 @@ def _get_materializer_queue(redis):
 
 def _get_zimfile_scheduling_queue(redis):
     return Queue("zimfile-scheduling", connection=redis)
+
+
+def _get_assessment_cache_queue(redis):
+    return Queue("assessment-cache", connection=redis)
+
+
+def schedule_assessment_cache_warming(redis: Redis):
+    """Idempotently (re)register the recurring assessment-cache warming job.
+
+    Safe to call on every deploy/worker boot: any previously registered
+    schedule with the same id is cancelled first, so the schedule never stacks
+    up into duplicates. The job runs immediately (warming the cache right after
+    a deploy) and then every ASSESSMENT_CACHE_INTERVAL_SECONDS thereafter.
+    """
+    queue = _get_assessment_cache_queue(redis)
+    scheduler = Scheduler(connection=queue.connection, queue=queue)
+
+    scheduler.cancel(ASSESSMENT_CACHE_JOB_ID)
+    return scheduler.schedule(
+        scheduled_time=utcnow(),
+        func=logic_rating.update_assessment_cache,
+        interval=ASSESSMENT_CACHE_INTERVAL_SECONDS,
+        repeat=None,
+        id=ASSESSMENT_CACHE_JOB_ID,
+        queue_name="assessment-cache",
+        # Without this, the job inherits RQ's 180s default timeout, but the
+        # query takes minutes in production. Use the repo-wide job timeout.
+        timeout=constants.JOB_TIMEOUT,
+    )
 
 
 def enqueue_all_projects(redis, wp10db):

--- a/wp1/queues_test.py
+++ b/wp1/queues_test.py
@@ -8,6 +8,7 @@ from wp1.environment import Environment
 from wp1 import queues
 from wp1.selection.models.simple import Builder as SimpleBuilder
 import wp1.logic.builder as logic_builder
+import wp1.logic.rating as logic_rating
 
 
 class QueuesTest(BaseWpOneDbTest):
@@ -252,3 +253,29 @@ class QueuesTest(BaseWpOneDbTest):
 
         self.assertFalse(result)
         mock_scheduler_instance.cancel.assert_called_once_with("test-job-id")
+
+    @patch("wp1.queues.utcnow")
+    @patch("wp1.queues.Scheduler")
+    def test_schedule_assessment_cache_warming(self, mock_scheduler, mock_utcnow):
+        mock_scheduler_instance = MagicMock()
+        mock_scheduler_instance.schedule.return_value = "job-id"
+        mock_scheduler.return_value = mock_scheduler_instance
+        now = datetime.datetime(2026, 12, 25, 4, 44, 44)
+        mock_utcnow.return_value = now
+
+        result = queues.schedule_assessment_cache_warming(self.redis)
+
+        self.assertEqual("job-id", result)
+        # Cancel-then-schedule keeps registration idempotent across reboots.
+        mock_scheduler_instance.cancel.assert_called_once_with(
+            queues.ASSESSMENT_CACHE_JOB_ID
+        )
+        mock_scheduler_instance.schedule.assert_called_once_with(
+            scheduled_time=now,
+            func=logic_rating.update_assessment_cache,
+            interval=queues.ASSESSMENT_CACHE_INTERVAL_SECONDS,
+            repeat=None,
+            id=queues.ASSESSMENT_CACHE_JOB_ID,
+            queue_name="assessment-cache",
+            timeout=constants.JOB_TIMEOUT,
+        )

--- a/wp1/queues_test.py
+++ b/wp1/queues_test.py
@@ -254,14 +254,11 @@ class QueuesTest(BaseWpOneDbTest):
         self.assertFalse(result)
         mock_scheduler_instance.cancel.assert_called_once_with("test-job-id")
 
-    @patch("wp1.queues.utcnow")
     @patch("wp1.queues.Scheduler")
-    def test_schedule_assessment_cache_warming(self, mock_scheduler, mock_utcnow):
+    def test_schedule_assessment_cache_warming(self, mock_scheduler):
         mock_scheduler_instance = MagicMock()
-        mock_scheduler_instance.schedule.return_value = "job-id"
+        mock_scheduler_instance.cron.return_value = "job-id"
         mock_scheduler.return_value = mock_scheduler_instance
-        now = datetime.datetime(2026, 12, 25, 4, 44, 44)
-        mock_utcnow.return_value = now
 
         result = queues.schedule_assessment_cache_warming(self.redis)
 
@@ -270,11 +267,9 @@ class QueuesTest(BaseWpOneDbTest):
         mock_scheduler_instance.cancel.assert_called_once_with(
             queues.ASSESSMENT_CACHE_JOB_ID
         )
-        mock_scheduler_instance.schedule.assert_called_once_with(
-            scheduled_time=now,
+        mock_scheduler_instance.cron.assert_called_once_with(
+            queues.ASSESSMENT_CACHE_CRON,
             func=logic_rating.update_assessment_cache,
-            interval=queues.ASSESSMENT_CACHE_INTERVAL_SECONDS,
-            repeat=None,
             id=queues.ASSESSMENT_CACHE_JOB_ID,
             queue_name="assessment-cache",
             timeout=constants.JOB_TIMEOUT,

--- a/wp1/web/projects.py
+++ b/wp1/web/projects.py
@@ -1,15 +1,15 @@
-from wp1.web import authenticate
-import attr
-import flask
 import logging
 
-from wp1.constants import PAGE_SIZE
-from wp1.web.db import get_db
-from wp1.web.redis import get_redis
+import attr
+import flask
+
 import wp1.logic.project as logic_project
 import wp1.logic.rating as logic_rating
-from wp1 import queues
-from wp1 import tables
+from wp1 import queues, tables
+from wp1.constants import PAGE_SIZE
+from wp1.web import authenticate
+from wp1.web.db import get_db
+from wp1.web.redis import get_redis
 
 projects = flask.Blueprint("projects", __name__)
 
@@ -26,6 +26,14 @@ def count():
     wp10db = get_db("wp10db")
     count = logic_project.count_projects(wp10db)
     return flask.jsonify({"count": count})
+
+
+@projects.route("/assessments")
+def assessments():
+    wp10db = get_db("wp10db")
+    redis = get_redis()
+    assessments = logic_rating.get_all_assessment_numbers(wp10db, redis)
+    return flask.jsonify(assessments)
 
 
 @projects.route("/<project_name>")

--- a/wp1/web/projects_test.py
+++ b/wp1/web/projects_test.py
@@ -175,6 +175,41 @@ class ProjectTest(BaseWebTestcase):
             data = json.loads(rv.data)
             self.assertEqual(101, data["count"])
 
+    def test_assessments(self):
+        with self.override_db(self.app), self.app.test_client() as client:
+            rv = client.get("/v1/projects/assessments")
+            self.assertEqual("200 OK", rv.status)
+
+            data = json.loads(rv.data)
+            # setUp seeds 150 ratings each for Project 0 and Project 1, all with
+            # assessed qualities (FA/A/B-Class) and none unassessed. The endpoint
+            # returns [project, unassessed, assessed] tuples; the two projects
+            # tie at 0 unassessed, so sort before comparing.
+            self.assertEqual(
+                [["Project 0", 0, 150], ["Project 1", 0, 150]],
+                sorted(data),
+            )
+
+    def test_assessments_served_from_cache(self):
+        with self.override_db(self.app), self.app.test_client() as client:
+            first = json.loads(client.get("/v1/projects/assessments").data)
+
+            # Add an unassessed rating *after* the first request populated the
+            # cache. A cached response will not reflect it; an uncached one would.
+            with self.wp10db.cursor() as cursor:
+                cursor.execute(
+                    "INSERT INTO ratings "
+                    "(r_project, r_namespace, r_article, r_score, r_quality, "
+                    " r_quality_timestamp, r_importance, r_importance_timestamp) "
+                    "VALUES ('Project 0', 0, 'Brand_New', 0, 'Unassessed-Class', "
+                    " '20191225T00:00:00', 'Low-Class', '20191226T00:00:00')"
+                )
+            self.wp10db.commit()
+
+            second = json.loads(client.get("/v1/projects/assessments").data)
+
+            self.assertEqual(first, second)
+
     def test_table(self):
         with self.override_db(self.app), self.app.test_client() as client:
             rv = client.get("/v1/projects/Project 1/table")


### PR DESCRIPTION
Fixes #1199 

Although this seems trivial, the hard part is that the query takes about 3+ minutes on production, which is longer than a web request. Therefore, we run the query only once every 24 hours and cache the results.

The UI on the site displays all data at once, paginated client side using DataTables.