### PR TITLE
Fix 500 on project table when ratings have NULL quality/importance

### DIFF
--- a/wp1/tables.py
+++ b/wp1/tables.py
@@ -283,11 +283,18 @@ def data_for_stats(stats):
     cols = {}
 
     for row in stats:
+        # A NULL quality or importance means the article has been rated on
+        # one axis but not the other. cleanup_project normalizes these to
+        # NOT_A_CLASS in the database, but the stats query can still see NULL
+        # rows (e.g. mid-update). Treat them as NOT_A_CLASS here as well, so
+        # that None never ends up as a table data key.
+        q = row["q"] if row["q"] is not None else NOT_A_CLASS
+        i = row["i"] if row["i"] is not None else NOT_A_CLASS
         # The += here is for 'NotA-Class' classifications, which
         # could happen either as a result of an actual category or as
         # the result of the if statements above
-        data[row["q"]][row["i"]] += row["n"]
-        cols[row["i"]] = 1
+        data[q][i] += row["n"]
+        cols[i] = 1
 
     return data, cols
 

--- a/wp1/tables_test.py
+++ b/wp1/tables_test.py
@@ -704,6 +704,56 @@ class TablesDbTest(BaseWpOneDbTest):
             self.wp10db.close = orig_close
 
 
+class TablesNullRatingsTest(unittest.TestCase):
+    # Stats as returned by get_project_stats for a project where some
+    # articles have a NULL quality or importance rating in the database.
+    stats = [
+        {"n": 3, "q": b"B-Class", "i": b"High-Class"},
+        {"n": 2, "q": b"B-Class", "i": None},
+        {"n": 1, "q": None, "i": b"Low-Class"},
+        {"n": 4, "q": b"Unassessed-Class", "i": b"Low-Class"},
+    ]
+
+    categories = {
+        "sort_qual": {
+            b"B-Class": 300,
+            tables.NOT_A_CLASS: 11,
+            tables.UNASSESSED_CLASS: 0,
+        },
+        "sort_imp": {
+            b"High-Class": 300,
+            b"Low-Class": 100,
+            tables.NOT_A_CLASS: 11,
+        },
+        "qual_labels": {},
+        "imp_labels": {},
+    }
+
+    def test_data_for_stats_maps_null_to_not_a_class(self):
+        data, cols = tables.data_for_stats(self.stats)
+
+        self.assertNotIn(None, cols)
+        self.assertNotIn(None, data)
+        for value in data.values():
+            self.assertNotIn(None, value)
+        self.assertEqual(2, data[b"B-Class"][tables.NOT_A_CLASS])
+        self.assertEqual(1, data[tables.NOT_A_CLASS][b"Low-Class"])
+
+    def test_convert_table_data_for_web_with_null_ratings(self):
+        table_data = tables.generate_table_data(
+            self.stats,
+            self.categories,
+            {"project": b"Test_Project", "project_display": "Test Project"},
+        )
+
+        # This raised AttributeError ("'NoneType' object has no attribute
+        # 'decode'") before NULL ratings were mapped to NOT_A_CLASS.
+        actual = tables.convert_table_data_for_web(table_data)
+
+        self.assertEqual(2, actual["data"]["B-Class"]["NotA-Class"])
+        self.assertEqual(1, actual["data"]["NotA-Class"]["Low-Class"])
+
+
 class TestMakeWikiLink(unittest.TestCase):
 
     def test_creates_link(self):


### PR DESCRIPTION
## What

`GET /v1/projects/<name>/table` returned a 500 for some projects (e.g. Calvinism):

```
File ".../wp1/tables.py", line 186, in <genexpr>
    (k.decode("utf-8"), v) for k, v in value.items()
AttributeError: 'NoneType' object has no attribute 'decode'
```

## Root cause

The `ratings` table can contain rows where `r_quality` or `r_importance` is NULL — an article rated on one axis but not the other, or a rating category the bot doesn't recognize. `cleanup_project` normalizes these NULLs to the `NotA-Class` sentinel at the end of each update run, but the stats query behind the table (`get_project_stats`) can still see NULL rows in between. A NULL importance becomes a `None` key in the nested table data built by `data_for_stats`; `generate_table_data` removes the unknown *column* from `cols`/`ordered_cols` (so wiki uploads never crashed) but leaves the key in the inner per-quality dicts, and `convert_table_data_for_web` then tries to `.decode()` it.

A comment in `data_for_stats` referring to NULL handling "in the if statements above" suggests this mapping existed in an ancestral implementation and was lost in a port.

## Fix

Map NULL quality/importance to `NOT_A_CLASS` in `data_for_stats`, mirroring exactly what `cleanup_project` does to the same values in the database. Such articles now count under the "Other" column/row instead of crashing the web view (previously they were silently excluded from totals).

## Tests

New `TablesNullRatingsTest` unit tests (no DB needed): one asserts `data_for_stats` produces no `None` keys, one runs `generate_table_data` → `convert_table_data_for_web` end-to-end on stats containing NULLs — reproducing the exact production `AttributeError` before the fix. Full `tables_test.py` (32) and `web/projects_test.py` (49) pass.

Note for deployment: the Redis table cache (1-day TTL) may still hold already-poisoned pickles; affected projects can 500 until their cache entries expire or are regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)