### PR TITLE
Prevent log pages from being overwritten after Redis data loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,20 @@ The `serve` command should print out the port to view the docs at, likely localh
 - Run the production database migrations in the worker container:
   - `sudo docker exec -ti -e PYTHONPATH=. wp1bot-workers yoyo -c /usr/src/app/db/production/yoyo.ini apply`
 
+## Redis persistence
+
+Redis holds the RQ queue state and the only copy of the rolling 7-day
+article assessment log history (used to generate the on-wiki log pages).
+The `redis` service therefore stores its data in the `redis-data` volume
+and its image tag is pinned in `docker-compose.yml`. To upgrade Redis,
+bump the tag deliberately and deploy normally; the volume preserves the
+data across the container recreation. Do not deploy with an unpinned
+`redis` image: a surprise upstream image update recreates the container,
+and before the volume existed that meant losing the entire keyspace
+(this happened on 2026-08-01 and overwrote hundreds of on-wiki log pages
+with false "no logs" notices; see
+[issue #1244](https://github.com/openzim/wp1/issues/1244)).
+
 # Rolling back production
 
 In addition to the moving `release` tag, every push to the `release`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,19 @@
 version: '3.5'
 services:
   redis:
-    image: redis
+    # Pin the minor version: an unpinned `redis` tag caused the container to
+    # be recreated on a routine deploy pull (2026-08-01), which destroyed all
+    # data because it had no volume. See
+    # https://github.com/openzim/wp1/issues/1244. Upgrade deliberately by
+    # bumping this tag.
+    image: redis:8.10
     container_name: wp1bot-redis
     expose:
       - 6379
+    volumes:
+      # RQ queue state and the 7-day article assessment log history live only
+      # in Redis. This volume makes them survive container recreation.
+      - redis-data:/data
     restart: always
     healthcheck:
       test: ['CMD', 'redis-cli', 'ping']
@@ -122,3 +131,6 @@ services:
 networks:
   default:
     name: openzim.org
+
+volumes:
+  redis-data:

--- a/wp1/logs.py
+++ b/wp1/logs.py
@@ -28,6 +28,12 @@ NOT_A_CLASS = config["NOT_A_CLASS"].encode("utf-8")
 
 RE_EXTRACT_TIME = re.compile(r"Log for ([^(]+)")
 
+RE_SECTION_DATE = re.compile(r"^===\s*([^=\n]+?)\s*===\s*$", re.MULTILINE)
+
+# LOG_DATE_FORMAT uses %-d, which strftime supports but strptime does not;
+# %d parses both padded and unpadded day numbers.
+LOG_DATE_PARSE_FORMAT = "%B %d, %Y"
+
 
 def log_page_name(project_name):
     return (
@@ -204,6 +210,27 @@ def generate_log_edits(wikidb, wp10db, project_name, log_map):
     return sorted_sections
 
 
+def live_page_dates_missing_from_logs(page_text, log_dates, from_dt):
+    """Dates of log sections on the live page that are inside the 7-day window
+    but absent from the logs read from Redis.
+
+    Under normal operation this is empty: a section still inside the window
+    was rendered from Redis keys whose 7-day TTL cannot have expired yet. A
+    non-empty result means Redis lost the log data (e.g. the container was
+    recreated without persistence), and regenerating the page would destroy
+    real log history. See https://github.com/openzim/wp1/issues/1244.
+    """
+    missing = []
+    for match in RE_SECTION_DATE.finditer(page_text):
+        try:
+            dt = datetime.strptime(match.group(1), LOG_DATE_PARSE_FORMAT).date()
+        except ValueError:
+            continue
+        if dt > from_dt.date() and dt not in log_dates:
+            missing.append(dt)
+    return missing
+
+
 def update_log_page_for_project(project_name):
     wikidb = wiki_connect()
     wp10db = wp10_connect()
@@ -216,11 +243,25 @@ def update_log_page_for_project(project_name):
 
         p = api.get_page(log_page_name(project_name))
 
+        today = get_current_datetime()
+        from_dt = today - timedelta(days=7)
+
+        page_text = p.text() if p is not None else ""
+        missing = live_page_dates_missing_from_logs(page_text, set(log_map), from_dt)
+        if missing:
+            logger.error(
+                "Skipping log page update for %s: the live page has log "
+                "sections for %s but Redis has no logs for those dates. "
+                "This means the Redis log data was lost; updating the page "
+                "would overwrite real log history.",
+                project_name,
+                ", ".join(str(dt) for dt in missing),
+            )
+            return
+
         header = "<noinclude>{{Log}}\n{{Automatically generated}}</noinclude>\n"
 
         if len(edits) == 0:
-            today = get_current_datetime()
-            from_dt = get_current_datetime() - timedelta(days=7)
             update = "%s'''There were no logs for this project from %s - %s.'''" % (
                 header,
                 from_dt.strftime(LOG_DATE_FORMAT),

--- a/wp1/logs_test.py
+++ b/wp1/logs_test.py
@@ -861,6 +861,7 @@ class LogsTest(BaseCombinedDbTest):
     def test_upload_log_page_for_project(
         self, patched_api, patched_wp10, patched_wiki, patched_redis
     ):
+        patched_api.get_page.return_value.text.return_value = ""
         logs.update_log_page_for_project(b"Catholicism")
         call = patched_api.save_page.call_args[0]
         self.assertEqual("Update logs for past 7 days", call[2])
@@ -874,6 +875,7 @@ class LogsTest(BaseCombinedDbTest):
         self, patched_datetime, patched_api, patched_wp10, patched_wiki, patched_redis
     ):
         project_name = b"Catholicism"
+        patched_api.get_page.return_value.text.return_value = ""
         header = "<noinclude>{{Log}}\n{{Automatically generated}}</noinclude>\n"
         no_logs_msg = (
             "'''There were no logs for this project from December 21, "
@@ -887,11 +889,117 @@ class LogsTest(BaseCombinedDbTest):
     @patch("wp1.logs.wiki_connect")
     @patch("wp1.logs.wp10_connect")
     @patch("wp1.logs.api")
+    @patch("wp1.logs.get_current_datetime", return_value=datetime(2018, 12, 28, 12))
+    def test_upload_log_page_no_logs_live_page_has_recent_sections_skips(
+        self, patched_datetime, patched_api, patched_wp10, patched_wiki, patched_redis
+    ):
+        patched_api.get_page.return_value.text.return_value = (
+            "<noinclude>{{Log}}\n{{Automatically generated}}</noinclude>\n"
+            "=== December 26, 2018 ===\n"
+            "==== Assessed ====\n"
+            "* '''[[Test results]]''' assessed.\n"
+        )
+        logs.update_log_page_for_project(b"Catholicism")
+        patched_api.save_page.assert_not_called()
+
+    @patch("wp1.logs.redis_connect")
+    @patch("wp1.logs.wiki_connect")
+    @patch("wp1.logs.wp10_connect")
+    @patch("wp1.logs.api")
+    @patch("wp1.logs.get_current_datetime", return_value=datetime(2018, 12, 28, 12))
+    def test_upload_log_page_no_logs_live_page_only_old_sections_saves(
+        self, patched_datetime, patched_api, patched_wp10, patched_wiki, patched_redis
+    ):
+        patched_api.get_page.return_value.text.return_value = (
+            "<noinclude>{{Log}}\n{{Automatically generated}}</noinclude>\n"
+            "=== December 20, 2018 ===\n"
+            "==== Assessed ====\n"
+            "* '''[[Test results]]''' assessed.\n"
+        )
+        header = "<noinclude>{{Log}}\n{{Automatically generated}}</noinclude>\n"
+        no_logs_msg = (
+            "'''There were no logs for this project from December 21, "
+            "2018 - December 28, 2018.'''"
+        )
+        logs.update_log_page_for_project(b"Catholicism")
+        call = patched_api.save_page.call_args[0]
+        self.assertEqual(header + no_logs_msg, call[1])
+
+    @patch("wp1.logs.redis_connect")
+    @patch("wp1.logs.wiki_connect")
+    @patch("wp1.logs.wp10_connect")
+    @patch("wp1.logs.api")
+    @patch("wp1.logs.generate_log_edits")
+    @patch("wp1.logs.calculate_logs_to_update")
+    @patch("wp1.logs.get_current_datetime", return_value=datetime(2018, 12, 28, 12))
+    def test_upload_log_page_live_page_date_missing_from_logs_skips(
+        self,
+        patched_datetime,
+        patched_calculate,
+        patched_generate,
+        patched_api,
+        patched_wp10,
+        patched_wiki,
+        patched_redis,
+    ):
+        patched_calculate.return_value = {datetime(2018, 12, 27).date(): ["some log"]}
+        patched_generate.return_value = ["=== December 27, 2018 ===\ncontent"]
+        patched_api.get_page.return_value.text.return_value = (
+            "<noinclude>{{Log}}\n{{Automatically generated}}</noinclude>\n"
+            "=== December 27, 2018 ===\n"
+            "==== Assessed ====\n"
+            "* '''[[Test results]]''' assessed.\n"
+            "=== December 26, 2018 ===\n"
+            "==== Assessed ====\n"
+            "* '''[[Testing tools]]''' assessed.\n"
+        )
+        logs.update_log_page_for_project(b"Catholicism")
+        patched_api.save_page.assert_not_called()
+
+    @patch("wp1.logs.redis_connect")
+    @patch("wp1.logs.wiki_connect")
+    @patch("wp1.logs.wp10_connect")
+    @patch("wp1.logs.api")
+    @patch("wp1.logs.generate_log_edits")
+    @patch("wp1.logs.calculate_logs_to_update")
+    @patch("wp1.logs.get_current_datetime", return_value=datetime(2018, 12, 28, 12))
+    def test_upload_log_page_live_page_dates_all_in_logs_saves(
+        self,
+        patched_datetime,
+        patched_calculate,
+        patched_generate,
+        patched_api,
+        patched_wp10,
+        patched_wiki,
+        patched_redis,
+    ):
+        patched_calculate.return_value = {
+            datetime(2018, 12, 26).date(): ["some log"],
+            datetime(2018, 12, 27).date(): ["other log"],
+        }
+        patched_generate.return_value = ["=== December 27, 2018 ===\ncontent"]
+        patched_api.get_page.return_value.text.return_value = (
+            "<noinclude>{{Log}}\n{{Automatically generated}}</noinclude>\n"
+            "=== December 27, 2018 ===\n"
+            "==== Assessed ====\n"
+            "* '''[[Test results]]''' assessed.\n"
+            "=== December 20, 2018 ===\n"
+            "==== Assessed ====\n"
+            "* '''[[Testing tools]]''' assessed.\n"
+        )
+        logs.update_log_page_for_project(b"Catholicism")
+        patched_api.save_page.assert_called_once()
+
+    @patch("wp1.logs.redis_connect")
+    @patch("wp1.logs.wiki_connect")
+    @patch("wp1.logs.wp10_connect")
+    @patch("wp1.logs.api")
     @patch("wp1.logs.generate_log_edits")
     def test_upload_log_page_for_project_huge_text(
         self, patched_generate, patched_api, patched_wp10, patched_wiki, patched_redis
     ):
         project_name = b"Catholicism"
+        patched_api.get_page.return_value.text.return_value = ""
         header = "<noinclude>{{Log}}\n{{Automatically generated}}</noinclude>\n"
         text = "a" * 1000 * 1024
         patched_generate.return_value = [text, text, text]
@@ -908,6 +1016,7 @@ class LogsTest(BaseCombinedDbTest):
         self, patched_generate, patched_api, patched_wp10, patched_wiki, patched_redis
     ):
         project_name = b"Catholicism"
+        patched_api.get_page.return_value.text.return_value = ""
         sorry_msg = "Sorry, all of the logs for this date were too large to " "upload."
         header = "<noinclude>{{Log}}\n{{Automatically generated}}</noinclude>\n"
         text = "a" * 3000 * 1024


### PR DESCRIPTION
Fixes #1244.

- Pin `redis:8.10` and persist `/data` in a `redis-data` volume.
- Skip a log page upload (with an error log) when the live page has dated sections inside the 7-day window that Redis returned no logs for — covers both the "no logs" stub and silent truncation. Costs one extra content GET per page per night.

Verification: full suite passes (835), including 4 new tests for the guard; watched the guard tests fail before implementing.

Deploy note: recreating the redis container for the new image/volume would itself wipe it. Carry the data across: stop workers+web → `redis-cli save` → `docker cp` dump.rdb out → `up -d redis` → stop redis → copy dump.rdb back → `up -d` → verify `dbsize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)