### PR TITLE
Fix zimfarm dev worker setup for current zimfarm-backend API

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,11 @@ You may need to install the `jq` tool with [these instructions](https://github.c
   ./create_worker.sh
   ```
 
-  This registers a worker with username `test_worker` and generates SSH keys for it to authenticate with the Zimfarm API. The worker is configured with 3 CPU, 20GB RAM and 20GB disk.
+  This generates an SSH key pair, registers a worker named `test-worker` with the Zimfarm API using the public key, and grants it the `wikimedia` context.
+
+  The context grant matters: WP1 creates all of its recipes with the `wikimedia` context, and the Zimfarm scheduler only offers those tasks to workers holding that context. If your ZIM tasks sit forever in "requested" with an online worker, a missing context grant is the usual cause.
+
+  The worker's resources (3 CPU, 20GB RAM, 20GB disk) and supported offliners are reported by the worker-manager container itself when it checks in — see the `ZIMFARM_*` environment variables in `docker-compose-dev.yml`. There is no worker user account: the current Zimfarm API authenticates workers purely by their SSH key.
 
 - Restart the dev stack with a Zimfarm worker now
   ```sh

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -202,7 +202,7 @@ services:
     depends_on:
       zimfarm-api:
         condition: service_healthy
-    command: worker-manager --webapi-uri 'http://zimfarm-api:80/v2' --username test_worker --name test_worker
+    command: worker-manager --webapi-uri 'http://zimfarm-api:80/v2' --name test-worker
     environment:
       - DEBUG=true
       - TASK_WORKER_IMAGE=ghcr.io/openzim/zimfarm-task-worker:latest

--- a/docker/zimfarm/create_worker.sh
+++ b/docker/zimfarm/create_worker.sh
@@ -1,33 +1,38 @@
 #!/usr/bin/env bash
 
-# Call it once to create a `test_worker`:
+# Call it once to create a `test-worker` for local development:
 # - retrieve an admin token
-# - create the `test_worker`` user
-# - create the associated worker object
-# - upload a test public key.
+# - generate an SSH key pair for the worker
+# - create the `test-worker` worker, registering its public key
+# - grant it the `wikimedia` context
 #
-# To be used to have a "real" test worker for local development, typically to start
-# a worker manager or a task manager or simply assign tasks to a worker in the UI/API
+# The context grant is required: WP1 creates all of its recipes with the
+# `wikimedia` context, and the Zimfarm scheduler only offers those tasks to
+# workers holding that context — a worker without it stays idle forever while
+# tasks sit in "requested".
+#
+# The worker-manager container (compose profile `zimfarm-worker`)
+# authenticates with the generated private key and performs its own check-in,
+# reporting its resources and supported offliners. The current Zimfarm API has
+# no users endpoint, so no user account and no manual check-in are involved.
+#
+# Safe to re-run: if the worker already exists, the freshly generated public
+# key is added to it and the context grant is re-applied.
 
 set -e
 
 ZIMFARM_BASE_API_URL="http://localhost:8004/v2"
+# Must match the `--name` passed to worker-manager in docker-compose-dev.yml.
+# The API requires ^[a-z0-9-]+$ (no underscores).
+WORKER_NAME="test-worker"
 
 die() {
     echo "ERROR: $1" >&2
     exit 1
 }
 
-check_http_code() {
-    local http_code="$1"
-    local response="$2"
-
-    if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
-	:
-    else
-	error_msg=$(echo "$response" | jq -r '.errors // .message // .detail // "Unknown error"' 2>/dev/null || echo "HTTP $http_code")
-	die "Could not checkin worker: ${error_msg}"
-    fi
+error_from() {
+    echo "$1" | jq -r '.errors // .message // .detail // "Unknown error"' 2>/dev/null || echo "$2"
 }
 
 echo "Retrieving admin access token"
@@ -43,68 +48,59 @@ if [ -z "$ZF_ADMIN_TOKEN" ] || [ "$ZF_ADMIN_TOKEN" = "null" ]; then
     die "Failed to retrieve admin access token"
 fi
 
-echo "Create test_worker user"
-
-curl -s -X 'POST' \
-  "${ZIMFARM_BASE_API_URL}/users" \
-  -H 'accept: */*' \
-  -H 'Content-Type: application/json' \
-  -H "Authorization: Bearer $ZF_ADMIN_TOKEN" \
-  -d '{
-  "role":"worker",
-  "username": "test_worker",
-  "password":"test_worker"
-}'
-
-echo "Retrieving test_worker access token"
-
-ZF_USER_TOKEN="$(curl -s -X 'POST' \
-    "${ZIMFARM_BASE_API_URL}/auth/authorize" \
-    -H 'accept: application/json' \
-    -H 'Content-Type: application/json' \
-    -d '{"username": "test_worker", "password": "test_worker"}' \
-    | jq -r '.access_token')"
-
-if [ -z "$ZF_USER_TOKEN" ] || [ "$ZF_USER_TOKEN" = "null" ]; then
-    die "Failed to retrieve worker access token"
-fi
-
-response=$(curl -s -w "\n%{http_code}" -X 'PUT' \
-  "${ZIMFARM_BASE_API_URL}/workers/test_worker/check-in" \
-  -H 'accept: */*' \
-  -H 'Content-Type: application/json' \
-  -H "Authorization: Bearer $ZF_USER_TOKEN" \
-  -d '{
-  "username": "test_worker",
-  "cpu": 3,
-  "memory": 21474836480,
-  "disk": 21474836480,
-  "offliners": [
-    "mwoffliner"
-  ]
-}')
-
-http_code=$(echo "$response" | tail -n1)
-response=$(echo "$response" | head -n -1)
-
-check_http_code "$http_code" "$response"
-
 echo "Generating SSH key pair (Ed25519)"
 rm -f id_ed25519 id_ed25519.pub
 ssh-keygen -t ed25519 -f id_ed25519 -N ""
-payload="$(jq -n --arg key "$(< id_ed25519.pub)" '{key: $key}')"
 
+# The API returns a 500 (not 409) when creating a worker that already exists,
+# so check for existence up front instead of interpreting the create response.
+exists_code=$(curl -s -o /dev/null -w "%{http_code}" \
+    "${ZIMFARM_BASE_API_URL}/workers/${WORKER_NAME}" \
+    -H "Authorization: Bearer ${ZF_ADMIN_TOKEN}")
 
-echo "Uploading worker keys to API"
-response=$(curl -s -w "\n%{http_code}" -X POST "${ZIMFARM_BASE_API_URL}/users/test_worker/keys" \
-  -H 'accept: */*' \
-  -H "Authorization: Bearer $ZF_USER_TOKEN" \
-  -H 'Content-Type: application/json; charset=utf-8' \
-  -d "$payload")
+if [ "$exists_code" -eq 404 ]; then
+    echo "Creating worker '${WORKER_NAME}' with its public key"
+    payload="$(jq -n --arg name "$WORKER_NAME" --arg key "$(< id_ed25519.pub)" \
+        '{name: $name, ssh_key: {key: $key}}')"
+    response=$(curl -s -w "\n%{http_code}" -X POST "${ZIMFARM_BASE_API_URL}/workers" \
+        -H 'accept: application/json' \
+        -H "Authorization: Bearer ${ZF_ADMIN_TOKEN}" \
+        -H 'Content-Type: application/json' \
+        -d "$payload")
+    http_code=$(echo "$response" | tail -n1)
+    body=$(echo "$response" | head -n -1)
+    if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+        die "Could not create worker: $(error_from "$body" "HTTP $http_code")"
+    fi
+elif [ "$exists_code" -ge 200 ] && [ "$exists_code" -lt 300 ]; then
+    echo "Worker already exists; registering the new public key with it"
+    key_payload="$(jq -n --arg key "$(< id_ed25519.pub)" '{key: $key}')"
+    response=$(curl -s -w "\n%{http_code}" -X POST \
+        "${ZIMFARM_BASE_API_URL}/workers/${WORKER_NAME}/keys" \
+        -H 'accept: application/json' \
+        -H "Authorization: Bearer ${ZF_ADMIN_TOKEN}" \
+        -H 'Content-Type: application/json' \
+        -d "$key_payload")
+    http_code=$(echo "$response" | tail -n1)
+    body=$(echo "$response" | head -n -1)
+    if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+        die "Could not register new key: $(error_from "$body" "HTTP $http_code")"
+    fi
+else
+    die "Could not check worker existence: HTTP $exists_code"
+fi
 
+echo "Granting the 'wikimedia' context to '${WORKER_NAME}'"
+response=$(curl -s -w "\n%{http_code}" -X PUT \
+    "${ZIMFARM_BASE_API_URL}/workers/${WORKER_NAME}" \
+    -H 'accept: application/json' \
+    -H "Authorization: Bearer ${ZF_ADMIN_TOKEN}" \
+    -H 'Content-Type: application/json' \
+    -d '{"contexts": {"wikimedia": null}}')
 http_code=$(echo "$response" | tail -n1)
-response=$(echo "$response" | head -n1)
-
-check_http_code "$http_code" "$response"
+body=$(echo "$response" | head -n -1)
+if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+    die "Could not grant context: $(error_from "$body" "HTTP $http_code")"
+fi
 
 echo "DONE"


### PR DESCRIPTION
The dev stack pulls `zimfarm-*:latest` images, and the current backend broke worker registration:

- `/v2/users` is gone — workers now auth by SSH key only, keys live under `/v2/workers/{name}/keys`
- worker names can't contain underscores, and worker-manager dropped `--username`
- workers need the `wikimedia` context (WP1 stamps it on every recipe) or tasks sit in "requested" forever

Fixes: `create_worker.sh` rewritten for the new API (grants the context, safe to re-run), compose worker-manager command updated, README documents the context requirement. Verified against a live dev stack end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)