### PR TITLE
Exclude base_web_testcase.py from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 source = wp1/
 omit =
     *_test.py
+    */base_web_testcase.py
 
 [report]
 show_missing = True


### PR DESCRIPTION
## Summary
- Add `*/base_web_testcase.py` to the `.coveragerc` omit list. It is a test-support base class imported only by the web tests, but it slipped through the existing `*_test.py` omit pattern and was being counted in coverage metrics.
- This closes the last gap for #981: `.coveragerc` (added in d48d868) already excludes `*_test.py` files, and a sweep of `wp1/` found no other test/mock/fixture helper files outside that pattern.

Fixes #981

## Test plan
- Ran `pytest --cov --cov-config=.coveragerc` and verified the coverage table enumerates the `wp1/` tree with no `*_test.py` files and no `base_web_testcase.py`.
- Ran the repo's pre-commit hooks (trailing-whitespace, end-of-file-fixer, prettier) on the changed file: all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)