### PR TITLE
Add Cypress coverage for update, compare, petscan and book pages

### DIFF
--- a/wp1-frontend/cypress/e2e/comparePage.cy.js
+++ b/wp1-frontend/cypress/e2e/comparePage.cy.js
@@ -1,0 +1,64 @@
+/// <reference types="Cypress" />
+
+describe('the compare projects page', () => {
+  beforeEach(() => {
+    // ArticleTable renders paired rows (row[0]/row[1]) when projectIdB is
+    // set, so the flat single-project fixture is reshaped into pairs here
+    // rather than stubbed as-is.
+    cy.fixture('articles_alien_predator.json').then((articles) => {
+      cy.intercept('v1/projects/Alien/articles?projectB=Aesthetics*', {
+        ...articles,
+        articles: articles.articles.map((article) => [article, article]),
+      }).as('compareArticles');
+    });
+  });
+
+  describe('with no URL parameters', () => {
+    beforeEach(() => {
+      cy.visit('/#/compare');
+    });
+
+    it('successfully loads', () => {});
+
+    it('shows two autocompletes and a disabled compare button', () => {
+      cy.get('input.search').should('have.length', 2);
+      cy.contains('button', 'Compare').should('have.attr', 'disabled');
+    });
+
+    it('enables compare after selecting two projects', () => {
+      cy.get('input.search').eq(0).type('Alien');
+      cy.get('.results:visible .result').first().click();
+      cy.get('input.search').eq(1).type('Aesthetics');
+      cy.get('.results:visible .result').first().click();
+      cy.contains('button', 'Compare').should('not.have.attr', 'disabled');
+    });
+
+    it('navigates and renders the table on compare click', () => {
+      cy.get('input.search').eq(0).type('Alien');
+      cy.get('.results:visible .result').first().click();
+      cy.get('input.search').eq(1).type('Aesthetics');
+      cy.get('.results:visible .result').first().click();
+      cy.contains('button', 'Compare').click();
+      cy.url().should('include', '/#/compare/Alien/Aesthetics');
+      cy.wait('@compareArticles');
+      cy.contains('Alien vs. Predator (film)');
+    });
+  });
+
+  describe('with projects in the URL', () => {
+    beforeEach(() => {
+      cy.visit('/#/compare/Alien/Aesthetics');
+    });
+
+    it('prefills both autocompletes', () => {
+      cy.get('input.search').eq(0).should('have.value', 'Alien');
+      cy.get('input.search').eq(1).should('have.value', 'Aesthetics');
+    });
+
+    it('renders the comparison table without a compare button', () => {
+      cy.wait('@compareArticles');
+      cy.contains('button', 'Compare').should('not.exist');
+      cy.contains('Alien vs. Predator (film)');
+    });
+  });
+});

--- a/wp1-frontend/cypress/e2e/createBookList.cy.js
+++ b/wp1-frontend/cypress/e2e/createBookList.cy.js
@@ -1,0 +1,189 @@
+/// <reference types="Cypress" />
+
+describe('the book builder page', () => {
+  describe('when the user is logged in', () => {
+    beforeEach(() => {
+      cy.intercept('v1/sites/', { fixture: 'sites.json' });
+      cy.intercept('v1/oauth/identify', { fixture: 'identity.json' });
+    });
+
+    describe('creating a new selection', () => {
+      beforeEach(() => {
+        cy.visit('/#/selections/book');
+      });
+
+      it('successfully loads', () => {});
+
+      it('displays wiki projects', () => {
+        cy.get('select').contains('aa.wikipedia.org');
+        cy.get('select').contains('en.wiktionary.org');
+        cy.get('select').contains('en.wikipedia.org');
+      });
+
+      it('validates list name on clicking save', () => {
+        cy.get('#saveListButton').click();
+        cy.get('#listName').contains('Please provide a valid list name');
+        cy.get('#listName > .invalid-feedback').should('be.visible');
+      });
+
+      it('shows URL validation error from the server', () => {
+        cy.get('#listName > .form-control').click().type('My List');
+        cy.get('#bookUrl').click().type('not-a-book-url');
+        cy.intercept('v1/builders/', { fixture: 'save_book_failure.json' });
+        cy.get('#saveListButton').click();
+        cy.get('#items > .invalid-feedback').should('be.visible');
+        cy.get('#invalid_articles').contains('Invalid Book URL');
+      });
+
+      it('redirects on successful save', () => {
+        cy.get('#listName > .form-control').click().type('My List');
+        cy.get('#bookUrl')
+          .click()
+          .type('https://en.wikipedia.org/wiki/Book:Example');
+        cy.intercept('v1/builders/', { fixture: 'save_list_success.json' });
+        cy.get('#saveListButton').click();
+        cy.url().should('eq', 'http://localhost:5173/#/selections/user');
+      });
+
+      it('sends correct data to the API', () => {
+        cy.get('#listName > .form-control').click().type('My List');
+        cy.get('#bookUrl')
+          .click()
+          .type('https://en.wikipedia.org/wiki/Book:Example');
+        cy.intercept('v1/builders/', { fixture: 'save_list_success.json' }).as(
+          'saveBuilder'
+        );
+        cy.get('#saveListButton').click();
+        cy.wait('@saveBuilder').then((interception) => {
+          expect(interception.request.body.model).to.equal(
+            'wp1.selection.models.book'
+          );
+          expect(interception.request.body.params.url).to.equal(
+            'https://en.wikipedia.org/wiki/Book:Example'
+          );
+        });
+      });
+
+      describe('when save button clicked', () => {
+        beforeEach(() => {
+          // Delayed reply keeps the spinner visible to assert on.
+          cy.intercept('v1/builders/', {
+            delay: 4000,
+            statusCode: 200,
+            fixture: 'save_list_success.json',
+          });
+          cy.get('#listName > .form-control').click().type('My List');
+          cy.get('#bookUrl')
+            .click()
+            .type('https://en.wikipedia.org/wiki/Book:Example');
+          cy.get('#saveListButton').click();
+        });
+
+        it('shows spinner', () => {
+          cy.get('#saveLoader').should('be.visible');
+        });
+
+        it('disables save button', () => {
+          cy.get('#saveListButton').should('have.attr', 'disabled');
+        });
+      });
+    });
+
+    describe('editing an existing selection', () => {
+      describe('and the builder is found', () => {
+        beforeEach(() => {
+          cy.intercept('GET', 'v1/builders/3', {
+            fixture: 'book_builder.json',
+          }).as('builder');
+          cy.visit('/#/selections/book/3');
+          cy.wait('@builder');
+        });
+
+        it('displays builder information', () => {
+          cy.get('#listName > .form-control').should(
+            'have.value',
+            'Book Builder'
+          );
+          cy.get('#bookUrl').should(
+            'have.value',
+            'https://en.wikipedia.org/wiki/Book:Example'
+          );
+        });
+
+        it('sends correct data to the API on update', () => {
+          cy.intercept('POST', 'v1/builders/3', {
+            fixture: 'save_list_success.json',
+          }).as('updateBuilder');
+          cy.get('#updateListButton').click();
+          cy.wait('@updateBuilder').then((interception) => {
+            expect(interception.request.body.params.url).to.equal(
+              'https://en.wikipedia.org/wiki/Book:Example'
+            );
+          });
+        });
+
+        it('redirects on successful update', () => {
+          cy.intercept('POST', 'v1/builders/3', {
+            fixture: 'save_list_success.json',
+          });
+          cy.get('#updateListButton').click();
+          cy.url().should('eq', 'http://localhost:5173/#/selections/user');
+        });
+      });
+
+      describe('and the builder has fatal errors', () => {
+        beforeEach(() => {
+          cy.intercept('GET', 'v1/builders/3', {
+            fixture: 'book_builder_fatal_error.json',
+          });
+          cy.visit('/#/selections/book/3');
+        });
+
+        it('displays the error div with a disabled retry button', () => {
+          cy.get('.materialize-error').should('be.visible');
+          cy.get('.materialize-error .btn').should('have.attr', 'disabled');
+        });
+      });
+
+      describe('and the builder has retryable errors', () => {
+        beforeEach(() => {
+          cy.intercept('GET', 'v1/builders/3', {
+            fixture: 'book_builder_retryable_error.json',
+          });
+          cy.visit('/#/selections/book/3');
+        });
+
+        it('displays the error div with an enabled retry button', () => {
+          cy.get('.materialize-error').should('be.visible');
+          cy.get('.materialize-error .btn').should('not.have.attr', 'disabled');
+        });
+      });
+
+      describe('and the builder is not found', () => {
+        beforeEach(() => {
+          cy.intercept('GET', 'v1/builders/3', {
+            statusCode: 404,
+            body: '404 NOT FOUND',
+          });
+          cy.visit('/#/selections/book/3');
+        });
+
+        it('displays the 404 text', () => {
+          cy.get('#404').should('be.visible');
+        });
+      });
+    });
+  });
+
+  describe('when the user is not logged in', () => {
+    beforeEach(() => {
+      cy.intercept('v1/sites/', { fixture: 'sites.json' });
+    });
+
+    it('opens login page', () => {
+      cy.visit('/#/selections/book');
+      cy.contains('Please Log In To Continue');
+      cy.get('.pt-2 > .btn');
+    });
+  });
+});

--- a/wp1-frontend/cypress/e2e/createPetscanList.cy.js
+++ b/wp1-frontend/cypress/e2e/createPetscanList.cy.js
@@ -176,6 +176,10 @@ describe('the petscan builder page', () => {
   });
 
   describe('when the user is not logged in', () => {
+    beforeEach(() => {
+      cy.intercept('v1/sites/', { fixture: 'sites.json' });
+    });
+
     it('opens login page', () => {
       cy.visit('/#/selections/petscan');
       cy.contains('Please Log In To Continue');

--- a/wp1-frontend/cypress/e2e/createPetscanList.cy.js
+++ b/wp1-frontend/cypress/e2e/createPetscanList.cy.js
@@ -1,0 +1,185 @@
+/// <reference types="Cypress" />
+
+describe('the petscan builder page', () => {
+  describe('when the user is logged in', () => {
+    beforeEach(() => {
+      cy.intercept('v1/sites/', { fixture: 'sites.json' });
+      cy.intercept('v1/oauth/identify', { fixture: 'identity.json' });
+    });
+
+    describe('creating a new selection', () => {
+      beforeEach(() => {
+        cy.visit('/#/selections/petscan');
+      });
+
+      it('successfully loads', () => {});
+
+      it('displays wiki projects', () => {
+        cy.get('select').contains('aa.wikipedia.org');
+        cy.get('select').contains('en.wiktionary.org');
+        cy.get('select').contains('en.wikipedia.org');
+      });
+
+      it('validates list name on clicking save', () => {
+        cy.get('#saveListButton').click();
+        cy.get('#listName').contains('Please provide a valid list name');
+        cy.get('#listName > .invalid-feedback').should('be.visible');
+      });
+
+      it('shows URL validation error from the server', () => {
+        cy.get('#listName > .form-control').click().type('My List');
+        cy.get('#petscanUrl').click().type('not-a-petscan-url');
+        cy.intercept('v1/builders/', { fixture: 'save_petscan_failure.json' });
+        cy.get('#saveListButton').click();
+        cy.get('#items > .invalid-feedback').should('be.visible');
+        cy.get('#invalid_articles').contains('Invalid PetScan URL');
+      });
+
+      it('redirects on successful save', () => {
+        cy.get('#listName > .form-control').click().type('My List');
+        cy.get('#petscanUrl')
+          .click()
+          .type('https://petscan.wmflabs.org/?psid=123456');
+        cy.intercept('v1/builders/', { fixture: 'save_list_success.json' });
+        cy.get('#saveListButton').click();
+        cy.url().should('eq', 'http://localhost:5173/#/selections/user');
+      });
+
+      it('sends correct data to the API', () => {
+        cy.get('#listName > .form-control').click().type('My List');
+        cy.get('#petscanUrl')
+          .click()
+          .type('https://petscan.wmflabs.org/?psid=123456');
+        cy.intercept('v1/builders/', { fixture: 'save_list_success.json' }).as(
+          'saveBuilder'
+        );
+        cy.get('#saveListButton').click();
+        cy.wait('@saveBuilder').then((interception) => {
+          expect(interception.request.body.model).to.equal(
+            'wp1.selection.models.petscan'
+          );
+          expect(interception.request.body.params.url).to.equal(
+            'https://petscan.wmflabs.org/?psid=123456'
+          );
+        });
+      });
+
+      describe('when save button clicked', () => {
+        beforeEach(() => {
+          // Delayed reply keeps the spinner visible to assert on.
+          cy.intercept('v1/builders/', {
+            delay: 4000,
+            statusCode: 200,
+            fixture: 'save_list_success.json',
+          });
+          cy.get('#listName > .form-control').click().type('My List');
+          cy.get('#petscanUrl')
+            .click()
+            .type('https://petscan.wmflabs.org/?psid=123456');
+          cy.get('#saveListButton').click();
+        });
+
+        it('shows spinner', () => {
+          cy.get('#saveLoader').should('be.visible');
+        });
+
+        it('disables save button', () => {
+          cy.get('#saveListButton').should('have.attr', 'disabled');
+        });
+      });
+    });
+
+    describe('editing an existing selection', () => {
+      describe('and the builder is found', () => {
+        beforeEach(() => {
+          cy.intercept('GET', 'v1/builders/3', {
+            fixture: 'petscan_builder.json',
+          }).as('builder');
+          cy.visit('/#/selections/petscan/3');
+          cy.wait('@builder');
+        });
+
+        it('displays builder information', () => {
+          cy.get('#listName > .form-control').should(
+            'have.value',
+            'Petscan Builder'
+          );
+          cy.get('#petscanUrl').should(
+            'have.value',
+            'https://petscan.wmflabs.org/?psid=123456'
+          );
+        });
+
+        it('sends correct data to the API on update', () => {
+          cy.intercept('POST', 'v1/builders/3', {
+            fixture: 'save_list_success.json',
+          }).as('updateBuilder');
+          cy.get('#updateListButton').click();
+          cy.wait('@updateBuilder').then((interception) => {
+            expect(interception.request.body.params.url).to.equal(
+              'https://petscan.wmflabs.org/?psid=123456'
+            );
+          });
+        });
+
+        it('redirects on successful update', () => {
+          cy.intercept('POST', 'v1/builders/3', {
+            fixture: 'save_list_success.json',
+          });
+          cy.get('#updateListButton').click();
+          cy.url().should('eq', 'http://localhost:5173/#/selections/user');
+        });
+      });
+
+      describe('and the builder has fatal errors', () => {
+        beforeEach(() => {
+          cy.intercept('GET', 'v1/builders/3', {
+            fixture: 'petscan_builder_fatal_error.json',
+          });
+          cy.visit('/#/selections/petscan/3');
+        });
+
+        it('displays the error div with a disabled retry button', () => {
+          cy.get('.materialize-error').should('be.visible');
+          cy.get('.materialize-error .btn').should('have.attr', 'disabled');
+        });
+      });
+
+      describe('and the builder has retryable errors', () => {
+        beforeEach(() => {
+          cy.intercept('GET', 'v1/builders/3', {
+            fixture: 'petscan_builder_retryable_error.json',
+          });
+          cy.visit('/#/selections/petscan/3');
+        });
+
+        it('displays the error div with an enabled retry button', () => {
+          cy.get('.materialize-error').should('be.visible');
+          cy.get('.materialize-error .btn').should('not.have.attr', 'disabled');
+        });
+      });
+
+      describe('and the builder is not found', () => {
+        beforeEach(() => {
+          cy.intercept('GET', 'v1/builders/3', {
+            statusCode: 404,
+            body: '404 NOT FOUND',
+          });
+          cy.visit('/#/selections/petscan/3');
+        });
+
+        it('displays the 404 text', () => {
+          cy.get('#404').should('be.visible');
+        });
+      });
+    });
+  });
+
+  describe('when the user is not logged in', () => {
+    it('opens login page', () => {
+      cy.visit('/#/selections/petscan');
+      cy.contains('Please Log In To Continue');
+      cy.get('.pt-2 > .btn');
+    });
+  });
+});

--- a/wp1-frontend/cypress/e2e/updatePage.cy.js
+++ b/wp1-frontend/cypress/e2e/updatePage.cy.js
@@ -1,0 +1,107 @@
+/// <reference types="Cypress" />
+
+describe('the manual update page', () => {
+  describe('when the user is logged in', () => {
+    beforeEach(() => {
+      cy.intercept('v1/oauth/identify', { fixture: 'identity.json' });
+    });
+
+    describe('and no project is selected', () => {
+      beforeEach(() => {
+        cy.visit('/#/update');
+      });
+
+      it('successfully loads', () => {});
+
+      it('displays the manual update instructions', () => {
+        cy.contains('To begin a manual update');
+      });
+
+      it('does not show the update button', () => {
+        cy.contains('button', 'Manual Update').should('not.exist');
+      });
+    });
+
+    describe('and a project is selected via autocomplete', () => {
+      beforeEach(() => {
+        cy.intercept('v1/projects/Alien/update/time', {
+          body: { next_update_time: null },
+        }).as('updateTime');
+        cy.visit('/#/update');
+        cy.get('input.search').type('Alien');
+        cy.get('.results .result').first().click();
+        cy.wait('@updateTime');
+      });
+
+      it('navigates to the project update URL', () => {
+        cy.url().should('eq', 'http://localhost:5173/#/update/Alien');
+      });
+
+      it('shows the update confirmation button', () => {
+        cy.contains('Proceed with manual update of');
+        cy.contains('button', 'Manual Update');
+      });
+
+      describe('when the update button is clicked', () => {
+        beforeEach(() => {
+          cy.intercept('POST', 'v1/projects/Alien/update', {
+            body: { next_update_time: '2026-08-01T00:00:00Z' },
+          }).as('postUpdate');
+          cy.intercept('v1/projects/Alien/update/progress', {
+            body: {
+              job: { progress: 50, total: 100 },
+              queue: { status: 'started' },
+            },
+          }).as('progress');
+          cy.contains('button', 'Manual Update').click();
+        });
+
+        it('POSTs to the update endpoint', () => {
+          cy.wait('@postUpdate');
+        });
+
+        it('shows the scheduled message and progress bar', () => {
+          cy.wait('@progress');
+          cy.contains('has been scheduled');
+          cy.get('.progress-bar').should('be.visible');
+        });
+      });
+    });
+
+    describe('and the project is provided in the URL', () => {
+      beforeEach(() => {
+        cy.intercept('v1/projects/Alien/update/time', {
+          body: { next_update_time: '2026-08-01T00:00:00Z' },
+        }).as('updateTime');
+        cy.intercept('v1/projects/Alien/update/progress', {
+          body: { job: null, queue: { status: 'queued' } },
+        }).as('progress');
+        cy.visit('/#/update/Alien');
+        cy.wait('@updateTime');
+      });
+
+      it('prefills the autocomplete from the URL', () => {
+        cy.get('input.search').should('have.value', 'Alien');
+      });
+
+      it('shows the next update time instead of the button', () => {
+        cy.contains('has been scheduled');
+        cy.contains('2026-08-01T00:00:00Z');
+        cy.contains('button', 'Manual Update').should('not.exist');
+      });
+
+      it('shows the scheduled-but-not-started progress string', () => {
+        cy.wait('@progress');
+        cy.contains("hasn't started yet");
+      });
+    });
+  });
+
+  describe('when the user is not logged in', () => {
+    it('shows the login required page', () => {
+      cy.visit('/#/update');
+      cy.contains('Please Log In To Continue');
+      cy.get('.pt-2 > .btn');
+    });
+  });
+});

--- a/wp1-frontend/cypress/fixtures/book_builder.json
+++ b/wp1-frontend/cypress/fixtures/book_builder.json
@@ -1,0 +1,7 @@
+{
+  "params": { "url": "https://en.wikipedia.org/wiki/Book:Example" },
+  "name": "Book Builder",
+  "model": "wp1.selection.models.book",
+  "project": "en.wikipedia.org",
+  "selection_errors": []
+}

--- a/wp1-frontend/cypress/fixtures/book_builder_fatal_error.json
+++ b/wp1-frontend/cypress/fixtures/book_builder_fatal_error.json
@@ -1,0 +1,13 @@
+{
+  "params": { "url": "https://en.wikipedia.org/wiki/Book:Example" },
+  "name": "Book Builder",
+  "model": "wp1.selection.models.book",
+  "project": "en.wikipedia.org",
+  "selection_errors": [
+    {
+      "error_messages": ["The book could not be fetched."],
+      "ext": "tsv",
+      "status": "FAILED"
+    }
+  ]
+}

--- a/wp1-frontend/cypress/fixtures/book_builder_retryable_error.json
+++ b/wp1-frontend/cypress/fixtures/book_builder_retryable_error.json
@@ -1,0 +1,13 @@
+{
+  "params": { "url": "https://en.wikipedia.org/wiki/Book:Example" },
+  "name": "Book Builder",
+  "model": "wp1.selection.models.book",
+  "project": "en.wikipedia.org",
+  "selection_errors": [
+    {
+      "error_messages": ["There was a timeout."],
+      "ext": "tsv",
+      "status": "CAN_RETRY"
+    }
+  ]
+}

--- a/wp1-frontend/cypress/fixtures/petscan_builder.json
+++ b/wp1-frontend/cypress/fixtures/petscan_builder.json
@@ -1,0 +1,7 @@
+{
+  "params": { "url": "https://petscan.wmflabs.org/?psid=123456" },
+  "name": "Petscan Builder",
+  "model": "wp1.selection.models.petscan",
+  "project": "en.wikipedia.org",
+  "selection_errors": []
+}

--- a/wp1-frontend/cypress/fixtures/petscan_builder_fatal_error.json
+++ b/wp1-frontend/cypress/fixtures/petscan_builder_fatal_error.json
@@ -1,0 +1,13 @@
+{
+  "params": { "url": "https://petscan.wmflabs.org/?psid=123456" },
+  "name": "Petscan Builder",
+  "model": "wp1.selection.models.petscan",
+  "project": "en.wikipedia.org",
+  "selection_errors": [
+    {
+      "error_messages": ["The PetScan URL could not be fetched."],
+      "ext": "tsv",
+      "status": "FAILED"
+    }
+  ]
+}

--- a/wp1-frontend/cypress/fixtures/petscan_builder_retryable_error.json
+++ b/wp1-frontend/cypress/fixtures/petscan_builder_retryable_error.json
@@ -1,0 +1,13 @@
+{
+  "params": { "url": "https://petscan.wmflabs.org/?psid=123456" },
+  "name": "Petscan Builder",
+  "model": "wp1.selection.models.petscan",
+  "project": "en.wikipedia.org",
+  "selection_errors": [
+    {
+      "error_messages": ["There was a timeout."],
+      "ext": "tsv",
+      "status": "CAN_RETRY"
+    }
+  ]
+}

--- a/wp1-frontend/cypress/fixtures/save_book_failure.json
+++ b/wp1-frontend/cypress/fixtures/save_book_failure.json
@@ -1,0 +1,8 @@
+{
+  "success": false,
+  "items": {
+    "valid": [],
+    "invalid": ["not-a-book-url"],
+    "errors": ["Invalid Book URL"]
+  }
+}

--- a/wp1-frontend/cypress/fixtures/save_petscan_failure.json
+++ b/wp1-frontend/cypress/fixtures/save_petscan_failure.json
@@ -1,0 +1,8 @@
+{
+  "success": false,
+  "items": {
+    "valid": [],
+    "invalid": ["not-a-petscan-url"],
+    "errors": ["Invalid PetScan URL"]
+  }
+}


### PR DESCRIPTION
Backfills e2e coverage for the four routed pages that had none:
`/update`, `/compare`, `/selections/petscan`, `/selections/book`
(~47 new tests, all stub-based/hermetic like the existing suite).

This is PR 1 of 2 for the Vue 3 migration (#1232) — these tests guard
that migration, but are valuable on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)