### PR TITLE
Seed assessment cache immediately on boot

### DIFF
--- a/schedule-cache-warming.py
+++ b/schedule-cache-warming.py
@@ -13,6 +13,12 @@ def main():
     queues.schedule_assessment_cache_warming(redis)
     logger.info("Registered recurring assessment-cache warming schedule")
 
+    # Also seed the cache immediately so a fresh deploy / Redis restart doesn't
+    # leave the slow query to run inline on web requests until the next
+    # scheduled run.
+    queues.enqueue_assessment_cache_warming(redis)
+    logger.info("Enqueued immediate assessment-cache warming job")
+
 
 if __name__ == "__main__":
     main()

--- a/wp1/queues.py
+++ b/wp1/queues.py
@@ -76,6 +76,23 @@ def schedule_assessment_cache_warming(redis: Redis):
     )
 
 
+def enqueue_assessment_cache_warming(redis: Redis):
+    """Enqueue a one-off assessment-cache warming job to run immediately.
+
+    Called on container boot (see schedule-cache-warming.py) alongside
+    registering the recurring schedule, so that a fresh deploy or a Redis
+    restart seeds the cache right away instead of leaving the slow query to run
+    inline on the first web request until the next scheduled (noon UTC) run.
+    """
+    queue = _get_assessment_cache_queue(redis)
+    return queue.enqueue(
+        logic_rating.update_assessment_cache,
+        # Matches the scheduled job: the query takes minutes, so override RQ's
+        # 180s default timeout with the repo-wide job timeout.
+        job_timeout=constants.JOB_TIMEOUT,
+    )
+
+
 def enqueue_all_projects(redis, wp10db):
     update_q, upload_q = _get_queues(redis)
 

--- a/wp1/queues_test.py
+++ b/wp1/queues_test.py
@@ -274,3 +274,15 @@ class QueuesTest(BaseWpOneDbTest):
             queue_name="assessment-cache",
             timeout=constants.JOB_TIMEOUT,
         )
+
+    @patch("wp1.queues.Queue")
+    def test_enqueue_assessment_cache_warming(self, mock_queue):
+        queue_mock = MagicMock()
+        mock_queue.return_value = queue_mock
+
+        queues.enqueue_assessment_cache_warming(self.redis)
+
+        queue_mock.enqueue.assert_called_once_with(
+            logic_rating.update_assessment_cache,
+            job_timeout=constants.JOB_TIMEOUT,
+        )


### PR DESCRIPTION
## Problem

`schedule-cache-warming.py` only **registers** the recurring noon-UTC warming job (`schedule_assessment_cache_warming`). It never runs it immediately. So after every deploy or Redis restart, the `all_assessment_numbers` cache stays cold until the next scheduled run (up to ~24h away).

During that window, `/v1/projects/assessments` falls through to the read-through query in `logic.rating.get_all_assessment_numbers`, which the docstring notes takes **minutes in production**. Run inline on a web request it times out, so the frontend "Assessments by Project" table renders empty ("No data available in table").

This actually happened on the latest production deploy.

## Fix

- Add `queues.enqueue_assessment_cache_warming(redis)` — enqueues a one-off `update_assessment_cache` job onto the existing `assessment-cache` queue (drained by the `wp1-assessment-cache` worker), using the same `JOB_TIMEOUT` as the scheduled run.
- Call it on boot in `schedule-cache-warming.py`, right after registering the recurring schedule, so a fresh deploy / Redis restart seeds the cache right away instead of leaving the slow query to run inline on web requests.

Enqueues rather than running inline so the boot step returns immediately and the dedicated worker does the multi-minute work off to the side — exactly what the scheduler does at noon, just now.

## Test

- New `test_enqueue_assessment_cache_warming` mirroring the existing enqueue tests.
- `16 passed` in `wp1/queues_test.py`; black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)