### PR TITLE
fix(docs): unbreak mkdocs build and add docs CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,28 @@ jobs:
       - name: Run ty
         run: ./check_types.sh
 
+  docs-build:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Mirrors the Python version in .readthedocs.yaml, so a dependency
+      # conflict here is the same one Read the Docs would hit.
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Install docs dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r docs/requirements.txt
+
+      - name: Build the docs
+        # --strict fails the build on broken nav entries and bad links.
+        run: mkdocs build --strict
+
   python-tests:
     runs-on: ubuntu-24.04
 

--- a/README.md
+++ b/README.md
@@ -372,7 +372,9 @@ to something like:
 
 Documentation lives at [Read the Docs](https://wp1.readthedocs.io/en/latest/). It is
 built using [mkdocs](https://www.mkdocs.org/). The Read the Docs site automatically
-monitors the WP1 github HEAD and re-builds the documentation on every push.
+monitors the WP1 github HEAD and re-builds the documentation on every push. CI also
+runs `mkdocs build --strict` on every pull request, so a broken docs build fails the
+build before it reaches Read the Docs.
 
 ## Local docs
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,8 +5,11 @@ Jinja2==3.1.6
 Markdown==3.8.1
 MarkupSafe==2.1.1
 mergedeep==1.3.4
-mkdocs==1.4.2
+mkdocs==1.6.1
+mkdocs-get-deps==0.2.0
 packaging==22.0
+pathspec==0.12.1
+platformdirs==4.3.6
 python-dateutil==2.8.2
 PyYAML==6.0.2
 pyyaml_env_tag==0.1


### PR DESCRIPTION
- **Broken:** `pip install -r docs/requirements.txt` fails with `ResolutionImpossible` — 14ca124 bumped `Markdown` to 3.8.1 but `mkdocs==1.4.2` pins `markdown<3.4`. The README's local-docs instructions and Read the Docs builds both hit this.
- **Fix:** bump `mkdocs` to 1.6.1 (accepts `markdown>=3.3.6`) and pin its three new transitive deps (`mkdocs-get-deps`, `pathspec`, `platformdirs`).
- **Guard:** new `docs-build` CI job installs `docs/requirements.txt` on Python 3.9 (matching `.readthedocs.yaml`) and runs `mkdocs build --strict`.

Verified: clean venv install + `mkdocs build --strict` passes on both Python 3.9 and 3.12; reproduced the original failure on both before the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)