### PR TITLE
fix: drop unused serialize-javascript dependency

### DIFF
--- a/wp1-frontend/package.json
+++ b/wp1-frontend/package.json
@@ -42,7 +42,6 @@
     "path-to-regexp": "^3.3.0",
     "popper.js": "^1.16.0",
     "postcss": "^8.5.18",
-    "serialize-javascript": "^3.1.0",
     "split-by-grapheme": "^1.0.1",
     "vite": "^6.0.0",
     "vue": "^3.5.0",

--- a/wp1-frontend/pnpm-lock.yaml
+++ b/wp1-frontend/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 10.4.16(postcss@8.5.25)
       axios:
         specifier: ^1.18.0
-        version: 1.18.0
+        version: 1.18.0(supports-color@8.1.1)
       bootstrap:
         specifier: ^4.4.1
         version: 4.6.2(jquery@3.7.1)(popper.js@1.16.1)
@@ -43,10 +43,10 @@ importers:
         version: 1.13.7
       eslint:
         specifier: ^7.32.0
-        version: 7.32.0
+        version: 7.32.0(supports-color@8.1.1)
       eslint-plugin-vue:
         specifier: ^9.4.0
-        version: 9.18.1(eslint@7.32.0)
+        version: 9.18.1(eslint@7.32.0(supports-color@8.1.1))(supports-color@8.1.1)
       jquery:
         specifier: ^3.6.0
         version: 3.7.1
@@ -65,9 +65,6 @@ importers:
       postcss:
         specifier: ^8.5.18
         version: 8.5.25
-      serialize-javascript:
-        specifier: ^3.1.0
-        version: 3.1.0
       split-by-grapheme:
         specifier: ^1.0.1
         version: 1.0.1
@@ -1431,9 +1428,6 @@ packages:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
 
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-
   regexpp@3.2.0:
     resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
     engines: {node: '>=8'}
@@ -1480,9 +1474,6 @@ packages:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
     engines: {node: '>=10'}
     hasBin: true
-
-  serialize-javascript@3.1.0:
-    resolution: {integrity: sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1906,12 +1897,12 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
-  '@eslint-community/eslint-utils@4.4.0(eslint@7.32.0)':
+  '@eslint-community/eslint-utils@4.4.0(eslint@7.32.0(supports-color@8.1.1))':
     dependencies:
-      eslint: 7.32.0
+      eslint: 7.32.0(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
-  '@eslint/eslintrc@0.4.3':
+  '@eslint/eslintrc@0.4.3(supports-color@8.1.1)':
     dependencies:
       ajv: 6.12.6
       debug: 4.4.3(supports-color@8.1.1)
@@ -1925,7 +1916,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@humanwhocodes/config-array@0.5.0':
+  '@humanwhocodes/config-array@0.5.0(supports-color@8.1.1)':
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
       debug: 4.4.3(supports-color@8.1.1)
@@ -2111,7 +2102,7 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -2185,11 +2176,11 @@ snapshots:
 
   aws4@1.12.0: {}
 
-  axios@1.18.0:
+  axios@1.18.0(supports-color@8.1.1):
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -2493,15 +2484,15 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-vue@9.18.1(eslint@7.32.0):
+  eslint-plugin-vue@9.18.1(eslint@7.32.0(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@7.32.0)
-      eslint: 7.32.0
+      '@eslint-community/eslint-utils': 4.4.0(eslint@7.32.0(supports-color@8.1.1))
+      eslint: 7.32.0(supports-color@8.1.1)
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.0.13
       semver: 7.5.4
-      vue-eslint-parser: 9.3.2(eslint@7.32.0)
+      vue-eslint-parser: 9.3.2(eslint@7.32.0(supports-color@8.1.1))(supports-color@8.1.1)
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -2526,11 +2517,11 @@ snapshots:
 
   eslint-visitor-keys@3.4.3: {}
 
-  eslint@7.32.0:
+  eslint@7.32.0(supports-color@8.1.1):
     dependencies:
       '@babel/code-frame': 7.12.11
-      '@eslint/eslintrc': 0.4.3
-      '@humanwhocodes/config-array': 0.5.0
+      '@eslint/eslintrc': 0.4.3(supports-color@8.1.1)
+      '@humanwhocodes/config-array': 0.5.0(supports-color@8.1.1)
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
@@ -2761,9 +2752,9 @@ snapshots:
       jsprim: 2.0.2
       sshpk: 1.18.0
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@8.1.1):
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -3044,10 +3035,6 @@ snapshots:
       es-define-property: 1.0.1
       side-channel: 1.1.1
 
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   regexpp@3.2.0: {}
 
   request-progress@3.0.0:
@@ -3109,10 +3096,6 @@ snapshots:
   semver@7.5.4:
     dependencies:
       lru-cache: 6.0.0
-
-  serialize-javascript@3.1.0:
-    dependencies:
-      randombytes: 2.1.0
 
   shebang-command@2.0.0:
     dependencies:
@@ -3319,10 +3302,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  vue-eslint-parser@9.3.2(eslint@7.32.0):
+  vue-eslint-parser@9.3.2(eslint@7.32.0(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 7.32.0
+      eslint: 7.32.0(supports-color@8.1.1)
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1


### PR DESCRIPTION
Fixes Dependabot alert [#284](https://github.com/openzim/wp1/security/dependabot/284) — GHSA-5c6j-r48x-rmvq (high, RCE via `RegExp.flags` / `Date.toISOString`), affecting `serialize-javascript <= 7.0.2`. `wp1-frontend` pinned `^3.1.0`.

- The dep was added in ecba674 (2020) to force a transitive bump under the old vue-cli/webpack toolchain. The frontend is on Vite now.
- Nothing in `src/`, `cypress/`, or `vite.config.js` imports it, and no other lockfile entry depends on it — so it's removed rather than bumped to 7.0.3.
- Lockfile diff includes incidental `(supports-color@8.1.1)` peer-key churn from pnpm recomputing the graph; no package versions changed.

Verified: `pnpm install --frozen-lockfile` and `pnpm run build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)