### PR TITLE
Fix Cypress failures: stub replag script, format ZIM date in UTC

### DIFF
--- a/wp1-frontend/cypress/support/e2e.js
+++ b/wp1-frontend/cypress/support/e2e.js
@@ -16,5 +16,16 @@
 // Import commands.js using ES2015 syntax:
 import './commands';
 
+// The replag banner script is third-party code fetched live from wmflabs on
+// every page load. Upstream changes to it can throw in the test browser and
+// fail every spec (Cypress fails tests on any uncaught exception). No test
+// asserts on the banner, so serve an empty script instead.
+beforeEach(() => {
+  cy.intercept(
+    { url: 'https://tools-static.wmflabs.org/replag-embed/replag-embed.js' },
+    { body: '' }
+  );
+});
+
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/wp1-frontend/src/components/ZimFile.vue
+++ b/wp1-frontend/src/components/ZimFile.vue
@@ -652,10 +652,14 @@ export default {
       if (!dateString) return 'Unknown';
       try {
         const date = new Date(dateString);
+        // The backend sends a date-only string (YYYY-MM-DD), which parses as
+        // UTC midnight. Format in UTC too, so the date doesn't shift for
+        // viewers in timezones behind UTC.
         return date.toLocaleDateString('en-US', {
           year: 'numeric',
           month: 'long',
           day: 'numeric',
+          timeZone: 'UTC',
         });
       } catch {
         return dateString;


### PR DESCRIPTION
## Problem

CI's `frontend-cypress` job started failing on every spec (13 of 13, 62 failures) with:

> `TypeError: Failed to execute 'setHTML' on 'Element': Failed to read the 'sanitizer' property from 'ElementSetHTMLOptions': Failed to convert value to 'Sanitizer'` — at `https://tools-static.wmflabs.org/replag-embed/replag-embed.js:41`

The replag banner script is fetched live from wmflabs on every page load (`index.html`). An upstream change to it (it now passes a new-spec Sanitizer config to `Element.setHTML()`) throws in Cypress's bundled Electron browser, and Cypress fails any test whose app throws an uncaught exception. Nothing in this repo changed — `main` was green two days before the same code went red.

## Fixes

- **Stub `replag-embed.js` in `cypress/support/e2e.js`**: a global `cy.intercept` serves an empty body for the script, so tests no longer execute third-party code fetched over the network (also removes a flakiness/external-dependency liability). No test asserts on the banner. Real browsers are unaffected.
- **Format the ZIM next-generation date in UTC** (`ZimFile.vue`): found while re-running the suite locally. The backend sends a date-only `YYYY-MM-DD` string, which `new Date()` parses as UTC midnight, but it was formatted in the viewer's local timezone — so the zimFile spec's "shows the next generation date" test fails in any timezone behind UTC, and real users west of UTC see the previous day. Adding `timeZone: 'UTC'` to `toLocaleDateString` fixes both. (This never failed in CI, which runs in UTC.)

## Testing

Full Cypress suite run locally against the dev stack, twice: **193/193 passing across all 13 specs.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)