### PR TITLE
handle referenced combinators during list deletion

### DIFF
--- a/wp1-frontend/cypress/e2e/updateSimpleList.cy.js
+++ b/wp1-frontend/cypress/e2e/updateSimpleList.cy.js
@@ -70,6 +70,80 @@ describe('the update simple list page', () => {
         cy.url().should('eq', 'http://localhost:5173/#/selections/user');
       });
 
+      it('requires typing the list name before deleting with no combinator impact', () => {
+        cy.intercept('GET', 'v1/builders/1/delete-impact', {
+          fixture: 'delete_impact_none.json',
+        }).as('deleteImpact');
+        cy.intercept('POST', 'v1/builders/1/delete', {
+          body: { status: '204' },
+        }).as('deleteBuilder');
+
+        cy.get('#deleteListButton').click();
+        cy.wait('@deleteImpact');
+        cy.get('#delete-impact-dialog').should('be.visible');
+        cy.get('#delete-impact-dialog').contains(
+          'No Combinator selections reference this list.'
+        );
+        cy.get('#confirmDeleteButton').should('be.disabled');
+        cy.get('#delete-confirm-name').type('Builder 1');
+        cy.get('#confirmDeleteButton').should('not.be.disabled').click();
+
+        cy.wait('@deleteBuilder').then((interception) => {
+          expect(interception.request.body).to.deep.equal({
+            delete_combinator_ids: [],
+            confirm_builder_name: 'Builder 1',
+          });
+        });
+        cy.url().should('eq', 'http://localhost:5173/#/selections/user');
+      });
+
+      it('lists affected combinators and sends selected deletes', () => {
+        cy.intercept('GET', 'v1/builders/1/delete-impact', {
+          fixture: 'delete_impact_combinators.json',
+        }).as('deleteImpact');
+        cy.intercept('POST', 'v1/builders/1/delete', {
+          body: { status: '204' },
+        }).as('deleteBuilder');
+
+        cy.get('#deleteListButton').click();
+        cy.wait('@deleteImpact');
+        cy.get('#delete-impact-dialog').contains('Keepable Combo');
+        cy.get('#delete-impact-dialog').contains('Empty Combo');
+        cy.get('#delete-impact-dialog').contains(
+          'they will be deleted automatically'
+        );
+        cy.get('#delete-combinator-combo-empty').should('not.exist');
+        cy.get('#delete-combinator-combo-keep').check();
+        cy.get('#delete-confirm-name').type('Builder 1');
+        cy.get('#confirmDeleteButton').click();
+
+        cy.wait('@deleteBuilder').then((interception) => {
+          expect(interception.request.body).to.deep.equal({
+            delete_combinator_ids: ['combo-keep'],
+            confirm_builder_name: 'Builder 1',
+          });
+        });
+      });
+
+      it('shows auto-deleted combinators without checkbox instructions', () => {
+        cy.intercept('GET', 'v1/builders/1/delete-impact', {
+          fixture: 'delete_impact_auto_delete_only.json',
+        }).as('deleteImpact');
+
+        cy.get('#deleteListButton').click();
+        cy.wait('@deleteImpact');
+
+        cy.get('#delete-impact-dialog').contains(
+          'They would have no included lists left, so they will be deleted automatically.'
+        );
+        cy.get('#delete-impact-dialog').contains('Empty Combo');
+        cy.get('#delete-impact-dialog').should(
+          'not.contain',
+          'Choose which Combinators to delete below'
+        );
+        cy.get('#delete-combinator-combo-empty').should('not.exist');
+      });
+
       describe('when update button clicked', () => {
         beforeEach(() => {
           cy.intercept('POST', 'v1/builders/1', (req) => {

--- a/wp1-frontend/cypress/e2e/updateSimpleList.cy.js
+++ b/wp1-frontend/cypress/e2e/updateSimpleList.cy.js
@@ -70,7 +70,7 @@ describe('the update simple list page', () => {
         cy.url().should('eq', 'http://localhost:5173/#/selections/user');
       });
 
-      it('requires typing the list name before deleting with no combinator impact', () => {
+      it('deletes with no combinator impact without typing the list name', () => {
         cy.intercept('GET', 'v1/builders/1/delete-impact', {
           fixture: 'delete_impact_none.json',
         }).as('deleteImpact');
@@ -81,17 +81,13 @@ describe('the update simple list page', () => {
         cy.get('#deleteListButton').click();
         cy.wait('@deleteImpact');
         cy.get('#delete-impact-dialog').should('be.visible');
-        cy.get('#delete-impact-dialog').contains(
-          'No Combinator selections reference this list.'
-        );
-        cy.get('#confirmDeleteButton').should('be.disabled');
-        cy.get('#delete-confirm-name').type('Builder 1');
+        cy.get('#affected-combinators').should('not.exist');
+        cy.get('#delete-confirm-name').should('not.exist');
         cy.get('#confirmDeleteButton').should('not.be.disabled').click();
 
         cy.wait('@deleteBuilder').then((interception) => {
           expect(interception.request.body).to.deep.equal({
             delete_combinator_ids: [],
-            confirm_builder_name: 'Builder 1',
           });
         });
         cy.url().should('eq', 'http://localhost:5173/#/selections/user');
@@ -109,10 +105,22 @@ describe('the update simple list page', () => {
         cy.wait('@deleteImpact');
         cy.get('#delete-impact-dialog').contains('Keepable Combo');
         cy.get('#delete-impact-dialog').contains('Empty Combo');
-        cy.get('#delete-impact-dialog').contains(
-          'they will be deleted automatically'
+        cy.get('#affected-combinators .alert-warning').contains(
+          'You must remove the list from the Combinator(s) or delete the Combinator(s) completely.'
         );
-        cy.get('#delete-combinator-combo-empty').should('not.exist');
+        cy.get('#confirmDeleteButton').should('be.disabled');
+        cy.get('#decision-required-combo-keep').should('exist');
+        cy.get('#decision-required-combo-empty').should('not.exist');
+        cy.get('#remove-builder-combo-keep').should('not.be.disabled');
+        cy.get('#remove-builder-combo-keep').should('not.be.checked');
+        cy.get('#delete-combinator-combo-keep').should('not.be.disabled');
+        cy.get('#delete-combinator-combo-keep').should('not.be.checked');
+        cy.get('label[for="delete-combinator-combo-keep"]').should(
+          'have.class',
+          'text-danger'
+        );
+        cy.get('#remove-builder-combo-empty').should('be.disabled');
+        cy.get('#delete-combinator-combo-empty').should('be.checked');
         cy.get('#delete-combinator-combo-keep').check();
         cy.get('#delete-confirm-name').type('Builder 1');
         cy.get('#confirmDeleteButton').click();
@@ -125,7 +133,7 @@ describe('the update simple list page', () => {
         });
       });
 
-      it('shows auto-deleted combinators without checkbox instructions', () => {
+      it('requires deleting combinators that would have no included lists left', () => {
         cy.intercept('GET', 'v1/builders/1/delete-impact', {
           fixture: 'delete_impact_auto_delete_only.json',
         }).as('deleteImpact');
@@ -133,15 +141,13 @@ describe('the update simple list page', () => {
         cy.get('#deleteListButton').click();
         cy.wait('@deleteImpact');
 
-        cy.get('#delete-impact-dialog').contains(
-          'They would have no included lists left, so they will be deleted automatically.'
+        cy.get('#affected-combinators .alert-warning').contains(
+          'You must remove the list from the Combinator(s) or delete the Combinator(s) completely.'
         );
         cy.get('#delete-impact-dialog').contains('Empty Combo');
-        cy.get('#delete-impact-dialog').should(
-          'not.contain',
-          'Choose which Combinators to delete below'
-        );
-        cy.get('#delete-combinator-combo-empty').should('not.exist');
+        cy.get('#decision-required-combo-empty').should('not.exist');
+        cy.get('#remove-builder-combo-empty').should('be.disabled');
+        cy.get('#delete-combinator-combo-empty').should('be.checked');
       });
 
       describe('when update button clicked', () => {

--- a/wp1-frontend/cypress/fixtures/delete_impact_auto_delete_only.json
+++ b/wp1-frontend/cypress/fixtures/delete_impact_auto_delete_only.json
@@ -1,0 +1,18 @@
+{
+  "builder": {
+    "id": "1",
+    "name": "Builder 1",
+    "project": "en.wiktionary.org",
+    "model": "wp1.selection.models.simple"
+  },
+  "affected_combinators": [
+    {
+      "id": "combo-empty",
+      "name": "Empty Combo",
+      "project": "en.wiktionary.org",
+      "referenced_in": ["include"],
+      "remaining_include_builder_count": 0,
+      "will_be_auto_deleted": true
+    }
+  ]
+}

--- a/wp1-frontend/cypress/fixtures/delete_impact_combinators.json
+++ b/wp1-frontend/cypress/fixtures/delete_impact_combinators.json
@@ -1,0 +1,26 @@
+{
+  "builder": {
+    "id": "1",
+    "name": "Builder 1",
+    "project": "en.wiktionary.org",
+    "model": "wp1.selection.models.simple"
+  },
+  "affected_combinators": [
+    {
+      "id": "combo-keep",
+      "name": "Keepable Combo",
+      "project": "en.wiktionary.org",
+      "referenced_in": ["include", "exclude"],
+      "remaining_include_builder_count": 1,
+      "will_be_auto_deleted": false
+    },
+    {
+      "id": "combo-empty",
+      "name": "Empty Combo",
+      "project": "en.wiktionary.org",
+      "referenced_in": ["include"],
+      "remaining_include_builder_count": 0,
+      "will_be_auto_deleted": true
+    }
+  ]
+}

--- a/wp1-frontend/cypress/fixtures/delete_impact_none.json
+++ b/wp1-frontend/cypress/fixtures/delete_impact_none.json
@@ -1,0 +1,9 @@
+{
+  "builder": {
+    "id": "1",
+    "name": "Builder 1",
+    "project": "en.wiktionary.org",
+    "model": "wp1.selection.models.simple"
+  },
+  "affected_combinators": []
+}

--- a/wp1-frontend/src/components/BaseBuilder.vue
+++ b/wp1-frontend/src/components/BaseBuilder.vue
@@ -160,6 +160,7 @@
                   id="deleteListButton"
                   type="button"
                   class="btn btn-danger ml-4"
+                  :disabled="deleteProcessing"
                 >
                   Delete List
                 </button>
@@ -184,6 +185,131 @@
               ></pulse-loader>
             </div>
           </form>
+        </div>
+      </div>
+
+      <div
+        v-if="showDeleteDialog"
+        id="delete-impact-dialog"
+        class="delete-dialog-backdrop"
+      >
+        <div
+          class="delete-dialog card shadow-lg"
+          role="dialog"
+          aria-modal="true"
+        >
+          <div class="card-header bg-danger text-white text-center">
+            <h5 class="mb-0">Confirm Delete</h5>
+          </div>
+          <div class="card-body">
+            <p>
+              Deleting <strong>{{ deleteBuilderName }}</strong> will permanently
+              delete this list and all downloadable selections.
+            </p>
+
+            <div
+              v-if="affectedCombinators.length === 0"
+              class="alert alert-info"
+            >
+              No Combinator selections reference this list.
+            </div>
+            <div v-else id="affected-combinators">
+              <div
+                v-if="manualDeleteCombinators.length > 0"
+                class="alert alert-warning"
+              >
+                This list is used by one or more Combinators. Choose which
+                Combinators to delete below. Any Combinator you leave unchecked
+                will be kept, but this list will be removed from it.
+              </div>
+              <div v-else class="alert alert-warning">
+                This list is used by one or more Combinators. They would have no
+                included lists left, so they will be deleted automatically.
+              </div>
+
+              <div v-if="manualDeleteCombinators.length > 0">
+                <div
+                  v-for="item in manualDeleteCombinators"
+                  :key="'manual-delete-' + item.id"
+                  class="form-check mb-2"
+                >
+                  <input
+                    class="form-check-input"
+                    type="checkbox"
+                    :id="'delete-combinator-' + item.id"
+                    :value="item.id"
+                    v-model="selectedDeleteCombinators"
+                  />
+                  <label
+                    class="form-check-label"
+                    :for="'delete-combinator-' + item.id"
+                  >
+                    Delete {{ item.name }} ({{ item.project }})
+                  </label>
+                  <div class="text-muted small">
+                    Referenced in {{ item.referenced_in.join(', ') }} group.
+                  </div>
+                </div>
+              </div>
+
+              <div v-if="autoDeleteCombinators.length > 0" class="mt-3">
+                <div
+                  v-if="manualDeleteCombinators.length > 0"
+                  class="alert alert-warning"
+                >
+                  These Combinators would have no included lists left, so they
+                  will be deleted automatically.
+                </div>
+                <ul class="mb-0">
+                  <li
+                    v-for="item in autoDeleteCombinators"
+                    :key="'auto-delete-' + item.id"
+                  >
+                    {{ item.name }} ({{ item.project }})
+                  </li>
+                </ul>
+              </div>
+            </div>
+
+            <div class="form-group mt-4">
+              <label for="delete-confirm-name">
+                Type <strong>{{ deleteBuilderName }}</strong> to confirm
+                deletion.
+              </label>
+              <input
+                id="delete-confirm-name"
+                v-model="deleteConfirmName"
+                type="text"
+                class="form-control"
+                autocomplete="off"
+              />
+            </div>
+
+            <div v-if="deleteSuccess == false" class="errors mb-3">
+              {{ errors }}
+            </div>
+
+            <div class="d-flex justify-content-end">
+              <button
+                id="cancelDeleteButton"
+                type="button"
+                class="btn btn-secondary mr-2"
+                :disabled="deleteProcessing"
+                @click="cancelDelete"
+              >
+                Cancel
+              </button>
+              <button
+                id="confirmDeleteButton"
+                type="button"
+                class="btn btn-danger"
+                :disabled="!deleteConfirmationMatches || deleteProcessing"
+                @click="confirmDelete"
+              >
+                Delete List
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -220,11 +346,16 @@ export default {
       serverError: false,
       wikiProjects: [],
       processing: false,
+      deleteProcessing: false,
       loaderColor: '#007bff',
       loaderSize: '.75rem',
       success: true,
       deleteSuccess: true,
       errors: '',
+      showDeleteDialog: false,
+      deleteImpact: null,
+      deleteConfirmName: '',
+      selectedDeleteCombinators: [],
       builder: {
         name: '',
         project: 'en.wikipedia.org',
@@ -254,6 +385,31 @@ export default {
         this.isEditing &&
         !this.builder.selection_errors.some((item) => item.status == 'FAILED')
       );
+    },
+    affectedCombinators: function () {
+      if (!this.deleteImpact || !this.deleteImpact.affected_combinators) {
+        return [];
+      }
+      return this.deleteImpact.affected_combinators;
+    },
+    manualDeleteCombinators: function () {
+      return this.affectedCombinators.filter(
+        (item) => !item.will_be_auto_deleted
+      );
+    },
+    autoDeleteCombinators: function () {
+      return this.affectedCombinators.filter(
+        (item) => item.will_be_auto_deleted
+      );
+    },
+    deleteBuilderName: function () {
+      if (this.deleteImpact && this.deleteImpact.builder) {
+        return this.deleteImpact.builder.name;
+      }
+      return this.builder.name;
+    },
+    deleteConfirmationMatches: function () {
+      return this.deleteConfirmName === this.deleteBuilderName;
     },
   },
   created: function () {
@@ -350,30 +506,107 @@ export default {
       }
     },
     onDelete: async function () {
-      if (
-        !window.confirm(
-          'Really delete this list? The definition and all downloadable selections will be permanently deleted.'
-        )
-      ) {
+      this.deleteSuccess = true;
+      this.errors = '';
+      this.deleteProcessing = true;
+
+      const impactUrl = `${import.meta.env.VITE_API_URL}/builders/${
+        this.$route.params.builder_id
+      }/delete-impact`;
+      let response = null;
+      try {
+        response = await fetch(impactUrl, {
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+        });
+      } catch (e) {
+        this.deleteSuccess = false;
+        this.errors = 'Could not check delete impact. Please try again.';
+        this.deleteProcessing = false;
         return;
       }
 
-      const postUrl = `${import.meta.env.VITE_API_URL}/builders/${
-        this.$route.params.builder_id
-      }/delete`;
-      const response = await fetch(postUrl, {
-        method: 'post',
-        credentials: 'include',
-      });
-
-      if (response.status == 200) {
-        this.$router.push('/selections/user');
-        return;
-      } else if (response.status == 404 || response.status == 401) {
+      this.deleteProcessing = false;
+      if (
+        response.status == 404 ||
+        response.status == 401 ||
+        response.status == 403
+      ) {
         this.deleteSuccess = false;
         this.errors =
           "Could not delete this list. Check that the list still exists and you're logged in as its owner.";
         return;
+      }
+      if (!response.ok) {
+        this.deleteSuccess = false;
+        this.errors = 'Could not check delete impact. Please try again.';
+        return;
+      }
+
+      this.deleteImpact = await response.json();
+      this.selectedDeleteCombinators = [];
+      this.deleteConfirmName = '';
+      this.showDeleteDialog = true;
+    },
+    cancelDelete: function () {
+      if (this.deleteProcessing) {
+        return;
+      }
+      this.showDeleteDialog = false;
+      this.deleteConfirmName = '';
+      this.selectedDeleteCombinators = [];
+    },
+    confirmDelete: async function () {
+      if (!this.deleteConfirmationMatches) {
+        return;
+      }
+
+      this.deleteSuccess = true;
+      this.errors = '';
+      this.deleteProcessing = true;
+      const postUrl = `${import.meta.env.VITE_API_URL}/builders/${
+        this.$route.params.builder_id
+      }/delete`;
+      let response = null;
+      try {
+        response = await fetch(postUrl, {
+          headers: { 'Content-Type': 'application/json' },
+          method: 'post',
+          credentials: 'include',
+          body: JSON.stringify({
+            delete_combinator_ids: this.selectedDeleteCombinators,
+            confirm_builder_name: this.deleteConfirmName,
+          }),
+        });
+      } catch (e) {
+        this.deleteSuccess = false;
+        this.errors = 'Could not delete this list. Please try again.';
+        this.deleteProcessing = false;
+        return;
+      }
+
+      this.deleteProcessing = false;
+
+      if (response.status == 200) {
+        this.$router.push('/selections/user');
+        return;
+      } else if (
+        response.status == 404 ||
+        response.status == 401 ||
+        response.status == 403
+      ) {
+        this.deleteSuccess = false;
+        this.errors =
+          "Could not delete this list. Check that the list still exists and you're logged in as its owner.";
+        return;
+      }
+
+      this.deleteSuccess = false;
+      try {
+        const data = await response.json();
+        this.errors = (data.error_messages || []).join(', ');
+      } catch (e) {
+        this.errors = 'Could not delete this list. Please try again.';
       }
     },
   },
@@ -390,5 +623,25 @@ export default {
 }
 .loader {
   margin-left: 1rem;
+}
+
+.delete-dialog-backdrop {
+  align-items: flex-start;
+  background: rgba(0, 0, 0, 0.45);
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  left: 0;
+  overflow-y: auto;
+  padding: 3rem 1rem;
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: 1050;
+}
+
+.delete-dialog {
+  max-width: 720px;
+  width: 100%;
 }
 </style>

--- a/wp1-frontend/src/components/BaseBuilder.vue
+++ b/wp1-frontend/src/components/BaseBuilder.vue
@@ -208,70 +208,68 @@
             </p>
 
             <div
-              v-if="affectedCombinators.length === 0"
-              class="alert alert-info"
+              v-if="affectedCombinators.length > 0"
+              id="affected-combinators"
             >
-              No Combinator selections reference this list.
-            </div>
-            <div v-else id="affected-combinators">
-              <div
-                v-if="manualDeleteCombinators.length > 0"
-                class="alert alert-warning"
-              >
-                This list is used by one or more Combinators. Choose which
-                Combinators to delete below. Any Combinator you leave unchecked
-                will be kept, but this list will be removed from it.
-              </div>
-              <div v-else class="alert alert-warning">
-                This list is used by one or more Combinators. They would have no
-                included lists left, so they will be deleted automatically.
+              <div class="alert alert-warning">
+                This list is used by one or more Combinators. You must remove
+                the list from the Combinator(s) or delete the Combinator(s)
+                completely. Choose below.
               </div>
 
-              <div v-if="manualDeleteCombinators.length > 0">
-                <div
-                  v-for="item in manualDeleteCombinators"
-                  :key="'manual-delete-' + item.id"
-                  class="form-check mb-2"
-                >
+              <div
+                v-for="item in affectedCombinators"
+                :key="'affected-combinator-' + item.id"
+                class="delete-combinator-choice border rounded p-3 mb-3"
+              >
+                <div class="font-weight-bold mb-2">
+                  <span
+                    v-if="!item.will_be_auto_deleted"
+                    :id="'decision-required-' + item.id"
+                    class="text-danger"
+                    aria-hidden="true"
+                  >
+                    *
+                  </span>
+                  {{ item.name }} ({{ item.project }})
+                </div>
+                <div class="form-check">
                   <input
                     class="form-check-input"
-                    type="checkbox"
-                    :id="'delete-combinator-' + item.id"
-                    :value="item.id"
-                    v-model="selectedDeleteCombinators"
+                    type="radio"
+                    :id="'remove-builder-' + item.id"
+                    :name="'delete-action-' + item.id"
+                    :disabled="item.will_be_auto_deleted"
+                    :checked="deleteCombinatorAction(item) === 'remove'"
+                    @change="setDeleteCombinatorAction(item.id, 'remove')"
                   />
                   <label
                     class="form-check-label"
+                    :for="'remove-builder-' + item.id"
+                  >
+                    Remove {{ deleteBuilderName }} from this combinator
+                  </label>
+                </div>
+                <div class="form-check">
+                  <input
+                    class="form-check-input"
+                    type="radio"
+                    :id="'delete-combinator-' + item.id"
+                    :name="'delete-action-' + item.id"
+                    :checked="deleteCombinatorAction(item) === 'delete'"
+                    @change="setDeleteCombinatorAction(item.id, 'delete')"
+                  />
+                  <label
+                    class="form-check-label text-danger"
                     :for="'delete-combinator-' + item.id"
                   >
-                    Delete {{ item.name }} ({{ item.project }})
+                    Delete this Combinator completely
                   </label>
-                  <div class="text-muted small">
-                    Referenced in {{ item.referenced_in.join(', ') }} group.
-                  </div>
                 </div>
-              </div>
-
-              <div v-if="autoDeleteCombinators.length > 0" class="mt-3">
-                <div
-                  v-if="manualDeleteCombinators.length > 0"
-                  class="alert alert-warning"
-                >
-                  These Combinators would have no included lists left, so they
-                  will be deleted automatically.
-                </div>
-                <ul class="mb-0">
-                  <li
-                    v-for="item in autoDeleteCombinators"
-                    :key="'auto-delete-' + item.id"
-                  >
-                    {{ item.name }} ({{ item.project }})
-                  </li>
-                </ul>
               </div>
             </div>
 
-            <div class="form-group mt-4">
+            <div v-if="requiresDeleteConfirmation" class="form-group mt-4">
               <label for="delete-confirm-name">
                 Type <strong>{{ deleteBuilderName }}</strong> to confirm
                 deletion.
@@ -303,7 +301,7 @@
                 id="confirmDeleteButton"
                 type="button"
                 class="btn btn-danger"
-                :disabled="!deleteConfirmationMatches || deleteProcessing"
+                :disabled="!canConfirmDelete"
                 @click="confirmDelete"
               >
                 Delete List
@@ -355,7 +353,7 @@ export default {
       showDeleteDialog: false,
       deleteImpact: null,
       deleteConfirmName: '',
-      selectedDeleteCombinators: [],
+      deleteCombinatorActions: {},
       builder: {
         name: '',
         project: 'en.wikipedia.org',
@@ -392,16 +390,6 @@ export default {
       }
       return this.deleteImpact.affected_combinators;
     },
-    manualDeleteCombinators: function () {
-      return this.affectedCombinators.filter(
-        (item) => !item.will_be_auto_deleted
-      );
-    },
-    autoDeleteCombinators: function () {
-      return this.affectedCombinators.filter(
-        (item) => item.will_be_auto_deleted
-      );
-    },
     deleteBuilderName: function () {
       if (this.deleteImpact && this.deleteImpact.builder) {
         return this.deleteImpact.builder.name;
@@ -410,6 +398,35 @@ export default {
     },
     deleteConfirmationMatches: function () {
       return this.deleteConfirmName === this.deleteBuilderName;
+    },
+    requiresDeleteConfirmation: function () {
+      return this.affectedCombinators.length > 0;
+    },
+    allCombinatorActionsSelected: function () {
+      return this.affectedCombinators.every(
+        (item) =>
+          item.will_be_auto_deleted || this.deleteCombinatorActions[item.id]
+      );
+    },
+    selectedDeleteCombinators: function () {
+      return this.affectedCombinators
+        .filter(
+          (item) =>
+            !item.will_be_auto_deleted &&
+            this.deleteCombinatorActions[item.id] === 'delete'
+        )
+        .map((item) => item.id);
+    },
+    canConfirmDelete: function () {
+      if (this.deleteProcessing) {
+        return false;
+      }
+      if (!this.requiresDeleteConfirmation) {
+        return true;
+      }
+      return (
+        this.deleteConfirmationMatches && this.allCombinatorActionsSelected
+      );
     },
   },
   created: function () {
@@ -505,6 +522,15 @@ export default {
         event.target.classList.add('is-invalid');
       }
     },
+    deleteCombinatorAction: function (item) {
+      if (item.will_be_auto_deleted) {
+        return 'delete';
+      }
+      return this.deleteCombinatorActions[item.id] || '';
+    },
+    setDeleteCombinatorAction: function (id, action) {
+      this.$set(this.deleteCombinatorActions, id, action);
+    },
     onDelete: async function () {
       this.deleteSuccess = true;
       this.errors = '';
@@ -544,7 +570,7 @@ export default {
       }
 
       this.deleteImpact = await response.json();
-      this.selectedDeleteCombinators = [];
+      this.deleteCombinatorActions = {};
       this.deleteConfirmName = '';
       this.showDeleteDialog = true;
     },
@@ -554,10 +580,10 @@ export default {
       }
       this.showDeleteDialog = false;
       this.deleteConfirmName = '';
-      this.selectedDeleteCombinators = [];
+      this.deleteCombinatorActions = {};
     },
     confirmDelete: async function () {
-      if (!this.deleteConfirmationMatches) {
+      if (!this.canConfirmDelete) {
         return;
       }
 
@@ -567,16 +593,19 @@ export default {
       const postUrl = `${import.meta.env.VITE_API_URL}/builders/${
         this.$route.params.builder_id
       }/delete`;
+      const body = {
+        delete_combinator_ids: this.selectedDeleteCombinators,
+      };
+      if (this.requiresDeleteConfirmation) {
+        body.confirm_builder_name = this.deleteConfirmName;
+      }
       let response = null;
       try {
         response = await fetch(postUrl, {
           headers: { 'Content-Type': 'application/json' },
           method: 'post',
           credentials: 'include',
-          body: JSON.stringify({
-            delete_combinator_ids: this.selectedDeleteCombinators,
-            confirm_builder_name: this.deleteConfirmName,
-          }),
+          body: JSON.stringify(body),
         });
       } catch (e) {
         this.deleteSuccess = false;

--- a/wp1-frontend/src/components/BaseBuilder.vue
+++ b/wp1-frontend/src/components/BaseBuilder.vue
@@ -569,7 +569,13 @@ export default {
         return;
       }
 
-      this.deleteImpact = await response.json();
+      try {
+        this.deleteImpact = await response.json();
+      } catch (e) {
+        this.deleteSuccess = false;
+        this.errors = 'Could not check delete impact. Please try again.';
+        return;
+      }
       this.deleteCombinatorActions = {};
       this.deleteConfirmName = '';
       this.showDeleteDialog = true;

--- a/wp1/exceptions.py
+++ b/wp1/exceptions.py
@@ -48,5 +48,9 @@ class UserNotAuthorizedError(Wp1Error):
     pass
 
 
+class BuilderDeleteConfirmationError(Wp1Error):
+    pass
+
+
 class Wp1ScoreProcessingError(Wp1Error):
     pass

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -305,6 +305,22 @@ def _update_builder_params(
     return rowcount > 0
 
 
+def _enqueue_combinator_materializations(
+    redis: Redis, combinators: list[Builder]
+) -> list[str]:
+    combinator_cls = None
+    enqueued_combinator_ids = []
+    for combinator in combinators:
+        if combinator_cls is None:
+            combinator_cls = get_builder_module_class(combinator.model)
+        queues.enqueue_materialize(
+            redis, combinator_cls, combinator, "text/tab-separated-values"
+        )
+        enqueued_combinator_ids.append(combinator.id)
+
+    return enqueued_combinator_ids
+
+
 def _combine_delete_status(aggregate: dict[str, Any], current: dict[str, bool]) -> None:
     for key in (
         "db_delete_success",
@@ -457,13 +473,9 @@ def delete_builder(
         if changed and _update_builder_params(wp10db, record["builder"], params):
             updated_combinators.append(record["builder"])
 
-    combinator_cls = None
-    for combinator in updated_combinators:
-        if combinator_cls is None:
-            combinator_cls = get_builder_module_class(combinator.model)
-        queues.enqueue_materialize(
-            redis, combinator_cls, combinator, "text/tab-separated-values"
-        )
+    updated_combinator_ids = _enqueue_combinator_materializations(
+        redis, updated_combinators
+    )
 
     status.update(
         {
@@ -473,9 +485,7 @@ def delete_builder(
             "auto_deleted_combinator_ids": [
                 record["id"] for record in auto_delete_records
             ],
-            "updated_combinator_ids": [
-                combinator.id for combinator in updated_combinators
-            ],
+            "updated_combinator_ids": updated_combinator_ids,
         }
     )
     return status

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -54,6 +54,147 @@ def is_meta_builder(builder: Builder) -> bool:
     return builder.model in META_BUILDER_MODELS
 
 
+def _assert_builder_owner(builder: Builder, user_id: str | bytes | int) -> None:
+    user_id_str = logic_util.as_text(user_id)
+    if builder.user_id == user_id_str:
+        return
+
+    msg = "User %s is not authorized to delete builder %s" % (
+        user_id_str,
+        builder.id,
+    )
+    logger.warning(msg)
+    raise UserNotAuthorizedError(msg)
+
+
+def _group_builder_ids(params: dict[str, Any], group_name: str) -> list[str]:
+    group = params.get(group_name)
+    if not isinstance(group, dict):
+        return []
+
+    builders = group.get("builders", [])
+    if not isinstance(builders, list):
+        return []
+
+    return [builder_id for builder_id in builders if isinstance(builder_id, str)]
+
+
+def _remove_builder_reference_from_params(
+    params: dict[str, Any], target_builder_id: str
+) -> tuple[dict[str, Any], bool]:
+    changed = False
+    for group_name in ("include", "exclude"):
+        group = params.get(group_name)
+        if not isinstance(group, dict):
+            continue
+
+        builders = group.get("builders", [])
+        if not isinstance(builders, list):
+            continue
+
+        filtered_builders = [
+            builder_id for builder_id in builders if builder_id != target_builder_id
+        ]
+        if filtered_builders != builders:
+            group["builders"] = filtered_builders
+            changed = True
+
+    return params, changed
+
+
+def _combinator_reference_record(
+    combinator: Builder, target_builder_id: str
+) -> dict[str, Any] | None:
+    try:
+        params = json.loads(combinator.b_params or b"{}")
+    except json.decoder.JSONDecodeError:
+        logger.warning("Could not parse params for builder id=%s", combinator.id)
+        return None
+
+    if not isinstance(params, dict):
+        return None
+
+    include_builders = _group_builder_ids(params, "include")
+    exclude_builders = _group_builder_ids(params, "exclude")
+
+    referenced_in = []
+    if target_builder_id in include_builders:
+        referenced_in.append("include")
+    if target_builder_id in exclude_builders:
+        referenced_in.append("exclude")
+
+    if not referenced_in:
+        return None
+
+    remaining_include_builders = [
+        builder_id for builder_id in include_builders if builder_id != target_builder_id
+    ]
+    return {
+        "builder": combinator,
+        "params": params,
+        "id": combinator.id,
+        "name": combinator.name,
+        "project": combinator.project,
+        "referenced_in": referenced_in,
+        "remaining_include_builder_count": len(remaining_include_builders),
+        "will_be_auto_deleted": len(remaining_include_builders) == 0,
+    }
+
+
+def _find_referencing_combinators(
+    wp10db: Connection, user_id: str | bytes | int, builder_id: str | bytes
+) -> list[dict[str, Any]]:
+    target_builder_id = logic_util.as_text(builder_id)
+    user_id_str = logic_util.as_text(user_id)
+
+    with wp10db.cursor() as cursor:
+        cursor.execute(
+            """SELECT * FROM builders
+           WHERE b_user_id = %s AND b_model = %s
+        """,
+            (user_id_str, "wp1.selection.models.combinator"),
+        )
+        combinators = [Builder(**row) for row in cursor.fetchall()]
+
+    records = []
+    for combinator in combinators:
+        if combinator.id == target_builder_id:
+            continue
+        record = _combinator_reference_record(combinator, target_builder_id)
+        if record is not None:
+            records.append(record)
+    return records
+
+
+def get_builder_delete_impact(
+    wp10db: Connection, user_id: str | bytes | int, builder_id: str | bytes
+) -> dict[str, Any]:
+    builder = get_builder(wp10db, builder_id)
+    _assert_builder_owner(builder, user_id)
+
+    return {
+        "builder": {
+            "id": builder.id,
+            "name": builder.name,
+            "project": builder.project,
+            "model": builder.model,
+        },
+        "affected_combinators": [
+            {
+                "id": record["id"],
+                "name": record["name"],
+                "project": record["project"],
+                "referenced_in": record["referenced_in"],
+                "remaining_include_builder_count": record[
+                    "remaining_include_builder_count"
+                ],
+                "will_be_auto_deleted": record["will_be_auto_deleted"],
+            }
+            for record in _find_referencing_combinators(wp10db, user_id, builder.id)
+        ],
+    }
+
+
 def get_builder_module_class(model: str) -> type[AbstractBuilder]:
     """Dynamically imports the builder module and returns the Builder class."""
     builder_module = importlib.import_module(model)
@@ -146,31 +287,47 @@ def update_builder(wp10db: Connection, builder: Builder) -> bool:
     return rowcount > 0
 
 
-def delete_builder(
-    wp10db: Connection, user_id: str | bytes, builder_id: str | bytes
+def _update_builder_params(
+    wp10db: Connection, builder: Builder, params: dict[str, Any]
+) -> bool:
+    builder.b_params = json.dumps(params).encode("utf-8")
+    builder.set_updated_at_now()
+    with wp10db.cursor() as cursor:
+        cursor.execute(
+            """UPDATE builders
+           SET b_params = %s, b_updated_at = %s
+           WHERE b_id = %s AND b_user_id = %s
+        """,
+            (builder.b_params, builder.b_updated_at, builder.b_id, builder.b_user_id),
+        )
+        rowcount = cursor.rowcount
+    wp10db.commit()
+    return rowcount > 0
+
+
+def _combine_delete_status(aggregate: dict[str, Any], current: dict[str, bool]) -> None:
+    for key in (
+        "db_delete_success",
+        "s3_delete_success",
+        "zimfarm_delete_success",
+        "rq_cancel_success",
+    ):
+        aggregate[key] = aggregate[key] and current[key]
+
+
+def _delete_builder_and_assets(
+    wp10db: Connection,
+    redis: Redis,
+    user_id: str | bytes | int,
+    builder_id: str | bytes,
 ) -> dict[str, bool]:
     if not isinstance(builder_id, bytes):
         builder_id = str(builder_id).encode("utf-8")
 
     # Fail fast if the Builder doesn't even exist
-    try:
-        builder = get_builder(wp10db, builder_id)
-    except ObjectNotFoundError:
-        raise
-
-    user_id_str = (
-        user_id.decode("utf-8") if isinstance(user_id, bytes) else str(user_id)
-    )
-    if builder.b_user_id.decode("utf-8") != user_id_str:
-        msg = "User %s is not authorized to delete builder %s" % (
-            user_id_str,
-            builder_id.decode("utf-8"),
-        )
-        logger.warning(msg)
-        raise UserNotAuthorizedError(msg)
-
-    # Connect to Redis for zimfarm operations
-    redis = redis_connect()
+    builder = get_builder(wp10db, builder_id)
+    _assert_builder_owner(builder, user_id)
+    user_id_str = logic_util.as_text(user_id)
 
     # Try to delete the zimfarm schedule first (before deleting from DB)
     zimfarm_delete_success = True
@@ -219,7 +376,7 @@ def delete_builder(
            WHERE b.b_user_id = %s AND b.b_id = %s
              AND s.s_object_key IS NOT NULL
         """,
-            (user_id, builder_id),
+            (user_id_str, builder_id),
         )
         keys_to_delete = [d["object_key"] for d in cursor.fetchall()]
         cursor.execute(
@@ -227,7 +384,7 @@ def delete_builder(
            LEFT JOIN selections AS s ON s.s_builder_id = b.b_id
            WHERE b.b_user_id = %s AND b.b_id = %s
         """,
-            (user_id, builder_id),
+            (user_id_str, builder_id),
         )
         rowcount = cursor.rowcount
 
@@ -241,6 +398,87 @@ def delete_builder(
         "zimfarm_delete_success": zimfarm_delete_success,
         "rq_cancel_success": rq_cancel_success,
     }
+
+
+def delete_builder(
+    wp10db: Connection,
+    user_id: str | bytes | int,
+    builder_id: str | bytes,
+    delete_combinator_ids: list[str] | None = None,
+    confirm_builder_name: str | None = None,
+) -> dict[str, Any]:
+    if not isinstance(builder_id, bytes):
+        builder_id = str(builder_id).encode("utf-8")
+    builder = get_builder(wp10db, builder_id)
+    _assert_builder_owner(builder, user_id)
+
+    if confirm_builder_name is not None and confirm_builder_name != builder.name:
+        raise ValueError("Builder name confirmation did not match")
+
+    redis = redis_connect()
+
+    selected_combinator_ids = {
+        logic_util.as_text(combinator_id)
+        for combinator_id in (delete_combinator_ids or [])
+    }
+    referencing_records = _find_referencing_combinators(wp10db, user_id, builder.id)
+
+    selected_delete_records = []
+    auto_delete_records = []
+    kept_records = []
+    for record in referencing_records:
+        if record["id"] in selected_combinator_ids:
+            selected_delete_records.append(record)
+        elif record["will_be_auto_deleted"]:
+            auto_delete_records.append(record)
+        else:
+            kept_records.append(record)
+
+    status: dict[str, Any] = {
+        "db_delete_success": True,
+        "s3_delete_success": True,
+        "zimfarm_delete_success": True,
+        "rq_cancel_success": True,
+    }
+    for record in selected_delete_records + auto_delete_records:
+        _combine_delete_status(
+            status, _delete_builder_and_assets(wp10db, redis, user_id, record["id"])
+        )
+
+    _combine_delete_status(
+        status, _delete_builder_and_assets(wp10db, redis, user_id, builder_id)
+    )
+
+    updated_combinators = []
+    for record in kept_records:
+        params, changed = _remove_builder_reference_from_params(
+            record["params"], builder.id
+        )
+        if changed and _update_builder_params(wp10db, record["builder"], params):
+            updated_combinators.append(record["builder"])
+
+    combinator_cls = None
+    for combinator in updated_combinators:
+        if combinator_cls is None:
+            combinator_cls = get_builder_module_class(combinator.model)
+        queues.enqueue_materialize(
+            redis, combinator_cls, combinator, "text/tab-separated-values"
+        )
+
+    status.update(
+        {
+            "deleted_combinator_ids": [
+                record["id"] for record in selected_delete_records
+            ],
+            "auto_deleted_combinator_ids": [
+                record["id"] for record in auto_delete_records
+            ],
+            "updated_combinator_ids": [
+                combinator.id for combinator in updated_combinators
+            ],
+        }
+    )
+    return status
 
 
 def get_builder(wp10db: Connection, id_: str | bytes) -> Builder:

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -23,7 +23,12 @@ from wp1.constants import (
 )
 from wp1.credentials import CREDENTIALS, ENV
 from wp1.environment import Environment
-from wp1.exceptions import ObjectNotFoundError, UserNotAuthorizedError, ZimFarmError
+from wp1.exceptions import (
+    BuilderDeleteConfirmationError,
+    ObjectNotFoundError,
+    UserNotAuthorizedError,
+    ZimFarmError,
+)
 from wp1.models.wp10.builder import Builder
 from wp1.models.wp10.selection import Selection
 from wp1.models.wp10.zim_file import ZimTask
@@ -429,7 +434,7 @@ def delete_builder(
     _assert_builder_owner(builder, user_id)
 
     if confirm_builder_name is not None and confirm_builder_name != builder.name:
-        raise ValueError("Builder name confirmation did not match")
+        raise BuilderDeleteConfirmationError("Builder name confirmation did not match")
 
     redis = redis_connect()
 

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 from unittest.mock import ANY, MagicMock, call, patch
 
 import attr
@@ -184,6 +185,51 @@ class BuilderTest(BaseWpOneDbTest):
             )
         self.wp10db.commit()
         return value_dict["b_id"]
+
+    def _insert_builder_record(
+        self,
+        id_,
+        name,
+        user_id="1234",
+        project="en.wikipedia.fake",
+        model="wp1.selection.models.simple",
+        params=None,
+        current_version=0,
+    ):
+        if params is None:
+            params = {"list": ["a", "b", "c"]}
+        with self.wp10db.cursor() as cursor:
+            cursor.execute(
+                """INSERT INTO builders
+               (b_id, b_name, b_user_id, b_project, b_params, b_model,
+                b_created_at, b_updated_at, b_current_version,
+                b_selection_zim_version)
+             VALUES
+               (%s, %s, %s, %s, %s, %s,
+                '20191225044444', '20191225044444', %s, 0)
+          """,
+                (
+                    id_.encode("utf-8"),
+                    name.encode("utf-8"),
+                    str(user_id).encode("utf-8"),
+                    project.encode("utf-8"),
+                    json.dumps(params).encode("utf-8"),
+                    model.encode("utf-8"),
+                    current_version,
+                ),
+            )
+        self.wp10db.commit()
+        return id_.encode("utf-8")
+
+    def _get_builder_params(self, builder_id):
+        with self.wp10db.cursor() as cursor:
+            cursor.execute(
+                "SELECT b_params FROM builders WHERE b_id = %s", (builder_id,)
+            )
+            row = cursor.fetchone()
+        if row is None:
+            return None
+        return json.loads(row["b_params"].decode("utf-8"))
 
     def _insert_zim_schedule(
         self,
@@ -854,6 +900,230 @@ class BuilderTest(BaseWpOneDbTest):
 
         self.assertIsNone(actual)
 
+    def test_get_builder_delete_impact_no_references(self):
+        self._insert_builder_record("target-builder", "Target Builder")
+
+        actual = logic_builder.get_builder_delete_impact(
+            self.wp10db, "1234", "target-builder"
+        )
+
+        self.assertEqual(
+            {
+                "builder": {
+                    "id": "target-builder",
+                    "name": "Target Builder",
+                    "project": "en.wikipedia.fake",
+                    "model": "wp1.selection.models.simple",
+                },
+                "affected_combinators": [],
+            },
+            actual,
+        )
+
+    def test_get_builder_delete_impact_with_references(self):
+        self._insert_builder_record("target-builder", "Target Builder")
+        self._insert_builder_record("other-builder", "Other Builder")
+        self._insert_builder_record(
+            "combo-keep",
+            "Keep Combo",
+            model="wp1.selection.models.combinator",
+            params={
+                "include": {
+                    "builders": ["target-builder", "other-builder"],
+                    "operation": "union",
+                },
+                "exclude": {"builders": ["target-builder"], "operation": "union"},
+            },
+        )
+        self._insert_builder_record(
+            "combo-empty",
+            "Empty Combo",
+            model="wp1.selection.models.combinator",
+            params={
+                "include": {"builders": ["target-builder"], "operation": "union"},
+                "exclude": {"builders": [], "operation": "union"},
+            },
+        )
+
+        actual = logic_builder.get_builder_delete_impact(
+            self.wp10db, "1234", "target-builder"
+        )
+        affected = sorted(actual["affected_combinators"], key=lambda item: item["id"])
+
+        self.assertEqual(
+            [
+                {
+                    "id": "combo-empty",
+                    "name": "Empty Combo",
+                    "project": "en.wikipedia.fake",
+                    "referenced_in": ["include"],
+                    "remaining_include_builder_count": 0,
+                    "will_be_auto_deleted": True,
+                },
+                {
+                    "id": "combo-keep",
+                    "name": "Keep Combo",
+                    "project": "en.wikipedia.fake",
+                    "referenced_in": ["include", "exclude"],
+                    "remaining_include_builder_count": 1,
+                    "will_be_auto_deleted": False,
+                },
+            ],
+            affected,
+        )
+
+    @patch("wp1.logic.builder.queues.enqueue_materialize")
+    @patch("wp1.logic.builder.queues.cancel_scheduled_job")
+    @patch("wp1.logic.builder.zimfarm.delete_zimfarm_schedule_by_builder_id")
+    @patch("wp1.logic.builder.logic_selection.delete_keys_from_storage")
+    def test_delete_builder_updates_kept_combinator(
+        self, mock_delete_keys, mock_delete_schedule, mock_cancel_job, mock_enqueue
+    ):
+        mock_delete_keys.return_value = True
+        self._insert_builder_record("target-builder", "Target Builder")
+        self._insert_builder_record("other-builder", "Other Builder")
+        self._insert_builder_record(
+            "combo-keep",
+            "Keep Combo",
+            model="wp1.selection.models.combinator",
+            params={
+                "include": {
+                    "builders": ["target-builder", "other-builder"],
+                    "operation": "union",
+                },
+                "exclude": {"builders": ["target-builder"], "operation": "union"},
+            },
+        )
+
+        actual = logic_builder.delete_builder(
+            self.wp10db,
+            "1234",
+            "target-builder",
+            confirm_builder_name="Target Builder",
+        )
+
+        self.assertTrue(actual["db_delete_success"])
+        self.assertEqual(["combo-keep"], actual["updated_combinator_ids"])
+        self.assertEqual(
+            {
+                "include": {"builders": ["other-builder"], "operation": "union"},
+                "exclude": {"builders": [], "operation": "union"},
+            },
+            self._get_builder_params(b"combo-keep"),
+        )
+        mock_enqueue.assert_called_once()
+
+    @patch("wp1.logic.builder.queues.enqueue_materialize")
+    @patch("wp1.logic.builder.queues.cancel_scheduled_job")
+    @patch("wp1.logic.builder.zimfarm.delete_zimfarm_schedule_by_builder_id")
+    @patch("wp1.logic.builder.logic_selection.delete_keys_from_storage")
+    def test_delete_builder_deletes_selected_combinator(
+        self, mock_delete_keys, mock_delete_schedule, mock_cancel_job, mock_enqueue
+    ):
+        mock_delete_keys.return_value = True
+        self._insert_builder_record("target-builder", "Target Builder")
+        self._insert_builder_record("other-builder", "Other Builder")
+        self._insert_builder_record(
+            "combo-delete",
+            "Delete Combo",
+            model="wp1.selection.models.combinator",
+            params={
+                "include": {
+                    "builders": ["target-builder", "other-builder"],
+                    "operation": "union",
+                },
+                "exclude": {"builders": [], "operation": "union"},
+            },
+        )
+
+        actual = logic_builder.delete_builder(
+            self.wp10db,
+            "1234",
+            "target-builder",
+            delete_combinator_ids=["combo-delete"],
+            confirm_builder_name="Target Builder",
+        )
+
+        self.assertTrue(actual["db_delete_success"])
+        self.assertEqual(["combo-delete"], actual["deleted_combinator_ids"])
+        self.assertIsNone(self._get_builder_params(b"combo-delete"))
+        mock_enqueue.assert_not_called()
+
+    @patch("wp1.logic.builder.queues.enqueue_materialize")
+    @patch("wp1.logic.builder.queues.cancel_scheduled_job")
+    @patch("wp1.logic.builder.zimfarm.delete_zimfarm_schedule_by_builder_id")
+    @patch("wp1.logic.builder.logic_selection.delete_keys_from_storage")
+    def test_delete_builder_auto_deletes_empty_combinator(
+        self, mock_delete_keys, mock_delete_schedule, mock_cancel_job, mock_enqueue
+    ):
+        mock_delete_keys.return_value = True
+        self._insert_builder_record("target-builder", "Target Builder")
+        self._insert_builder_record(
+            "combo-empty",
+            "Empty Combo",
+            model="wp1.selection.models.combinator",
+            params={
+                "include": {"builders": ["target-builder"], "operation": "union"},
+                "exclude": {"builders": [], "operation": "union"},
+            },
+        )
+
+        actual = logic_builder.delete_builder(
+            self.wp10db,
+            "1234",
+            "target-builder",
+            confirm_builder_name="Target Builder",
+        )
+
+        self.assertTrue(actual["db_delete_success"])
+        self.assertEqual(["combo-empty"], actual["auto_deleted_combinator_ids"])
+        self.assertIsNone(self._get_builder_params(b"combo-empty"))
+        mock_enqueue.assert_not_called()
+
+    @patch("wp1.logic.builder.queues.enqueue_materialize")
+    @patch("wp1.logic.builder.queues.cancel_scheduled_job")
+    @patch("wp1.logic.builder.zimfarm.delete_zimfarm_schedule_by_builder_id")
+    @patch("wp1.logic.builder.logic_selection.delete_keys_from_storage")
+    def test_delete_builder_ignores_stale_selected_combinator(
+        self, mock_delete_keys, mock_delete_schedule, mock_cancel_job, mock_enqueue
+    ):
+        mock_delete_keys.return_value = True
+        self._insert_builder_record("target-builder", "Target Builder")
+        self._insert_builder_record("other-builder", "Other Builder")
+        self._insert_builder_record(
+            "combo-stale",
+            "Stale Combo",
+            model="wp1.selection.models.combinator",
+            params={
+                "include": {"builders": ["other-builder"], "operation": "union"},
+                "exclude": {"builders": [], "operation": "union"},
+            },
+        )
+
+        actual = logic_builder.delete_builder(
+            self.wp10db,
+            "1234",
+            "target-builder",
+            delete_combinator_ids=["combo-stale"],
+            confirm_builder_name="Target Builder",
+        )
+
+        self.assertTrue(actual["db_delete_success"])
+        self.assertEqual([], actual["deleted_combinator_ids"])
+        self.assertIsNotNone(self._get_builder_params(b"combo-stale"))
+        mock_enqueue.assert_not_called()
+
+    def test_delete_builder_name_confirmation_mismatch(self):
+        self._insert_builder_record("target-builder", "Target Builder")
+
+        with self.assertRaises(ValueError):
+            logic_builder.delete_builder(
+                self.wp10db,
+                "1234",
+                "target-builder",
+                confirm_builder_name="Wrong Name",
+            )
+
     @patch("wp1.logic.builder.queues.cancel_scheduled_job")
     @patch("wp1.logic.builder.zimfarm.delete_zimfarm_schedule_by_builder_id")
     @patch("wp1.logic.builder.logic_selection")
@@ -990,6 +1260,29 @@ class BuilderTest(BaseWpOneDbTest):
                 b"proper/selection/4321/name.tsv",
             ]
         )
+
+    @patch("wp1.logic.selection.connect_storage")
+    @patch("wp1.logic.builder.queues.cancel_scheduled_job")
+    @patch("wp1.logic.builder.zimfarm.delete_zimfarm_schedule_by_builder_id")
+    def test_delete_builder_retryable_selection_without_object_key(
+        self, mock_delete_schedule, mock_cancel_job, mock_connect_storage
+    ):
+        builder_id = self._insert_builder()
+        self._insert_selection(
+            1,
+            "text/tab-separated-values",
+            object_key=None,
+            builder_id=builder_id,
+            has_errors=True,
+            skip_zim=True,
+        )
+
+        actual = logic_builder.delete_builder(self.wp10db, 1234, builder_id)
+
+        self.assertTrue(actual["db_delete_success"])
+        self.assertTrue(actual["s3_delete_success"])
+        self.assertIsNone(self._get_builder_params(builder_id))
+        mock_connect_storage.assert_not_called()
 
     @patch("wp1.logic.builder.queues.cancel_scheduled_job")
     @patch("wp1.logic.builder.zimfarm.delete_zimfarm_schedule_by_builder_id")

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -7,6 +7,7 @@ import attr
 from wp1.base_db_test import BaseWpOneDbTest
 from wp1.environment import Environment
 from wp1.exceptions import (
+    BuilderDeleteConfirmationError,
     InvalidZimTitleError,
     ObjectNotFoundError,
     UserNotAuthorizedError,
@@ -1116,7 +1117,7 @@ class BuilderTest(BaseWpOneDbTest):
     def test_delete_builder_name_confirmation_mismatch(self):
         self._insert_builder_record("target-builder", "Target Builder")
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(BuilderDeleteConfirmationError):
             logic_builder.delete_builder(
                 self.wp10db,
                 "1234",

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -151,13 +151,20 @@ def delete_keys_from_storage(keys: bytes | list[bytes]) -> bool:
         if isinstance(key, str):
             raise ValueError("Expected keys to all be bytes, not str")
 
-    s3 = connect_storage()
-    resp = s3.bucket.delete_objects(
-        Delete={
-            "Objects": [{"Key": html.escape(k.decode("utf-8"))} for k in keys],
-            "Quiet": True,
-        }
-    )
+    if not keys:
+        return True
+
+    try:
+        s3 = connect_storage()
+        resp = s3.bucket.delete_objects(
+            Delete={
+                "Objects": [{"Key": html.escape(k.decode("utf-8"))} for k in keys],
+                "Quiet": True,
+            }
+        )
+    except Exception:
+        logger.warning("Failed to delete keys from storage", exc_info=True)
+        return False
 
     fully_successful = True
 

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -135,18 +135,50 @@ def get_builder(builder_id):
     return flask.jsonify(res)
 
 
+@builders.route("/<builder_id>/delete-impact")
+@authenticate
+def get_builder_delete_impact(builder_id):
+    wp10db = get_db("wp10db")
+    user_id = flask.session["user"]["identity"]["sub"]
+
+    try:
+        impact = logic_builder.get_builder_delete_impact(wp10db, user_id, builder_id)
+    except UserNotAuthorizedError:
+        flask.abort(403)
+    except ObjectNotFoundError:
+        flask.abort(404)
+
+    return flask.jsonify(impact)
+
+
 @builders.route("/<builder_id>/delete", methods=["POST"])
 @authenticate
 def delete_builder(builder_id):
     wp10db = get_db("wp10db")
     user_id = flask.session["user"]["identity"]["sub"]
+    data = flask.request.get_json(silent=True) or {}
+    delete_combinator_ids = data.get("delete_combinator_ids", [])
+    confirm_builder_name = data.get("confirm_builder_name")
+
+    if not isinstance(delete_combinator_ids, list) or not all(
+        isinstance(item, str) for item in delete_combinator_ids
+    ):
+        return flask.jsonify({"error_messages": ["Invalid delete_combinator_ids"]}), 400
 
     try:
-        status = logic_builder.delete_builder(wp10db, user_id, builder_id)
+        status = logic_builder.delete_builder(
+            wp10db,
+            user_id,
+            builder_id,
+            delete_combinator_ids=delete_combinator_ids,
+            confirm_builder_name=confirm_builder_name,
+        )
     except UserNotAuthorizedError as e:
         flask.abort(403)
     except ObjectNotFoundError:
         flask.abort(404)
+    except ValueError as e:
+        return flask.jsonify({"error_messages": [str(e)]}), 400
 
     if not status["db_delete_success"]:
         return (

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -11,6 +11,7 @@ from wp1 import queues
 from wp1.constants import EXT_TO_CONTENT_TYPE
 from wp1.credentials import CREDENTIALS, ENV
 from wp1.exceptions import (
+    BuilderDeleteConfirmationError,
     InvalidZimDescriptionError,
     InvalidZimFlavourError,
     InvalidZimLongDescriptionError,
@@ -177,7 +178,7 @@ def delete_builder(builder_id):
         flask.abort(403)
     except ObjectNotFoundError:
         flask.abort(404)
-    except ValueError as e:
+    except BuilderDeleteConfirmationError as e:
         return flask.jsonify({"error_messages": [str(e)]}), 400
 
     if not status["db_delete_success"]:

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 from unittest.mock import ANY, MagicMock, patch
 
 import attr
@@ -80,6 +81,44 @@ class BuildersTest(BaseWebTestcase):
             )
         self.wp10db.commit()
         return self.builder.b_id.decode("utf-8")
+
+    def _insert_builder_record(
+        self,
+        id_,
+        name,
+        user_id="1234",
+        project="en.wikipedia.fake",
+        model="wp1.selection.models.simple",
+        params=None,
+    ):
+        if params is None:
+            params = {"list": ["a", "b", "c"]}
+        with self.wp10db.cursor() as cursor:
+            cursor.execute(
+                """INSERT INTO builders
+               (b_id, b_name, b_user_id, b_project, b_params, b_model,
+                b_created_at, b_updated_at, b_current_version,
+                b_selection_zim_version)
+             VALUES
+               (%s, %s, %s, %s, %s, %s,
+                '20191225044444', '20191225044444', 0, 0)
+        """,
+                (
+                    id_.encode("utf-8"),
+                    name.encode("utf-8"),
+                    str(user_id).encode("utf-8"),
+                    project.encode("utf-8"),
+                    json.dumps(params).encode("utf-8"),
+                    model.encode("utf-8"),
+                ),
+            )
+        self.wp10db.commit()
+        return id_
+
+    def _builder_exists(self, builder_id):
+        with self.wp10db.cursor() as cursor:
+            cursor.execute("SELECT 1 FROM builders WHERE b_id = %s", (builder_id,))
+            return cursor.fetchone() is not None
 
     def _insert_selections(self, builder_id):
         selections = [
@@ -496,6 +535,132 @@ class BuildersTest(BaseWebTestcase):
         with self.app.test_client() as client:
             rv = client.get("/v1/builders/%s/selection/latest.tsv" % builder_id)
         self.assertEqual("404 NOT FOUND", rv.status)
+
+    def test_delete_impact_successful(self):
+        self._insert_builder_record("target-builder", "Target Builder")
+        self._insert_builder_record("other-builder", "Other Builder")
+        self._insert_builder_record(
+            "combo-keep",
+            "Keep Combo",
+            model="wp1.selection.models.combinator",
+            params={
+                "include": {
+                    "builders": ["target-builder", "other-builder"],
+                    "operation": "union",
+                },
+                "exclude": {"builders": [], "operation": "union"},
+            },
+        )
+
+        self.app = create_app()
+        with self.override_db(self.app), self.app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess["user"] = self.USER
+            rv = client.get("/v1/builders/target-builder/delete-impact")
+
+        self.assertEqual("200 OK", rv.status)
+        self.assertEqual(
+            {
+                "builder": {
+                    "id": "target-builder",
+                    "name": "Target Builder",
+                    "project": "en.wikipedia.fake",
+                    "model": "wp1.selection.models.simple",
+                },
+                "affected_combinators": [
+                    {
+                        "id": "combo-keep",
+                        "name": "Keep Combo",
+                        "project": "en.wikipedia.fake",
+                        "referenced_in": ["include"],
+                        "remaining_include_builder_count": 1,
+                        "will_be_auto_deleted": False,
+                    }
+                ],
+            },
+            rv.get_json(),
+        )
+
+    def test_delete_impact_not_owner(self):
+        self._insert_builder_record("target-builder", "Target Builder")
+
+        self.app = create_app()
+        with self.override_db(self.app), self.app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess["user"] = self.UNAUTHORIZED_USER
+            rv = client.get("/v1/builders/target-builder/delete-impact")
+
+        self.assertEqual("403 FORBIDDEN", rv.status)
+
+    def test_delete_impact_no_builder(self):
+        self.app = create_app()
+        with self.override_db(self.app), self.app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess["user"] = self.USER
+            rv = client.get("/v1/builders/missing-builder/delete-impact")
+
+        self.assertEqual("404 NOT FOUND", rv.status)
+
+    @patch("wp1.logic.builder.redis_connect")
+    @patch("wp1.logic.selection.connect_storage")
+    def test_delete_with_selected_combinator(
+        self, patched_connect_storage, patched_redis_connect
+    ):
+        patched_redis_connect.return_value = MagicMock()
+        self._insert_builder_record("target-builder", "Target Builder")
+        self._insert_builder_record("other-builder", "Other Builder")
+        self._insert_builder_record(
+            "combo-delete",
+            "Delete Combo",
+            model="wp1.selection.models.combinator",
+            params={
+                "include": {
+                    "builders": ["target-builder", "other-builder"],
+                    "operation": "union",
+                },
+                "exclude": {"builders": [], "operation": "union"},
+            },
+        )
+
+        self.app = create_app()
+        with self.override_db(self.app), self.app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess["user"] = self.USER
+            rv = client.post(
+                "/v1/builders/target-builder/delete",
+                json={
+                    "delete_combinator_ids": ["combo-delete"],
+                    "confirm_builder_name": "Target Builder",
+                },
+            )
+
+        self.assertEqual("200 OK", rv.status)
+        self.assertEqual({"status": "204"}, rv.get_json())
+        self.assertFalse(self._builder_exists("target-builder"))
+        self.assertFalse(self._builder_exists("combo-delete"))
+
+    @patch("wp1.logic.builder.redis_connect")
+    @patch("wp1.logic.selection.connect_storage")
+    def test_delete_confirmation_mismatch(
+        self, patched_connect_storage, patched_redis_connect
+    ):
+        patched_redis_connect.return_value = MagicMock()
+        self._insert_builder_record("target-builder", "Target Builder")
+
+        self.app = create_app()
+        with self.override_db(self.app), self.app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess["user"] = self.USER
+            rv = client.post(
+                "/v1/builders/target-builder/delete",
+                json={"confirm_builder_name": "Wrong Name"},
+            )
+
+        self.assertEqual("400 BAD REQUEST", rv.status)
+        self.assertEqual(
+            {"error_messages": ["Builder name confirmation did not match"]},
+            rv.get_json(),
+        )
 
     @patch("wp1.logic.builder.redis_connect")
     @patch("wp1.logic.selection.connect_storage")


### PR DESCRIPTION
**Problem**

Deleting a list that is used by Combinators could leave broken references or make Combinators invalid when they have no included lists left.

**Summary**
- Adds a delete-impact API endpoint to preview affected Combinators before deleting a list.
- Extends list deletion to accept selected Combinator IDs and optional name confirmation.
- Re-checks Combinator references during final delete so stale preview data is not trusted.
- Deletes selected Combinators and auto-deletes Combinators that would have no included lists left.
- Updates kept Combinators by removing the deleted list reference and rematerialize them.

fixed https://github.com/openzim/wp1/issues/1178