### PR TITLE
Auto update combinator

### DIFF
--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -310,9 +310,27 @@ def _update_builder_params(
     return rowcount > 0
 
 
-def _enqueue_combinator_materializations(
-    redis: Redis, combinators: list[Builder]
-) -> list[str]:
+def _mark_combinator_pending_rebuild(wp10db: Connection, combinator: Builder) -> bool:
+    # The list UI treats builders newer than their latest selection as pending.
+    combinator = attr.evolve(combinator)
+    combinator.set_updated_at_now()
+    if combinator.b_id is None:
+        raise ValueError("Cannot update combinator without b_id")
+
+    with wp10db.cursor() as cursor:
+        cursor.execute(
+            """UPDATE builders
+           SET b_updated_at = %s
+           WHERE b_id = %s AND b_user_id = %s
+        """,
+            (combinator.b_updated_at, combinator.b_id, combinator.b_user_id),
+        )
+        rowcount = cursor.rowcount
+    wp10db.commit()
+    return rowcount > 0
+
+
+def _enqueue_combinator_rebuilds(redis: Redis, combinators: list[Builder]) -> list[str]:
     combinator_cls = None
     enqueued_combinator_ids = []
     for combinator in combinators:
@@ -322,6 +340,24 @@ def _enqueue_combinator_materializations(
             redis, combinator_cls, combinator, "text/tab-separated-values"
         )
         enqueued_combinator_ids.append(combinator.id)
+
+    return enqueued_combinator_ids
+
+
+def _rebuild_referencing_combinators(
+    redis: Redis, wp10db: Connection, builder: Builder
+) -> list[str]:
+    referencing_records = _find_referencing_combinators(
+        wp10db, builder.user_id, builder.id
+    )
+
+    enqueued_combinator_ids = []
+    for record in referencing_records:
+        combinator = record["builder"]
+        enqueued_combinator_ids.extend(
+            _enqueue_combinator_rebuilds(redis, [combinator])
+        )
+        _mark_combinator_pending_rebuild(wp10db, combinator)
 
     return enqueued_combinator_ids
 
@@ -478,9 +514,7 @@ def delete_builder(
         if changed and _update_builder_params(wp10db, record["builder"], params):
             updated_combinators.append(record["builder"])
 
-    updated_combinator_ids = _enqueue_combinator_materializations(
-        redis, updated_combinators
-    )
+    updated_combinator_ids = _enqueue_combinator_rebuilds(redis, updated_combinators)
 
     status.update(
         {
@@ -554,6 +588,14 @@ def materialize_builder(
             # version was updated, because that indicates that the ZIM file
             # was never requested or errored and should remain in that state.
             auto_handle_zim_generation(redis, wp10db, builder.b_id)
+        if content_type == "text/tab-separated-values" and not is_meta_builder(builder):
+            try:
+                _rebuild_referencing_combinators(redis, wp10db, builder)
+            except Exception:
+                logger.exception(
+                    "Could not enqueue dependent Combinator rebuilds for builder id=%s",
+                    builder.b_id,
+                )
     finally:
         if should_close:
             wp10db.close()

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import json
 import logging
+import time
 from typing import TYPE_CHECKING, Any
 
 import attr
@@ -10,7 +11,7 @@ from dateutil.relativedelta import relativedelta
 from kiwixstorage import KiwixStorage
 from pymysql.connections import Connection
 from redis import Redis
-
+from redis.exceptions import RedisError
 import wp1.logic.selection as logic_selection
 import wp1.logic.util as logic_util
 import wp1.logic.zim_files as logic_zim_tasks
@@ -310,26 +311,6 @@ def _update_builder_params(
     return rowcount > 0
 
 
-def _mark_combinator_pending_rebuild(wp10db: Connection, combinator: Builder) -> bool:
-    # The list UI treats builders newer than their latest selection as pending.
-    combinator = attr.evolve(combinator)
-    combinator.set_updated_at_now()
-    if combinator.b_id is None:
-        raise ValueError("Cannot update combinator without b_id")
-
-    with wp10db.cursor() as cursor:
-        cursor.execute(
-            """UPDATE builders
-           SET b_updated_at = %s
-           WHERE b_id = %s AND b_user_id = %s
-        """,
-            (combinator.b_updated_at, combinator.b_id, combinator.b_user_id),
-        )
-        rowcount = cursor.rowcount
-    wp10db.commit()
-    return rowcount > 0
-
-
 def _enqueue_combinator_rebuilds(redis: Redis, combinators: list[Builder]) -> list[str]:
     combinator_cls = None
     enqueued_combinator_ids = []
@@ -352,12 +333,33 @@ def _rebuild_referencing_combinators(
     )
 
     enqueued_combinator_ids = []
-    for record in referencing_records:
-        combinator = record["builder"]
-        enqueued_combinator_ids.extend(
-            _enqueue_combinator_rebuilds(redis, [combinator])
-        )
-        _mark_combinator_pending_rebuild(wp10db, combinator)
+    with wp10db.cursor() as cursor:
+        for record in referencing_records:
+            combinator = record["builder"]
+            try:
+                enqueued_combinator_ids.extend(
+                    _enqueue_combinator_rebuilds(redis, [combinator])
+                )
+            except RedisError:
+                logger.exception(
+                    "Could not enqueue dependent Combinator rebuild for builder id=%s",
+                    combinator.b_id,
+                )
+                continue
+
+            # The list UI treats builders newer than their latest selection as pending.
+            cursor.execute(
+                """UPDATE builders
+               SET b_updated_at = %s
+               WHERE b_id = %s AND b_user_id = %s
+            """,
+                (
+                    time.strftime(TS_FORMAT_WP10, time.gmtime()).encode("utf-8"),
+                    combinator.b_id,
+                    combinator.b_user_id,
+                ),
+            )
+    wp10db.commit()
 
     return enqueued_combinator_ids
 
@@ -589,13 +591,7 @@ def materialize_builder(
             # was never requested or errored and should remain in that state.
             auto_handle_zim_generation(redis, wp10db, builder.b_id)
         if content_type == "text/tab-separated-values" and not is_meta_builder(builder):
-            try:
-                _rebuild_referencing_combinators(redis, wp10db, builder)
-            except Exception:
-                logger.exception(
-                    "Could not enqueue dependent Combinator rebuilds for builder id=%s",
-                    builder.b_id,
-                )
+            _rebuild_referencing_combinators(redis, wp10db, builder)
     finally:
         if should_close:
             wp10db.close()

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -3,6 +3,7 @@ import json
 from unittest.mock import ANY, MagicMock, call, patch
 
 import attr
+from redis.exceptions import RedisError
 
 from wp1.base_db_test import BaseWpOneDbTest
 from wp1.environment import Environment
@@ -231,6 +232,16 @@ class BuilderTest(BaseWpOneDbTest):
         if row is None:
             return None
         return json.loads(row["b_params"].decode("utf-8"))
+
+    def _get_builder_updated_at(self, builder_id):
+        with self.wp10db.cursor() as cursor:
+            cursor.execute(
+                "SELECT b_updated_at FROM builders WHERE b_id = %s", (builder_id,)
+            )
+            row = cursor.fetchone()
+        if row is None:
+            return None
+        return row["b_updated_at"]
 
     def _insert_zim_schedule(
         self,
@@ -974,6 +985,62 @@ class BuilderTest(BaseWpOneDbTest):
             ],
             affected,
         )
+
+    @patch("wp1.logic.builder.time.strftime", return_value="20200102030405")
+    @patch("wp1.logic.builder.queues.enqueue_materialize")
+    def test_rebuild_referencing_combinators_enqueues_and_marks_pending(
+        self, mock_enqueue, mock_strftime
+    ):
+        self._insert_builder_record("target-builder", "Target Builder")
+        self._insert_builder_record("other-builder", "Other Builder")
+        self._insert_builder_record(
+            "combo-keep",
+            "Keep Combo",
+            model="wp1.selection.models.combinator",
+            params={
+                "include": {
+                    "builders": ["target-builder", "other-builder"],
+                    "operation": "union",
+                },
+                "exclude": {"builders": [], "operation": "union"},
+            },
+        )
+        target_builder = logic_builder.get_builder(self.wp10db, "target-builder")
+
+        actual = logic_builder._rebuild_referencing_combinators(
+            MagicMock(), self.wp10db, target_builder
+        )
+
+        self.assertEqual(["combo-keep"], actual)
+        self.assertEqual(b"20200102030405", self._get_builder_updated_at(b"combo-keep"))
+        mock_enqueue.assert_called_once()
+        mock_strftime.assert_called_once()
+
+    @patch("wp1.logic.builder.time.strftime", return_value="20200102030405")
+    @patch("wp1.logic.builder.queues.enqueue_materialize")
+    def test_rebuild_referencing_combinators_skips_pending_mark_on_enqueue_error(
+        self, mock_enqueue, mock_strftime
+    ):
+        mock_enqueue.side_effect = RedisError("Redis unavailable")
+        self._insert_builder_record("target-builder", "Target Builder")
+        self._insert_builder_record(
+            "combo-keep",
+            "Keep Combo",
+            model="wp1.selection.models.combinator",
+            params={
+                "include": {"builders": ["target-builder"], "operation": "union"},
+                "exclude": {"builders": [], "operation": "union"},
+            },
+        )
+        target_builder = logic_builder.get_builder(self.wp10db, "target-builder")
+
+        actual = logic_builder._rebuild_referencing_combinators(
+            MagicMock(), self.wp10db, target_builder
+        )
+
+        self.assertEqual([], actual)
+        self.assertEqual(b"20191225044444", self._get_builder_updated_at(b"combo-keep"))
+        mock_strftime.assert_not_called()
 
     @patch("wp1.logic.builder.queues.enqueue_materialize")
     @patch("wp1.logic.builder.queues.cancel_scheduled_job")


### PR DESCRIPTION
**Problem**

Updating a source list did not automatically refresh Combinators that depend on it, so those Combinators could keep showing selections based on an older version of the referenced list.

 **Solution**

- After a list finishes materializing, find Combinators that reference it
- Enqueue rebuild jobs for those Combinators and mark each successfully enqueued one as pending
- If rebuilding a dependent Combinator fails, log the error but do not fail the original list update