### PR TITLE
fix(deps): bump js-yaml to 3.15.1 in frontend lockfile

### DIFF
--- a/wp1-frontend/pnpm-lock.yaml
+++ b/wp1-frontend/pnpm-lock.yaml
@@ -1177,8 +1177,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
   jsbn@0.1.1:
@@ -1910,7 +1910,7 @@ snapshots:
       globals: 13.23.0
       ignore: 4.0.6
       import-fresh: 3.3.0
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -2544,7 +2544,7 @@ snapshots:
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
       is-glob: 4.0.3
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -2814,7 +2814,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1


### PR DESCRIPTION
- Dependabot alert 285 (GHSA-5p4m-2wfm-xmqj, high): js-yaml >=3.0.0 <3.15.1 quadratic CPU consumption in `!!omap` resolution
- Bumped transitive js-yaml 3.15.0 → 3.15.1 in `wp1-frontend/pnpm-lock.yaml` (via eslint); lockfile-only

Verified with `pnpm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)