### PR TITLE
Fix OAuth login: rebuild RequestToken from JSON-serialized session

### DIFF
--- a/wp1/web/oauth.py
+++ b/wp1/web/oauth.py
@@ -1,7 +1,7 @@
 import attr
 import flask
 from flask import jsonify, session
-from mwoauth import ConsumerToken, Handshaker
+from mwoauth import ConsumerToken, Handshaker, RequestToken
 
 from wp1 import environment
 from wp1.credentials import CREDENTIALS, ENV
@@ -96,7 +96,11 @@ def complete():
 
     handshaker = get_handshaker()
     query_string = str(flask.request.query_string.decode("utf-8"))
-    access_token = handshaker.complete(session["request_token"], query_string)
+    # flask-session serializes the session as JSON, so the RequestToken
+    # namedtuple stored by /initiate comes back as a plain list. Rebuild it
+    # before handing it to mwoauth, which accesses request_token.key.
+    request_token = RequestToken(*session["request_token"])
+    access_token = handshaker.complete(request_token, query_string)
     session.pop("request_token")
     identity = handshaker.identify(access_token)
 

--- a/wp1/web/oauth_test.py
+++ b/wp1/web/oauth_test.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import Mock, patch
 
+from mwoauth import RequestToken
+
 from wp1.credentials import CREDENTIALS
 from wp1.environment import Environment
 from wp1.web.app import create_app
@@ -121,6 +123,23 @@ class IdentifyTest(BaseWebTestcase):
                 row = cursor.fetchone()
                 self.assertIsNotNone(row)
                 self.assertEqual("wp1user@email.ch", row["u_email"].decode("utf-8"))
+
+    @patch("wp1.web.oauth.CREDENTIALS", TEST_OAUTH_CREDS)
+    @patch("wp1.web.oauth.get_handshaker", lambda: handshaker)
+    def test_complete_coerces_deserialized_request_token(self):
+        # flask-session >= 0.6 serializes sessions as JSON (msgspec), so the
+        # RequestToken namedtuple stored by /initiate round-trips as a plain
+        # list. /complete must rebuild a RequestToken before calling mwoauth,
+        # which does request_token.key.
+        self.app = create_app()
+        with self.override_db(self.app), self.app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess["request_token"] = ["request_token", "request_token_secret"]
+            rv = client.get("/v1/oauth/complete?query_string")
+            self.assertEqual("302 FOUND", rv.status)
+            token = handshaker.complete.call_args[0][0]
+            self.assertIsInstance(token, RequestToken)
+            self.assertEqual("request_token", token.key)
 
     @patch("wp1.web.oauth.CREDENTIALS", TEST_OAUTH_CREDS)
     @patch("wp1.web.oauth.get_handshaker", lambda: handshaker)


### PR DESCRIPTION
- flask-session 0.8.0 (bumped in 792db9e) switched session serialization from pickle to JSON, so the `RequestToken` namedtuple stored at `/oauth/initiate` comes back as a plain list; `mwoauth.complete()` then crashes with `AttributeError: 'list' object has no attribute 'key'`, breaking all real logins.
- Fix: rebuild `RequestToken(*session["request_token"])` before the handshake (mwoauth's documented Flask pattern).
- Not yet broken in production only because `release` predates the flask-session bump — this needs to land before the next deploy.

Verified: new regression test reproduces the list round-trip; `WP1_ENV=test pipenv run pytest wp1/web/oauth_test.py` — 23 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)