### PR TITLE
fix(deps): bump nanoid to 3.3.18 in frontend lockfile

### DIFF
--- a/wp1-frontend/pnpm-lock.yaml
+++ b/wp1-frontend/pnpm-lock.yaml
@@ -1282,8 +1282,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2921,7 +2921,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -3007,7 +3007,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
- Dependabot alert 286 (GHSA-2v37-7h3g-55p8 / CVE-2026-67213, high): nanoid <3.3.17 custom generators can loop indefinitely when size is zero
- Bumped transitive nanoid 3.3.16 → 3.3.18 in `wp1-frontend/pnpm-lock.yaml` (via postcss); lockfile-only

Verified with `pnpm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)