### PR TITLE
Improve Combinator dependency error handling

### DIFF
--- a/wp1-frontend/cypress/e2e/combinator.cy.js
+++ b/wp1-frontend/cypress/e2e/combinator.cy.js
@@ -235,6 +235,18 @@ describe('the combinator builder page', () => {
       it('disables the retry button', () => {
         cy.get('.materialize-error .btn').should('have.attr', 'disabled');
       });
+
+      it('links to the failed referenced builder', () => {
+        cy.get('.materialize-error').contains(
+          'This Combinator could not be created because one or more referenced lists need attention.'
+        );
+        cy.get('.materialize-error a')
+          .contains('Failed Builder (failed-builder)')
+          .should('have.attr', 'href', '#/selections/simple/failed-builder');
+        cy.get('.materialize-error').contains(
+          'Open this list, fix the failed selection, then update this Combinator.'
+        );
+      });
     });
 
     describe('when the builder has retryable errors', () => {

--- a/wp1-frontend/cypress/fixtures/combinator_builder_fatal_error.json
+++ b/wp1-frontend/cypress/fixtures/combinator_builder_fatal_error.json
@@ -17,6 +17,18 @@
       "error_messages": [
         "Referenced builder Failed Builder (failed-builder) latest selection failed"
       ],
+      "referenced_builder_errors": [
+        {
+          "builder_id": "failed-builder",
+          "builder_name": "Failed Builder",
+          "builder_model": "wp1.selection.models.simple",
+          "code": "REFERENCED_SELECTION_FAILED",
+          "message": "Referenced builder Failed Builder (failed-builder) latest selection failed",
+          "reason": "latest selection failed",
+          "action": "Open this list, fix the failed selection, then update this Combinator.",
+          "status": "FAILED"
+        }
+      ],
       "ext": "tsv",
       "status": "FAILED"
     }

--- a/wp1-frontend/cypress/fixtures/combinator_builder_retryable_error.json
+++ b/wp1-frontend/cypress/fixtures/combinator_builder_retryable_error.json
@@ -15,7 +15,19 @@
   "selection_errors": [
     {
       "error_messages": [
-        "Referenced builder Retry Builder (retry-builder) latest selection is not ready"
+        "Referenced builder Retry Builder (retry-builder) latest selection failed but can be retried"
+      ],
+      "referenced_builder_errors": [
+        {
+          "builder_id": "retry-builder",
+          "builder_name": "Retry Builder",
+          "builder_model": "wp1.selection.models.simple",
+          "code": "REFERENCED_SELECTION_RETRYABLE_FAILURE",
+          "message": "Referenced builder Retry Builder (retry-builder) latest selection failed but can be retried",
+          "reason": "latest selection failed but can be retried",
+          "action": "Open this list and retry it, then retry this Combinator.",
+          "status": "CAN_RETRY"
+        }
       ],
       "ext": "tsv",
       "status": "CAN_RETRY"

--- a/wp1-frontend/src/components/BaseBuilder.vue
+++ b/wp1-frontend/src/components/BaseBuilder.vue
@@ -33,13 +33,41 @@
             </h4>
             <div
               v-for="item in builder.selection_errors"
-              v-bind:key="item.error_messages[0]"
+              v-bind:key="materializeErrorKey(item)"
             >
               <div>
                 The following errors occurred when creating the .{{ item.ext }}
                 version:
               </div>
-              <ul class="materialize-error-list">
+              <div
+                v-if="hasReferencedBuilderErrors(item)"
+                class="referenced-builder-errors"
+              >
+                <p>
+                  This Combinator could not be created because one or more
+                  referenced lists need attention.
+                </p>
+                <ul class="materialize-error-list">
+                  <li
+                    v-for="error in item.referenced_builder_errors"
+                    v-bind:key="referencedBuilderErrorKey(error)"
+                  >
+                    <router-link
+                      v-if="referencedBuilderPath(error)"
+                      class="referenced-builder-link"
+                      :to="referencedBuilderPath(error)"
+                    >
+                      {{ referencedBuilderLabel(error) }}
+                    </router-link>
+                    <span v-else>{{ referencedBuilderLabel(error) }}</span>
+                    <span>: {{ referencedBuilderReason(error) }}</span>
+                    <div v-if="error.action" class="referenced-builder-action">
+                      {{ error.action }}
+                    </div>
+                  </li>
+                </ul>
+              </div>
+              <ul v-else class="materialize-error-list">
                 <li v-for="msg in item.error_messages" v-bind:key="msg">
                   {{ msg }}
                 </li>
@@ -268,6 +296,37 @@ export default {
     },
   },
   methods: {
+    materializeErrorKey: function (item) {
+      const messages = item.error_messages || [];
+      return `${item.ext}:${item.status}:${messages[0] || ''}`;
+    },
+    hasReferencedBuilderErrors: function (item) {
+      return (
+        item.referenced_builder_errors &&
+        item.referenced_builder_errors.length > 0
+      );
+    },
+    referencedBuilderErrorKey: function (error) {
+      return `${error.builder_id || ''}:${error.message || ''}`;
+    },
+    referencedBuilderPath: function (error) {
+      if (!error.builder_id || !error.builder_model) {
+        return null;
+      }
+
+      const fragments = error.builder_model.split('.');
+      const modelFragment = fragments[fragments.length - 1];
+      return { path: `/selections/${modelFragment}/${error.builder_id}` };
+    },
+    referencedBuilderLabel: function (error) {
+      if (error.builder_name && error.builder_id) {
+        return `${error.builder_name} (${error.builder_id})`;
+      }
+      return error.builder_name || error.builder_id || 'Referenced list';
+    },
+    referencedBuilderReason: function (error) {
+      return error.reason || error.message || 'needs attention';
+    },
     getWikiProjects: async function () {
       const response = await fetch(`${import.meta.env.VITE_API_URL}/sites/`);
       var data = await response.json();
@@ -388,6 +447,22 @@ export default {
 .materialize-error {
   background-color: pink;
 }
+
+.referenced-builder-link,
+.referenced-builder-link:visited,
+.referenced-builder-link:active,
+.referenced-builder-link:focus {
+  color: #0063cc !important;
+}
+
+.referenced-builder-link:hover {
+  color: #004a99 !important;
+}
+
+.referenced-builder-action {
+  margin-top: 0.25rem;
+}
+
 .loader {
   margin-left: 1rem;
 }

--- a/wp1/exceptions.py
+++ b/wp1/exceptions.py
@@ -3,7 +3,9 @@ class Wp1Error(Exception):
 
 
 class Wp1SelectionError(Wp1Error):
-    pass
+    def __init__(self, *args, extra=None):
+        super().__init__(*args)
+        self.extra = extra or {}
 
 
 class Wp1RetryableSelectionError(Wp1SelectionError):

--- a/wp1/exceptions.py
+++ b/wp1/exceptions.py
@@ -1,9 +1,12 @@
+from typing import Any
+
+
 class Wp1Error(Exception):
     pass
 
 
 class Wp1SelectionError(Wp1Error):
-    def __init__(self, *args, extra=None):
+    def __init__(self, *args: Any, extra: dict[str, Any] | None = None):
         super().__init__(*args)
         self.extra = extra or {}
 
@@ -14,6 +17,74 @@ class Wp1RetryableSelectionError(Wp1SelectionError):
 
 class Wp1FatalSelectionError(Wp1SelectionError):
     pass
+
+
+class Wp1MetaSelectionError(Wp1SelectionError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str,
+        reason: str,
+        action: str,
+        **details: str | None,
+    ):
+        super().__init__(message)
+        self.code = code
+        self.reason = reason
+        self.action = action
+        self.details = {
+            key: value for key, value in details.items() if value is not None
+        }
+
+
+class Wp1RetryableMetaSelectionError(Wp1MetaSelectionError, Wp1RetryableSelectionError):
+    pass
+
+
+class Wp1FatalMetaSelectionError(Wp1MetaSelectionError, Wp1FatalSelectionError):
+    pass
+
+
+class Wp1MetaBuilderProcessError(Wp1SelectionError):
+    def __init__(self, failures: list[tuple[dict[str, Any], Wp1SelectionError]]):
+        super().__init__("One or more referenced selections failed")
+        self.failures = failures
+
+    @property
+    def has_fatal_errors(self) -> bool:
+        return any(
+            isinstance(error, Wp1FatalSelectionError)
+            for _reference, error in self.failures
+        )
+
+    def to_user_messages(self) -> list[dict[str, Any]]:
+        messages = []
+        for reference, error in self.failures:
+            message = str(error)
+            data = {
+                "builder_id": reference["id"],
+                "builder_name": reference["name"],
+                "builder_model": reference["model"],
+                "message": message,
+                "reason": message,
+                "status": (
+                    "FAILED"
+                    if isinstance(error, Wp1FatalSelectionError)
+                    else "CAN_RETRY"
+                ),
+            }
+            if isinstance(error, Wp1MetaSelectionError):
+                data.update(
+                    {
+                        "code": error.code,
+                        "reason": error.reason,
+                        "action": error.action,
+                    }
+                )
+                data.update(error.details)
+            messages.append(data)
+        return messages
 
 
 class ZimFarmError(Wp1Error):

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -227,6 +227,7 @@ class BuilderTest(BaseWpOneDbTest):
         object_key="selections/foo/1234/name.tsv",
         builder_id=b"1a-2b-3c-4d",
         has_errors=False,
+        error_messages=None,
         zim_file_ready=False,
         zim_task_id="5678",
         skip_zim=False,
@@ -234,7 +235,8 @@ class BuilderTest(BaseWpOneDbTest):
     ):
         if has_errors:
             status = "CAN_RETRY"
-            error_messages = '{"error_messages":["There was an error"]}'
+            if error_messages is None:
+                error_messages = '{"error_messages":["There was an error"]}'
         else:
             status = "OK"
             error_messages = None
@@ -1067,6 +1069,48 @@ class BuilderTest(BaseWpOneDbTest):
         actual = logic_builder.latest_selections_with_errors(self.wp10db, builder_id)
 
         self.assertEqual(0, len(actual))
+
+    def test_latest_selection_with_errors_includes_referenced_builders(self):
+        builder_id = self._insert_builder(current_version=1)
+        self._insert_selection(
+            1,
+            "text/tab-separated-values",
+            builder_id=builder_id,
+            has_errors=True,
+            error_messages=(
+                '{"error_messages":["Combinator failed"],'
+                '"referenced_builder_errors":[{'
+                '"builder_id":"builder-a",'
+                '"builder_name":"Builder A",'
+                '"builder_model":"wp1.selection.models.simple",'
+                '"message":"Referenced builder Builder A failed",'
+                '"reason":"failed",'
+                '"status":"FAILED"}]}'
+            ),
+        )
+
+        actual = logic_builder.latest_selections_with_errors(self.wp10db, builder_id)
+
+        self.assertEqual(
+            [
+                {
+                    "status": "CAN_RETRY",
+                    "ext": "tsv",
+                    "error_messages": ["Combinator failed"],
+                    "referenced_builder_errors": [
+                        {
+                            "builder_id": "builder-a",
+                            "builder_name": "Builder A",
+                            "builder_model": "wp1.selection.models.simple",
+                            "message": "Referenced builder Builder A failed",
+                            "reason": "failed",
+                            "status": "FAILED",
+                        }
+                    ],
+                }
+            ],
+            actual,
+        )
 
     @patch("wp1.logic.builder.zimfarm.create_or_update_zimfarm_schedule")
     @patch("wp1.logic.builder.zimfarm.request_zimfarm_task")

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -188,7 +188,11 @@ def set_error_messages(selection: Selection, e: Exception) -> None:
     # Use __cause__ because we can use '... from e' expressions to either set or suppress the cause.
     if e.__cause__:
         messages.append(str(e.__cause__))
-    selection.s_error_messages = json.dumps({"error_messages": messages})
+    error_data = {"error_messages": messages}
+    extra = getattr(e, "extra", None)
+    if isinstance(extra, dict):
+        error_data.update(extra)
+    selection.s_error_messages = json.dumps(error_data)
 
 
 def update_zimfarm_task(

--- a/wp1/selection/abstract_builder_test.py
+++ b/wp1/selection/abstract_builder_test.py
@@ -46,6 +46,15 @@ class TestBuilderNoContext(TestBuilder):
         raise Wp1FatalSelectionError("Something broke")
 
 
+class TestBuilderExtraError(TestBuilder):
+
+    def build(self, content_type, **params):
+        raise Wp1FatalSelectionError(
+            "Referenced builder broke",
+            extra={"extra_context": "kept"},
+        )
+
+
 class TestBuilderSuppressedException(TestBuilder):
 
     def build(self, content_type, **params):
@@ -210,6 +219,22 @@ class AbstractBuilderTest(BaseWpOneDbTest):
 
         self.assertEqual(
             {"error_messages": ["Something broke"]}, json.loads(actual.s_error_messages)
+        )
+
+    def test_materialize_extra_error_data(self):
+        builder_obj = TestBuilderExtraError()
+        builder_obj.materialize(
+            self.s3, self.wp10db, self.builder, "text/tab-separated-values", 1
+        )
+
+        actual = get_first_selection(self.wp10db)
+
+        self.assertEqual(
+            {
+                "error_messages": ["Referenced builder broke"],
+                "extra_context": "kept",
+            },
+            json.loads(actual.s_error_messages),
         )
 
     def test_materialize_suppressed_message(self):

--- a/wp1/selection/meta_builder.py
+++ b/wp1/selection/meta_builder.py
@@ -11,6 +11,19 @@ from wp1.exceptions import (
 from wp1.selection.abstract_builder import AbstractBuilder
 
 
+# Most dependdency errors only need code/reason/action, details are optional debug fields
+def _dependency_error_extra(
+    code: str, reason: str, action: str, **details: str
+) -> dict[str, str]:
+    extra = {
+        "dependency_code": code,
+        "dependency_reason": reason,
+        "dependency_action": action,
+    }
+    extra.update({key: value for key, value in details.items() if value is not None})
+    return extra
+
+
 class MetaBuilder(AbstractBuilder):
     """Base class for builders that reference other builders."""
 
@@ -27,26 +40,50 @@ class MetaBuilder(AbstractBuilder):
         if selection is None:
             raise Wp1RetryableSelectionError(
                 f"Referenced builder {label} has no usable selection "
-                f"(no selection found)"
+                f"(no selection found)",
+                extra=_dependency_error_extra(
+                    "REFERENCED_SELECTION_MISSING",
+                    "has no usable TSV selection yet",
+                    "Open this list and create or retry its selection, then retry this Combinator.",
+                ),
             )
 
         status = logic_util.as_text(selection.s_status)
         if status == "FAILED":
             raise Wp1FatalSelectionError(
-                f"Referenced builder {label} latest selection failed"
+                f"Referenced builder {label} latest selection failed",
+                extra=_dependency_error_extra(
+                    "REFERENCED_SELECTION_FAILED",
+                    "latest selection failed",
+                    "Open this list, fix the failed selection, then update this Combinator.",
+                ),
             )
 
         if status != "OK":
+            if status == "CAN_RETRY":
+                code = "REFERENCED_SELECTION_RETRYABLE_FAILURE"
+                reason = "latest selection failed but can be retried"
+                action = "Open this list and retry it, then retry this Combinator."
+            else:
+                code = "REFERENCED_SELECTION_NOT_READY"
+                reason = "latest selection is not ready yet"
+                action = "Wait for this list to finish processing, then retry this Combinator."
+
             raise Wp1RetryableSelectionError(
-                f"Referenced builder {label} latest selection is not ready "
-                f"(status={status!r})"
+                f"Referenced builder {label} {reason}",
+                extra=_dependency_error_extra(code, reason, action),
             )
 
         # OK selections can have no stored data when materialization produced empty
         # data, since AbstractBuilder only uploads filled selection.data.
         if selection.s_object_key is None:
             raise Wp1RetryableSelectionError(
-                f"Referenced builder {label} latest selection has no stored data"
+                f"Referenced builder {label} latest selection has no stored data",
+                extra=_dependency_error_extra(
+                    "REFERENCED_SELECTION_NO_DATA",
+                    "latest selection has no stored data",
+                    "Retry this list, then retry this Combinator.",
+                ),
             )
 
         object_key = selection.s_object_key
@@ -59,8 +96,14 @@ class MetaBuilder(AbstractBuilder):
         except ClientError as e:
             code = e.response.get("Error", {}).get("Code", "Unknown")
             raise Wp1RetryableSelectionError(
-                f"Failed to download selection for builder {label} "
-                f"from S3 key {object_key!r}: {code}"
+                f"Failed to download selection for referenced builder {label}: {code}",
+                extra=_dependency_error_extra(
+                    "REFERENCED_SELECTION_DOWNLOAD_FAILED",
+                    "could not download the latest selection",
+                    "Retry this Combinator. If it fails again, update the referenced list to recreate its download.",
+                    object_key=object_key,
+                    storage_error_code=code,
+                ),
             ) from e
 
         return buffer.getvalue()

--- a/wp1/selection/meta_builder.py
+++ b/wp1/selection/meta_builder.py
@@ -5,23 +5,10 @@ from botocore.exceptions import ClientError
 import wp1.logic.builder as logic_builder
 from wp1.logic import util as logic_util
 from wp1.exceptions import (
-    Wp1FatalSelectionError,
-    Wp1RetryableSelectionError,
+    Wp1FatalMetaSelectionError,
+    Wp1RetryableMetaSelectionError,
 )
 from wp1.selection.abstract_builder import AbstractBuilder
-
-
-# Most dependdency errors only need code/reason/action, details are optional debug fields
-def _dependency_error_extra(
-    code: str, reason: str, action: str, **details: str
-) -> dict[str, str]:
-    extra = {
-        "dependency_code": code,
-        "dependency_reason": reason,
-        "dependency_action": action,
-    }
-    extra.update({key: value for key, value in details.items() if value is not None})
-    return extra
 
 
 class MetaBuilder(AbstractBuilder):
@@ -38,25 +25,21 @@ class MetaBuilder(AbstractBuilder):
 
         # TODO: #1196 - Add retry handling for Combinator referenced selections.
         if selection is None:
-            raise Wp1RetryableSelectionError(
+            raise Wp1RetryableMetaSelectionError(
                 f"Referenced builder {label} has no usable selection "
                 f"(no selection found)",
-                extra=_dependency_error_extra(
-                    "REFERENCED_SELECTION_MISSING",
-                    "has no usable TSV selection yet",
-                    "Open this list and create or retry its selection, then retry this Combinator.",
-                ),
+                code="REFERENCED_SELECTION_MISSING",
+                reason="has no usable TSV selection yet",
+                action="Open this list and create or retry its selection, then retry this Combinator.",
             )
 
         status = logic_util.as_text(selection.s_status)
         if status == "FAILED":
-            raise Wp1FatalSelectionError(
+            raise Wp1FatalMetaSelectionError(
                 f"Referenced builder {label} latest selection failed",
-                extra=_dependency_error_extra(
-                    "REFERENCED_SELECTION_FAILED",
-                    "latest selection failed",
-                    "Open this list, fix the failed selection, then update this Combinator.",
-                ),
+                code="REFERENCED_SELECTION_FAILED",
+                reason="latest selection failed",
+                action="Open this list, fix the failed selection, then update this Combinator.",
             )
 
         if status != "OK":
@@ -69,21 +52,21 @@ class MetaBuilder(AbstractBuilder):
                 reason = "latest selection is not ready yet"
                 action = "Wait for this list to finish processing, then retry this Combinator."
 
-            raise Wp1RetryableSelectionError(
+            raise Wp1RetryableMetaSelectionError(
                 f"Referenced builder {label} {reason}",
-                extra=_dependency_error_extra(code, reason, action),
+                code=code,
+                reason=reason,
+                action=action,
             )
 
         # OK selections can have no stored data when materialization produced empty
         # data, since AbstractBuilder only uploads filled selection.data.
         if selection.s_object_key is None:
-            raise Wp1RetryableSelectionError(
+            raise Wp1RetryableMetaSelectionError(
                 f"Referenced builder {label} latest selection has no stored data",
-                extra=_dependency_error_extra(
-                    "REFERENCED_SELECTION_NO_DATA",
-                    "latest selection has no stored data",
-                    "Retry this list, then retry this Combinator.",
-                ),
+                code="REFERENCED_SELECTION_NO_DATA",
+                reason="latest selection has no stored data",
+                action="Retry this list, then retry this Combinator.",
             )
 
         object_key = selection.s_object_key
@@ -95,15 +78,13 @@ class MetaBuilder(AbstractBuilder):
             s3.download_fileobj(object_key, buffer)
         except ClientError as e:
             code = e.response.get("Error", {}).get("Code", "Unknown")
-            raise Wp1RetryableSelectionError(
+            raise Wp1RetryableMetaSelectionError(
                 f"Failed to download selection for referenced builder {label}: {code}",
-                extra=_dependency_error_extra(
-                    "REFERENCED_SELECTION_DOWNLOAD_FAILED",
-                    "could not download the latest selection",
-                    "Retry this Combinator. If it fails again, update the referenced list to recreate its download.",
-                    object_key=object_key,
-                    storage_error_code=code,
-                ),
+                code="REFERENCED_SELECTION_DOWNLOAD_FAILED",
+                reason="could not download the latest selection",
+                action="Retry this Combinator. If it fails again, update the referenced list to recreate its download.",
+                object_key=object_key,
+                storage_error_code=code,
             ) from e
 
         return buffer.getvalue()

--- a/wp1/selection/meta_builder_test.py
+++ b/wp1/selection/meta_builder_test.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+from botocore.exceptions import ClientError
+
 from wp1.exceptions import Wp1FatalSelectionError, Wp1RetryableSelectionError
 from wp1.models.wp10.selection import Selection
 from wp1.selection.meta_builder import MetaBuilder
@@ -36,15 +38,35 @@ class MetaBuilderTest(TestCase):
     def test_fetch_selection_data_failed_selection(self, mock_latest_selection):
         mock_latest_selection.return_value = _selection(status=b"FAILED")
 
-        with self.assertRaises(Wp1FatalSelectionError):
+        with self.assertRaises(Wp1FatalSelectionError) as context:
             self.builder._fetch_selection_data(MagicMock(), MagicMock(), "builder-a")
+
+        self.assertEqual(
+            "REFERENCED_SELECTION_FAILED", context.exception.extra["dependency_code"]
+        )
+        self.assertEqual(
+            "latest selection failed", context.exception.extra["dependency_reason"]
+        )
 
     @patch("wp1.selection.meta_builder.logic_builder.latest_selection_for")
     def test_fetch_selection_data_retryable_selection(self, mock_latest_selection):
         mock_latest_selection.return_value = _selection(status=b"CAN_RETRY")
 
-        with self.assertRaises(Wp1RetryableSelectionError):
+        with self.assertRaises(Wp1RetryableSelectionError) as context:
             self.builder._fetch_selection_data(MagicMock(), MagicMock(), "builder-a")
+
+        self.assertEqual(
+            "REFERENCED_SELECTION_RETRYABLE_FAILURE",
+            context.exception.extra["dependency_code"],
+        )
+        self.assertEqual(
+            "latest selection failed but can be retried",
+            context.exception.extra["dependency_reason"],
+        )
+        self.assertEqual(
+            "Open this list and retry it, then retry this Combinator.",
+            context.exception.extra["dependency_action"],
+        )
 
     @patch("wp1.selection.meta_builder.logic_builder.latest_selection_for")
     def test_fetch_selection_data_without_stored_data(self, mock_latest_selection):
@@ -57,5 +79,31 @@ class MetaBuilderTest(TestCase):
     def test_fetch_selection_data_missing_selection(self, mock_latest_selection):
         mock_latest_selection.return_value = None
 
-        with self.assertRaises(Wp1RetryableSelectionError):
+        with self.assertRaises(Wp1RetryableSelectionError) as context:
             self.builder._fetch_selection_data(MagicMock(), MagicMock(), "builder-a")
+
+        self.assertEqual(
+            "REFERENCED_SELECTION_MISSING", context.exception.extra["dependency_code"]
+        )
+
+    @patch("wp1.selection.meta_builder.logic_builder.latest_selection_for")
+    def test_fetch_selection_data_download_error(self, mock_latest_selection):
+        mock_latest_selection.return_value = _selection(object_key=b"object-key")
+        s3 = MagicMock()
+        s3.download_fileobj.side_effect = ClientError(
+            {"Error": {"Code": "NoSuchKey"}}, "GetObject"
+        )
+
+        with self.assertRaises(Wp1RetryableSelectionError) as context:
+            self.builder._fetch_selection_data(MagicMock(), s3, "builder-a")
+
+        self.assertEqual(
+            "REFERENCED_SELECTION_DOWNLOAD_FAILED",
+            context.exception.extra["dependency_code"],
+        )
+        self.assertEqual(
+            "could not download the latest selection",
+            context.exception.extra["dependency_reason"],
+        )
+        self.assertEqual("object-key", context.exception.extra["object_key"])
+        self.assertEqual("NoSuchKey", context.exception.extra["storage_error_code"])

--- a/wp1/selection/meta_builder_test.py
+++ b/wp1/selection/meta_builder_test.py
@@ -3,7 +3,10 @@ from unittest.mock import MagicMock, patch
 
 from botocore.exceptions import ClientError
 
-from wp1.exceptions import Wp1FatalSelectionError, Wp1RetryableSelectionError
+from wp1.exceptions import (
+    Wp1FatalMetaSelectionError,
+    Wp1RetryableMetaSelectionError,
+)
 from wp1.models.wp10.selection import Selection
 from wp1.selection.meta_builder import MetaBuilder
 
@@ -38,53 +41,41 @@ class MetaBuilderTest(TestCase):
     def test_fetch_selection_data_failed_selection(self, mock_latest_selection):
         mock_latest_selection.return_value = _selection(status=b"FAILED")
 
-        with self.assertRaises(Wp1FatalSelectionError) as context:
+        with self.assertRaises(Wp1FatalMetaSelectionError) as context:
             self.builder._fetch_selection_data(MagicMock(), MagicMock(), "builder-a")
 
-        self.assertEqual(
-            "REFERENCED_SELECTION_FAILED", context.exception.extra["dependency_code"]
-        )
-        self.assertEqual(
-            "latest selection failed", context.exception.extra["dependency_reason"]
-        )
+        self.assertEqual("REFERENCED_SELECTION_FAILED", context.exception.code)
+        self.assertEqual("latest selection failed", context.exception.reason)
 
     @patch("wp1.selection.meta_builder.logic_builder.latest_selection_for")
     def test_fetch_selection_data_retryable_selection(self, mock_latest_selection):
         mock_latest_selection.return_value = _selection(status=b"CAN_RETRY")
 
-        with self.assertRaises(Wp1RetryableSelectionError) as context:
+        with self.assertRaises(Wp1RetryableMetaSelectionError) as context:
             self.builder._fetch_selection_data(MagicMock(), MagicMock(), "builder-a")
 
         self.assertEqual(
-            "REFERENCED_SELECTION_RETRYABLE_FAILURE",
-            context.exception.extra["dependency_code"],
+            "REFERENCED_SELECTION_RETRYABLE_FAILURE", context.exception.code
         )
         self.assertEqual(
-            "latest selection failed but can be retried",
-            context.exception.extra["dependency_reason"],
-        )
-        self.assertEqual(
-            "Open this list and retry it, then retry this Combinator.",
-            context.exception.extra["dependency_action"],
+            "latest selection failed but can be retried", context.exception.reason
         )
 
     @patch("wp1.selection.meta_builder.logic_builder.latest_selection_for")
     def test_fetch_selection_data_without_stored_data(self, mock_latest_selection):
         mock_latest_selection.return_value = _selection(object_key=None)
 
-        with self.assertRaisesRegex(Wp1RetryableSelectionError, "no stored data"):
+        with self.assertRaisesRegex(Wp1RetryableMetaSelectionError, "no stored data"):
             self.builder._fetch_selection_data(MagicMock(), MagicMock(), "builder-a")
 
     @patch("wp1.selection.meta_builder.logic_builder.latest_selection_for")
     def test_fetch_selection_data_missing_selection(self, mock_latest_selection):
         mock_latest_selection.return_value = None
 
-        with self.assertRaises(Wp1RetryableSelectionError) as context:
+        with self.assertRaises(Wp1RetryableMetaSelectionError) as context:
             self.builder._fetch_selection_data(MagicMock(), MagicMock(), "builder-a")
 
-        self.assertEqual(
-            "REFERENCED_SELECTION_MISSING", context.exception.extra["dependency_code"]
-        )
+        self.assertEqual("REFERENCED_SELECTION_MISSING", context.exception.code)
 
     @patch("wp1.selection.meta_builder.logic_builder.latest_selection_for")
     def test_fetch_selection_data_download_error(self, mock_latest_selection):
@@ -94,16 +85,9 @@ class MetaBuilderTest(TestCase):
             {"Error": {"Code": "NoSuchKey"}}, "GetObject"
         )
 
-        with self.assertRaises(Wp1RetryableSelectionError) as context:
+        with self.assertRaises(Wp1RetryableMetaSelectionError) as context:
             self.builder._fetch_selection_data(MagicMock(), s3, "builder-a")
 
-        self.assertEqual(
-            "REFERENCED_SELECTION_DOWNLOAD_FAILED",
-            context.exception.extra["dependency_code"],
-        )
-        self.assertEqual(
-            "could not download the latest selection",
-            context.exception.extra["dependency_reason"],
-        )
-        self.assertEqual("object-key", context.exception.extra["object_key"])
-        self.assertEqual("NoSuchKey", context.exception.extra["storage_error_code"])
+        self.assertEqual("REFERENCED_SELECTION_DOWNLOAD_FAILED", context.exception.code)
+        self.assertEqual("object-key", context.exception.details["object_key"])
+        self.assertEqual("NoSuchKey", context.exception.details["storage_error_code"])

--- a/wp1/selection/models/combinator.py
+++ b/wp1/selection/models/combinator.py
@@ -6,6 +6,8 @@ from wp1.logic import util as logic_util
 from wp1.exceptions import (
     ObjectNotFoundError,
     Wp1FatalSelectionError,
+    Wp1RetryableSelectionError,
+    Wp1SelectionError,
 )
 from wp1.selection.meta_builder import MetaBuilder
 
@@ -169,29 +171,103 @@ class Builder(MetaBuilder):
 
         return ([], [], [])
 
-    def _process_group(self, wp10db, s3, group: dict[str, Any]) -> set[str]:
+    def _process_group(
+        self,
+        wp10db,
+        s3,
+        group: dict[str, Any],
+        retryable_errors: list[dict[str, Any]],
+        fatal_errors: list[dict[str, Any]],
+    ) -> set[str]:
 
         builder_values = group.get("builders", [])
 
-        builder_ids = [
-            builder_id for builder_id in builder_values if isinstance(builder_id, str)
-        ]
+        builder_ids = []
+        for builder_id in builder_values:
+            if isinstance(builder_id, str) and builder_id not in builder_ids:
+                builder_ids.append(builder_id)
 
         operation = group.get("operation", "union")
 
         sets: list[set[str]] = []
-        # TODO: #1184 - Handle multiple bad referenced selections in combinator build.
-        for builder_id in set(builder_ids):
-            data = self._fetch_selection_data(
-                wp10db,
-                s3,
-                builder_id,
-                logic_builder.builder_label_by_id(wp10db, builder_id),
-            )
+        for builder_id in builder_ids:
+            reference: dict[str, Any]
+            try:
+                builder = logic_builder.get_builder(wp10db, builder_id)
+                reference = {
+                    "id": builder.id,
+                    "name": builder.name,
+                    "model": builder.model,
+                    "label": builder.label,
+                }
+            except ObjectNotFoundError:
+                reference = {
+                    "id": builder_id,
+                    "name": builder_id,
+                    "model": None,
+                    "label": builder_id,
+                }
+
+            try:
+                data = self._fetch_selection_data(
+                    wp10db, s3, builder_id, reference["label"]
+                )
+            except Wp1FatalSelectionError as e:
+                fatal_errors.append(
+                    self._referenced_builder_error(reference, e, "FAILED")
+                )
+                continue
+            except Wp1RetryableSelectionError as e:
+                retryable_errors.append(
+                    self._referenced_builder_error(reference, e, "CAN_RETRY")
+                )
+                continue
             title_set = _parse_tsv_to_set(data)
             sets.append(title_set)
 
         return _apply_operation(operation, sets)
+
+    def _referenced_builder_error(
+        self, reference: dict[str, Any], error: Wp1SelectionError, status: str
+    ) -> dict[str, Any]:
+        message = str(error)
+        extra = error.extra if isinstance(error.extra, dict) else {}
+        reason = extra.get("dependency_reason")
+        if not reason:
+            label = reference["label"] or reference["id"] or ""
+            prefix = f"Referenced builder {label} "
+            if message.startswith(prefix):
+                reason = message[len(prefix) :]
+            else:
+                download_prefix = f"Failed to download selection for builder {label} "
+                if message.startswith(download_prefix):
+                    reason = (
+                        "could not download the latest selection "
+                        + message[len(download_prefix) :]
+                    )
+                else:
+                    reason = message
+
+        data = {
+            "builder_id": reference["id"],
+            "builder_name": reference["name"],
+            "builder_model": reference["model"],
+            "message": message,
+            "reason": reason,
+            "status": status,
+        }
+        optional_keys = (
+            ("code", "dependency_code"),
+            ("action", "dependency_action"),
+            ("object_key", "object_key"),
+            ("storage_error_code", "storage_error_code"),
+        )
+        for response_key, extra_key in optional_keys:
+            value = extra.get(extra_key)
+            if value:
+                data[response_key] = value
+
+        return data
 
     def build(self, content_type: str, **params: Any) -> bytes:
         """Build the combinator selection from referenced builders."""
@@ -212,13 +288,33 @@ class Builder(MetaBuilder):
 
         exclude_group = params.get("exclude")
 
-        include_set = self._process_group(wp10db, s3, include_group)
+        retryable_errors: list[dict[str, Any]] = []
+        fatal_errors: list[dict[str, Any]] = []
+
+        include_set = self._process_group(
+            wp10db, s3, include_group, retryable_errors, fatal_errors
+        )
 
         exclude_set: set[str] = set()
         if exclude_group is not None:
             exclude_builders = exclude_group.get("builders", [])
             if exclude_builders:
-                exclude_set = self._process_group(wp10db, s3, exclude_group)
+                exclude_set = self._process_group(
+                    wp10db, s3, exclude_group, retryable_errors, fatal_errors
+                )
+
+        if retryable_errors or fatal_errors:
+            referenced_builder_errors = fatal_errors + retryable_errors
+            message = (
+                "Could not build Combinator because referenced selections failed: "
+                + "; ".join(
+                    error["message"] or "" for error in referenced_builder_errors
+                )
+            )
+            extra = {"referenced_builder_errors": referenced_builder_errors}
+            if fatal_errors:
+                raise Wp1FatalSelectionError(message, extra=extra)
+            raise Wp1RetryableSelectionError(message, extra=extra)
 
         result = include_set - exclude_set
 

--- a/wp1/selection/models/combinator.py
+++ b/wp1/selection/models/combinator.py
@@ -6,6 +6,7 @@ from wp1.logic import util as logic_util
 from wp1.exceptions import (
     ObjectNotFoundError,
     Wp1FatalSelectionError,
+    Wp1MetaBuilderProcessError,
     Wp1RetryableSelectionError,
     Wp1SelectionError,
 )
@@ -176,98 +177,70 @@ class Builder(MetaBuilder):
         wp10db,
         s3,
         group: dict[str, Any],
-        retryable_errors: list[dict[str, Any]],
-        fatal_errors: list[dict[str, Any]],
-    ) -> set[str]:
+    ) -> tuple[set[str], list[tuple[dict[str, Any], Wp1SelectionError]]]:
 
         builder_values = group.get("builders", [])
 
-        builder_ids = []
-        for builder_id in builder_values:
-            if isinstance(builder_id, str) and builder_id not in builder_ids:
-                builder_ids.append(builder_id)
+        builder_ids = list(
+            dict.fromkeys(
+                builder_id
+                for builder_id in builder_values
+                if isinstance(builder_id, str)
+            )
+        )
 
         operation = group.get("operation", "union")
 
         sets: list[set[str]] = []
+        failures = []
         for builder_id in builder_ids:
-            reference: dict[str, Any]
             try:
                 builder = logic_builder.get_builder(wp10db, builder_id)
+            except ObjectNotFoundError:
+                reference = {
+                    "id": None,
+                    "name": None,
+                    "model": None,
+                    "label": builder_id,
+                }
+            else:
                 reference = {
                     "id": builder.id,
                     "name": builder.name,
                     "model": builder.model,
                     "label": builder.label,
                 }
-            except ObjectNotFoundError:
-                reference = {
-                    "id": builder_id,
-                    "name": builder_id,
-                    "model": None,
-                    "label": builder_id,
-                }
 
             try:
                 data = self._fetch_selection_data(
                     wp10db, s3, builder_id, reference["label"]
                 )
-            except Wp1FatalSelectionError as e:
-                fatal_errors.append(
-                    self._referenced_builder_error(reference, e, "FAILED")
-                )
+            except (Wp1FatalSelectionError, Wp1RetryableSelectionError) as e:
+                failures.append((reference, e))
                 continue
-            except Wp1RetryableSelectionError as e:
-                retryable_errors.append(
-                    self._referenced_builder_error(reference, e, "CAN_RETRY")
-                )
-                continue
+
             title_set = _parse_tsv_to_set(data)
             sets.append(title_set)
 
-        return _apply_operation(operation, sets)
+        return _apply_operation(operation, sets), failures
 
-    def _referenced_builder_error(
-        self, reference: dict[str, Any], error: Wp1SelectionError, status: str
-    ) -> dict[str, Any]:
-        message = str(error)
-        extra = error.extra if isinstance(error.extra, dict) else {}
-        reason = extra.get("dependency_reason")
-        if not reason:
-            label = reference["label"] or reference["id"] or ""
-            prefix = f"Referenced builder {label} "
-            if message.startswith(prefix):
-                reason = message[len(prefix) :]
-            else:
-                download_prefix = f"Failed to download selection for builder {label} "
-                if message.startswith(download_prefix):
-                    reason = (
-                        "could not download the latest selection "
-                        + message[len(download_prefix) :]
-                    )
-                else:
-                    reason = message
+    def _process_groups(
+        self, wp10db, s3, include_group: dict[str, Any], exclude_group: dict[str, Any]
+    ) -> tuple[set[str], set[str]]:
+        include_set, failures = self._process_group(wp10db, s3, include_group)
 
-        data = {
-            "builder_id": reference["id"],
-            "builder_name": reference["name"],
-            "builder_model": reference["model"],
-            "message": message,
-            "reason": reason,
-            "status": status,
-        }
-        optional_keys = (
-            ("code", "dependency_code"),
-            ("action", "dependency_action"),
-            ("object_key", "object_key"),
-            ("storage_error_code", "storage_error_code"),
-        )
-        for response_key, extra_key in optional_keys:
-            value = extra.get(extra_key)
-            if value:
-                data[response_key] = value
+        exclude_set: set[str] = set()
+        exclude_builders = exclude_group.get("builders", [])
+        if exclude_builders:
+            exclude_set, exclude_failures = self._process_group(
+                wp10db, s3, exclude_group
+            )
+            failures.extend(exclude_failures)
 
-        return data
+        if failures:
+            raise Wp1MetaBuilderProcessError(failures)
+
+        return include_set, exclude_set
 
     def build(self, content_type: str, **params: Any) -> bytes:
         """Build the combinator selection from referenced builders."""
@@ -286,35 +259,22 @@ class Builder(MetaBuilder):
         if include_group is None:
             raise Wp1FatalSelectionError("Missing required 'include' group")
 
-        exclude_group = params.get("exclude")
+        exclude_group = params.get("exclude") or {"builders": []}
 
-        retryable_errors: list[dict[str, Any]] = []
-        fatal_errors: list[dict[str, Any]] = []
-
-        include_set = self._process_group(
-            wp10db, s3, include_group, retryable_errors, fatal_errors
-        )
-
-        exclude_set: set[str] = set()
-        if exclude_group is not None:
-            exclude_builders = exclude_group.get("builders", [])
-            if exclude_builders:
-                exclude_set = self._process_group(
-                    wp10db, s3, exclude_group, retryable_errors, fatal_errors
-                )
-
-        if retryable_errors or fatal_errors:
-            referenced_builder_errors = fatal_errors + retryable_errors
+        try:
+            include_set, exclude_set = self._process_groups(
+                wp10db, s3, include_group, exclude_group
+            )
+        except Wp1MetaBuilderProcessError as e:
+            referenced_builder_errors = e.to_user_messages()
             message = (
                 "Could not build Combinator because referenced selections failed: "
-                + "; ".join(
-                    error["message"] or "" for error in referenced_builder_errors
-                )
+                + "; ".join(error["message"] for error in referenced_builder_errors)
             )
             extra = {"referenced_builder_errors": referenced_builder_errors}
-            if fatal_errors:
-                raise Wp1FatalSelectionError(message, extra=extra)
-            raise Wp1RetryableSelectionError(message, extra=extra)
+            if e.has_fatal_errors:
+                raise Wp1FatalSelectionError(message, extra=extra) from e
+            raise Wp1RetryableSelectionError(message, extra=extra) from e
 
         result = include_set - exclude_set
 

--- a/wp1/selection/models/combinator_test.py
+++ b/wp1/selection/models/combinator_test.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from wp1.base_db_test import BaseWpOneDbTest
-from wp1.exceptions import Wp1FatalSelectionError
+from wp1.exceptions import Wp1FatalSelectionError, Wp1RetryableSelectionError
 from wp1.models.wp10.builder import Builder
 from wp1.selection.models.combinator import Builder as CombinatorBuilder
 
@@ -232,6 +232,107 @@ class CombinatorBuilderTest(BaseWpOneDbTest):
 
         with self.assertRaises(Wp1FatalSelectionError):
             self.builder.build("text/tab-separated-values", **params)
+
+    @patch("wp1.selection.models.combinator.logic_builder.get_builder")
+    @patch("wp1.selection.models.combinator.Builder._fetch_selection_data")
+    def test_build_reports_all_retryable_dependency_failures(
+        self, mock_fetch_selection_data, mock_get_builder
+    ):
+        mock_get_builder.side_effect = lambda _wp10db, builder_id: _reference_builder(
+            id_=builder_id,
+            name={
+                "builder-a": "Builder A",
+                "builder-b": "Builder B",
+                "builder-c": "Builder C",
+            }[builder_id],
+        )
+
+        def fetch_selection(_wp10db, _s3, builder_id, label):
+            if builder_id in ("builder-a", "builder-b"):
+                raise Wp1RetryableSelectionError(
+                    f"Referenced builder {label} is not ready"
+                )
+            return b"ok\n"
+
+        mock_fetch_selection_data.side_effect = fetch_selection
+        params = dict(self.params)
+        params.update(
+            include={
+                "builders": ["builder-a", "builder-b", "builder-c"],
+                "operation": "union",
+            },
+            s3=MagicMock(),
+        )
+
+        with self.assertRaises(Wp1RetryableSelectionError) as context:
+            self.builder.build("text/tab-separated-values", **params)
+
+        self.assertEqual(3, mock_fetch_selection_data.call_count)
+        message = str(context.exception)
+        self.assertIn("Builder A (builder-a) is not ready", message)
+        self.assertIn("Builder B (builder-b) is not ready", message)
+        referenced_errors = context.exception.extra["referenced_builder_errors"]
+        self.assertEqual(
+            ["builder-a", "builder-b"],
+            [error["builder_id"] for error in referenced_errors],
+        )
+        self.assertEqual(
+            ["CAN_RETRY", "CAN_RETRY"],
+            [error["status"] for error in referenced_errors],
+        )
+
+    @patch("wp1.selection.models.combinator.logic_builder.get_builder")
+    @patch("wp1.selection.models.combinator.Builder._fetch_selection_data")
+    def test_build_reports_mixed_dependency_failures_as_fatal(
+        self, mock_fetch_selection_data, mock_get_builder
+    ):
+        mock_get_builder.side_effect = lambda _wp10db, builder_id: _reference_builder(
+            id_=builder_id,
+            name={
+                "builder-a": "Builder A",
+                "builder-b": "Builder B",
+                "builder-c": "Builder C",
+            }[builder_id],
+        )
+
+        def fetch_selection(_wp10db, _s3, builder_id, label):
+            if builder_id == "builder-b":
+                raise Wp1RetryableSelectionError(
+                    f"Referenced builder {label} is not ready"
+                )
+            if builder_id == "builder-c":
+                raise Wp1FatalSelectionError(
+                    f"Referenced builder {label} latest selection failed",
+                    extra={
+                        "dependency_code": "REFERENCED_SELECTION_FAILED",
+                        "dependency_reason": "latest selection failed",
+                        "dependency_action": "Open this list, fix the failed selection, then update this Combinator.",
+                    },
+                )
+            return b"ok\n"
+
+        mock_fetch_selection_data.side_effect = fetch_selection
+        params = dict(self.params)
+        params.update(
+            include={"builders": ["builder-a", "builder-b"], "operation": "union"},
+            exclude={"builders": ["builder-c"], "operation": "union"},
+            s3=MagicMock(),
+        )
+
+        with self.assertRaises(Wp1FatalSelectionError) as context:
+            self.builder.build("text/tab-separated-values", **params)
+
+        self.assertEqual(3, mock_fetch_selection_data.call_count)
+        message = str(context.exception)
+        self.assertIn("Builder B (builder-b) is not ready", message)
+        self.assertIn("Builder C (builder-c) latest selection failed", message)
+        referenced_errors = context.exception.extra["referenced_builder_errors"]
+        self.assertEqual(
+            ["FAILED", "CAN_RETRY"],
+            [error["status"] for error in referenced_errors],
+        )
+        self.assertEqual("REFERENCED_SELECTION_FAILED", referenced_errors[0]["code"])
+        self.assertIn("fix the failed selection", referenced_errors[0]["action"])
 
     def test_validate_with_referenced_builder_in_db(self):
         self._insert_builder()

--- a/wp1/selection/models/combinator_test.py
+++ b/wp1/selection/models/combinator_test.py
@@ -1,7 +1,13 @@
 from unittest.mock import MagicMock, patch
 
 from wp1.base_db_test import BaseWpOneDbTest
-from wp1.exceptions import Wp1FatalSelectionError, Wp1RetryableSelectionError
+from wp1.exceptions import (
+    Wp1FatalMetaSelectionError,
+    Wp1FatalSelectionError,
+    Wp1MetaBuilderProcessError,
+    Wp1RetryableMetaSelectionError,
+    Wp1RetryableSelectionError,
+)
 from wp1.models.wp10.builder import Builder
 from wp1.selection.models.combinator import Builder as CombinatorBuilder
 
@@ -249,8 +255,11 @@ class CombinatorBuilderTest(BaseWpOneDbTest):
 
         def fetch_selection(_wp10db, _s3, builder_id, label):
             if builder_id in ("builder-a", "builder-b"):
-                raise Wp1RetryableSelectionError(
-                    f"Referenced builder {label} is not ready"
+                raise Wp1RetryableMetaSelectionError(
+                    f"Referenced builder {label} is not ready",
+                    code="REFERENCED_SELECTION_NOT_READY",
+                    reason="latest selection is not ready yet",
+                    action="Wait for this list to finish processing, then retry this Combinator.",
                 )
             return b"ok\n"
 
@@ -267,6 +276,7 @@ class CombinatorBuilderTest(BaseWpOneDbTest):
         with self.assertRaises(Wp1RetryableSelectionError) as context:
             self.builder.build("text/tab-separated-values", **params)
 
+        self.assertIsInstance(context.exception.__cause__, Wp1MetaBuilderProcessError)
         self.assertEqual(3, mock_fetch_selection_data.call_count)
         message = str(context.exception)
         self.assertIn("Builder A (builder-a) is not ready", message)
@@ -297,17 +307,18 @@ class CombinatorBuilderTest(BaseWpOneDbTest):
 
         def fetch_selection(_wp10db, _s3, builder_id, label):
             if builder_id == "builder-b":
-                raise Wp1RetryableSelectionError(
-                    f"Referenced builder {label} is not ready"
+                raise Wp1RetryableMetaSelectionError(
+                    f"Referenced builder {label} is not ready",
+                    code="REFERENCED_SELECTION_NOT_READY",
+                    reason="latest selection is not ready yet",
+                    action="Wait for this list to finish processing, then retry this Combinator.",
                 )
             if builder_id == "builder-c":
-                raise Wp1FatalSelectionError(
+                raise Wp1FatalMetaSelectionError(
                     f"Referenced builder {label} latest selection failed",
-                    extra={
-                        "dependency_code": "REFERENCED_SELECTION_FAILED",
-                        "dependency_reason": "latest selection failed",
-                        "dependency_action": "Open this list, fix the failed selection, then update this Combinator.",
-                    },
+                    code="REFERENCED_SELECTION_FAILED",
+                    reason="latest selection failed",
+                    action="Open this list, fix the failed selection, then update this Combinator.",
                 )
             return b"ok\n"
 
@@ -322,17 +333,19 @@ class CombinatorBuilderTest(BaseWpOneDbTest):
         with self.assertRaises(Wp1FatalSelectionError) as context:
             self.builder.build("text/tab-separated-values", **params)
 
+        self.assertIsInstance(context.exception.__cause__, Wp1MetaBuilderProcessError)
         self.assertEqual(3, mock_fetch_selection_data.call_count)
         message = str(context.exception)
         self.assertIn("Builder B (builder-b) is not ready", message)
         self.assertIn("Builder C (builder-c) latest selection failed", message)
         referenced_errors = context.exception.extra["referenced_builder_errors"]
         self.assertEqual(
-            ["FAILED", "CAN_RETRY"],
+            ["CAN_RETRY", "FAILED"],
             [error["status"] for error in referenced_errors],
         )
-        self.assertEqual("REFERENCED_SELECTION_FAILED", referenced_errors[0]["code"])
-        self.assertIn("fix the failed selection", referenced_errors[0]["action"])
+        fatal_error = referenced_errors[1]
+        self.assertEqual("REFERENCED_SELECTION_FAILED", fatal_error["code"])
+        self.assertIn("fix the failed selection", fatal_error["action"])
 
     def test_validate_with_referenced_builder_in_db(self):
         self._insert_builder()


### PR DESCRIPTION
**Problem**
- Combinator builds only surfaced the first failed referenced list, so users had to fix errors one at a time and rerun the Combinator to discover the next failure.

**Summary**
- Added structured dependency error metadata for Combinator referenced-list failures.
- Collected all failed referenced lists instead of stopping at the first failure.
- Added clear user-facing reasons and actions for each dependency failure.
- Linked each failed referenced list from the Combinator error message.

fixes #1184