### PR TITLE
Publish immutable image tags for rollbacks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,13 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.project }}
+          # In addition to the moving `release` tag, publish immutable
+          # tags (`release-<run number>` and `sha-<git sha>`) so that
+          # previous versions can be pulled for rollbacks. See #974.
+          tags: |
+            type=ref,event=branch
+            type=raw,value=release-${{ github.run_number }}
+            type=sha
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4

--- a/README.md
+++ b/README.md
@@ -390,6 +390,34 @@ The `serve` command should print out the port to view the docs at, likely localh
 - Run the production database migrations in the worker container:
   - `sudo docker exec -ti -e PYTHONPATH=. wp1bot-workers yoyo -c /usr/src/app/db/production/yoyo.ini apply`
 
+# Rolling back production
+
+In addition to the moving `release` tag, every push to the `release`
+branch publishes each image with two immutable tags: `release-<n>`
+(where `<n>` is the run number of the publish workflow) and
+`sha-<git sha>`. The available versions for each image are listed on
+its GitHub packages page:
+
+- https://github.com/openzim/wp1/pkgs/container/wp1-workers/versions
+- https://github.com/openzim/wp1/pkgs/container/wp1-web/versions
+- https://github.com/openzim/wp1/pkgs/container/wp1-frontend/versions
+
+To roll back a bad deploy, log in to the production machine, then pull
+the previous version of each image and re-tag it locally as `release`
+(no registry login or push is required, the local tag is what
+docker compose uses):
+
+- `sudo docker pull ghcr.io/openzim/wp1-workers:release-41`
+- `sudo docker tag ghcr.io/openzim/wp1-workers:release-41 ghcr.io/openzim/wp1-workers:release`
+- Repeat for `wp1-web` and `wp1-frontend`, then recreate the containers:
+- `sudo docker compose up -d`
+
+Note that the next normal deploy (`docker pull ... :release`) rolls
+forward again. If the deploy being rolled back included database
+migrations, roll those back too:
+
+- `sudo docker exec -ti -e PYTHONPATH=. wp1bot-workers yoyo -c /usr/src/app/db/production/yoyo.ini rollback`
+
 # Pre-commit hooks
 
 This project is configured to use git pre-commit hooks managed by the


### PR DESCRIPTION
## Summary
- The publish workflow previously pushed only the moving `release` tag, so rolling back a bad deploy meant fishing sha256 digests out of the registry UI with a PAT (the procedure described in #974).
- Each image is now also published with two immutable tags:
  - `release-<n>` — the sequential run number of the publish workflow, matching the `release-1`, `release-2` scheme requested in the issue
  - `sha-<short git sha>` — ties each image to the exact commit it was built from
- Adds a "Rolling back production" section to the README: pull the previous `release-<n>` tag on the production machine, `docker tag` it locally as `release`, and `docker compose up -d`. No registry login or push needed, plus a note about rolling back migrations with yoyo.

Fixes #974

## Test plan
- Validated the workflow YAML parses and the metadata-action `tags` block emits `type=ref,event=branch`, `type=raw,value=release-<run number>`, and `type=sha`.
- Ran the repo's pre-commit hooks (trailing-whitespace, end-of-file-fixer, prettier) on both changed files: all passed.
- The tag output itself can be confirmed on the next push to `release` in the publish workflow logs / GHCR package versions pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)