### PR TITLE
add zimfarm oauth config vars

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -15,4 +15,5 @@ STORAGE_URL=http://minio:9000
 CLIENT_BACKEND_URL=http://wp1bot-web-dev:5000
 CLIENT_BACKEND_S3_URL=http://minio:9000/org-kiwix-dev-wp1
 ZIMFARM_URL=http://zimfarm-api/v2
+ZIMFARM_AUTH_MODE=local
 ZIMFARM_S3_URL=https://minio:9000/org-kiwix-dev-zims

--- a/.env.example
+++ b/.env.example
@@ -137,6 +137,11 @@ ZIMFARM_URL=http://localhost:8003/v2
 ZIMFARM_S3_URL=https://localhost:9000/org-kiwix-dev-zims  # if using minio
 ZIMFARM_USER=admin
 ZIMFARM_PASSWORD=admin
+ZIMFARM_AUTH_MODE=ouath # can be 'oauth' or 'local'
+ZIMFARM_OAUTH_ISSUER=https://ory.login.kiwix.org
+ZIMFARM_OAUTH_CLIENT_ID="zimfarm_oauth_client_id" # remove if auth mode is 'local'
+ZIMFARM_OAUTH_CLIENT_SECRET="zimfarm_oauth_client_secret" # remove if auth mode is 'local'
+ZIMFARM_OAUTH_AUDIENCE_ID="zimfarm_oauth_audience_id" # remove if auth mode is 'local'
 # A simple token secret exchanged between the WP1 server and the zimfarm
 # server, to ensure requests to the webhook endpoint are valid.
 

--- a/.env.test
+++ b/.env.test
@@ -57,6 +57,7 @@ STORAGE_SECRET=test_secret
 STORAGE_BUCKET=org-kiwix-dev-wp1
 
 # Fake Zimfarm values for tests
+ZIMFARM_AUTH_MODE=local
 ZIMFARM_URL=https://fake.farm/v2
 ZIMFARM_S3_URL=https://fake.wasabisys.com/org-kiwix-zimit
 ZIMFARM_USER=farmuser

--- a/wp1/config.py
+++ b/wp1/config.py
@@ -25,7 +25,6 @@ else:
 
 
 def _getenv(key, *, default=None, required=False):
-
     value = os.environ.get(key)
     if value is None:
         if required:
@@ -74,7 +73,6 @@ def _resolve_env():
 
 
 class Config:
-
     # --- Environment ---
     ENV = _resolve_env()
     CONF_LANG = _getenv("WP1_CONF_LANG", default="en")
@@ -133,6 +131,8 @@ class Config:
 
     # --- Zimfarm ---
     ZIMFARM_URL = _getenv("ZIMFARM_URL", default="http://localhost:8003/v2")
+    # Authentication mode: 'oauth' or 'local'
+    ZIMFARM_AUTH_MODE = _getenv("ZIMFARM_AUTH_MODE", default="local")
     ZIMFARM_S3_URL = _getenv(
         "ZIMFARM_S3_URL", default="https://localhost:9000/org-kiwix-dev-zims"
     )
@@ -144,6 +144,19 @@ class Config:
     )
     ZIMFARM_DEFINITION_VERSION = _getenv("ZIMFARM_DEFINITION_VERSION")
     ZIMFARM_CACHE_URL = _getenv("ZIMFARM_CACHE_URL")  # production only
+    ZIMFARM_OAUTH_ISSUER = _getenv(
+        "ZIMFARM_OAUTH_ISSUER",
+        default="https://ory.login.kiwix.org",
+    )
+    ZIMFARM_OAUTH_CLIENT_ID = _getenv(
+        "ZIMFARM_OAUTH_CLIENT_ID", required=ZIMFARM_AUTH_MODE == "oauth"
+    )
+    ZIMFARM_OAUTH_CLIENT_SECRET = _getenv(
+        "ZIMFARM_OAUTH_CLIENT_SECRET", required=ZIMFARM_AUTH_MODE == "oauth"
+    )
+    ZIMFARM_OAUTH_AUDIENCE_ID = _getenv(
+        "ZIMFARM_OAUTH_AUDIENCE_ID", required=ZIMFARM_AUTH_MODE == "oauth"
+    )
 
     # --- Mailgun ---
     MAILGUN_URL = _getenv(

--- a/wp1/credentials.py
+++ b/wp1/credentials.py
@@ -79,6 +79,7 @@ _active_creds = {
         "bucket": Config.STORAGE_BUCKET,
     },
     "ZIMFARM": {
+        "auth_mode": Config.ZIMFARM_AUTH_MODE,
         "url": Config.ZIMFARM_URL,
         "s3_url": Config.ZIMFARM_S3_URL,
         "user": Config.ZIMFARM_USER,
@@ -95,6 +96,10 @@ _active_creds = {
             if Config.ZIMFARM_CACHE_URL is not None
             else {}
         ),
+        "oauth_issuer": Config.ZIMFARM_OAUTH_ISSUER,
+        "oauth_client_id": Config.ZIMFARM_OAUTH_CLIENT_ID,
+        "oauth_client_secret": Config.ZIMFARM_OAUTH_CLIENT_SECRET,
+        "oauth_audience_id": Config.ZIMFARM_OAUTH_AUDIENCE_ID,
     },
     "MAILGUN": {
         "url": Config.MAILGUN_URL,

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -74,7 +74,7 @@ class ZimfarmClientTokenProvider:
         self._zimfarm_creds: dict[str, Any] = CREDENTIALS[ENV].get("ZIMFARM", {})
 
     def _validate_creds(self):
-        if self._zimfarm_creds.get("auth_mode", "local") == "local":
+        if self._zimfarm_creds.get("auth_mode") == "local":
             if not (
                 self._zimfarm_creds.get("user") and self._zimfarm_creds.get("password")
             ):


### PR DESCRIPTION
## Changes
- add zimfarm oauth authentication credentials introduced in https://github.com/openzim/wp1/pull/1146 so they can be loaded from .env (https://github.com/openzim/wp1/pull/1102)

This closes https://github.com/openzim/wp1/issues/1225