### PR TITLE
fix: store article logs under per-date Redis keys

### DIFF
--- a/wp1/logic/log.py
+++ b/wp1/logic/log.py
@@ -12,11 +12,17 @@ REDIS_NULL = b"__redis__none__"
 
 
 def insert_or_update(redis: Redis, log: Log):
+    # The date component keeps each day's log for an article in its own key:
+    # a later re-log of the same article (e.g. a reassessment the next day)
+    # must not overwrite an earlier day's entry, or that date would vanish
+    # from Redis while still listed on the live log page (issue behind the
+    # stalled log uploads of 2026-08-15). Same-day repeats still dedupe.
     log_key = gen_redis_log_key(
         project=log.l_project,
         namespace=log.l_namespace,
         action=log.l_action,
         article=log.l_article,
+        date=log.l_timestamp[:8],
     )
     with redis.pipeline() as pipe:
         mapping = {
@@ -37,8 +43,17 @@ def get_logs(
     start_dt: datetime.datetime | None = None,
 ) -> list[Log]:
     """Retrieve logs from Redis matching the given filters."""
+    # Keys written since the date suffix was added end in :YYYYMMDD; keys
+    # written before it do not. A wildcard article already matches both
+    # forms with no suffix; an exact article needs the ':*' to match dated
+    # keys (legacy keys expire within 7 days of the transition).
+    exact_article = article not in ("*", b"*")
     key = gen_redis_log_key(
-        project=project, namespace=namespace, action=action, article=article
+        project=project,
+        namespace=namespace,
+        action=action,
+        article=article,
+        date="*" if exact_article else None,
     )
     logs: list[Log] = []
     for log_key in redis.scan_iter(match=key, _type="HASH"):

--- a/wp1/logic/log.py
+++ b/wp1/logic/log.py
@@ -2,8 +2,9 @@ import datetime
 
 import attr
 from redis import Redis
-from wp1.redis_db import gen_redis_log_key
+
 from wp1.models.wp10.log import Log
+from wp1.redis_db import gen_redis_log_key
 
 # Redis does not allow None types. However if a log to be stored has a None
 # we convert it to this value while storing on Redis and back to None
@@ -12,11 +13,7 @@ REDIS_NULL = b"__redis__none__"
 
 
 def insert_or_update(redis: Redis, log: Log):
-    # The date component keeps each day's log for an article in its own key:
-    # a later re-log of the same article (e.g. a reassessment the next day)
-    # must not overwrite an earlier day's entry, or that date would vanish
-    # from Redis while still listed on the live log page (issue behind the
-    # stalled log uploads of 2026-08-15). Same-day repeats still dedupe.
+    # The date component keeps each day's log for an article in its own key.
     log_key = gen_redis_log_key(
         project=log.l_project,
         namespace=log.l_namespace,

--- a/wp1/logs.py
+++ b/wp1/logs.py
@@ -214,11 +214,13 @@ def live_page_dates_missing_from_logs(page_text, log_dates, from_dt):
     """Dates of log sections on the live page that are inside the 7-day window
     but absent from the logs read from Redis.
 
-    Under normal operation this is empty: a section still inside the window
-    was rendered from Redis keys whose 7-day TTL cannot have expired yet. A
-    non-empty result means Redis lost the log data (e.g. the container was
-    recreated without persistence), and regenerating the page would destroy
-    real log history. See https://github.com/openzim/wp1/issues/1244.
+    Under normal operation this is empty: log keys are stored per (article,
+    date), so a section still inside the window was rendered from keys whose
+    7-day TTL cannot have expired yet and which no later re-log can
+    overwrite. A non-empty result means Redis lost the log data (e.g. the
+    container was recreated without persistence), and regenerating the page
+    would destroy real log history. See
+    https://github.com/openzim/wp1/issues/1244.
     """
     missing = []
     for match in RE_SECTION_DATE.finditer(page_text):

--- a/wp1/logs_test.py
+++ b/wp1/logs_test.py
@@ -5,8 +5,8 @@ from unittest.mock import patch
 import attr
 
 from wp1 import logs
-from wp1.logic import log as logic_log
 from wp1.base_db_test import BaseCombinedDbTest
+from wp1.logic import log as logic_log
 from wp1.models.wp10.log import Log
 
 
@@ -1093,7 +1093,7 @@ class LogsTest(BaseCombinedDbTest):
     ):
         project_name = b"Catholicism"
         patched_api.get_page.return_value.text.return_value = ""
-        sorry_msg = "Sorry, all of the logs for this date were too large to " "upload."
+        sorry_msg = "Sorry, all of the logs for this date were too large to upload."
         header = "<noinclude>{{Log}}\n{{Automatically generated}}</noinclude>\n"
         text = "a" * 3000 * 1024
         patched_generate.return_value = [text, text, text]

--- a/wp1/logs_test.py
+++ b/wp1/logs_test.py
@@ -541,6 +541,82 @@ class LogsTest(BaseCombinedDbTest):
         actual = list(attr.astuple(a) for a in actual)
         self.assertEqual(sorted(expected), sorted(actual))
 
+    def test_insert_or_update_preserves_earlier_dates(self):
+        # Regression: re-logging the same article on a later day must not
+        # overwrite the earlier day's log, or that date vanishes from Redis
+        # while still present on the live log page (stalled uploads of
+        # 2026-08-15).
+        day_one = Log(
+            l_project=self.project,
+            l_article=b"Repeat offender",
+            l_action=b"quality",
+            l_old=b"NotA-Class",
+            l_new=b"Stub-Class",
+            l_namespace=0,
+            l_timestamp=b"20181225112233",
+            l_revision_timestamp=b"2018-12-25T08:22:33Z",
+        )
+        day_two = attr.evolve(
+            day_one,
+            l_old=b"Stub-Class",
+            l_new=b"C-Class",
+            l_timestamp=b"20181226101010",
+            l_revision_timestamp=b"2018-12-26T05:10:10Z",
+        )
+        logic_log.insert_or_update(self.redis, day_one)
+        logic_log.insert_or_update(self.redis, day_two)
+
+        actual = logic_log.get_logs(self.redis, article=b"Repeat offender")
+        self.assertEqual(sorted([day_one, day_two]), sorted(actual))
+
+    def test_insert_or_update_dedupes_same_day(self):
+        first = Log(
+            l_project=self.project,
+            l_article=b"Same day",
+            l_action=b"quality",
+            l_old=b"NotA-Class",
+            l_new=b"Stub-Class",
+            l_namespace=0,
+            l_timestamp=b"20181225112233",
+            l_revision_timestamp=b"2018-12-25T08:22:33Z",
+        )
+        second = attr.evolve(
+            first,
+            l_old=b"Stub-Class",
+            l_new=b"B-Class",
+            l_timestamp=b"20181225180000",
+        )
+        logic_log.insert_or_update(self.redis, first)
+        logic_log.insert_or_update(self.redis, second)
+
+        actual = logic_log.get_logs(self.redis, article=b"Same day")
+        self.assertEqual([second], actual)
+
+    def test_get_logs_matches_legacy_undated_keys(self):
+        # Keys written before the :YYYYMMDD suffix existed must still be
+        # returned by wildcard-article reads until their TTL expires.
+        legacy = Log(
+            l_project=self.project,
+            l_article=b"Legacy article",
+            l_action=b"quality",
+            l_old=b"NotA-Class",
+            l_new=b"GA-Class",
+            l_namespace=0,
+            l_timestamp=b"20181227130000",
+            l_revision_timestamp=b"2018-12-27T08:00:00Z",
+        )
+        mapping = {
+            k: b"__redis__none__" if v is None else v
+            for k, v in attr.asdict(legacy).items()
+        }
+        self.redis.hset(
+            "wp1:logs:%s:0:quality:Legacy article" % self.project.decode("utf-8"),
+            mapping=mapping,
+        )
+
+        actual = logic_log.get_logs(self.redis, project=self.project)
+        self.assertIn(legacy, actual)
+
     def test_move_target(self):
         for i, m in enumerate(self.moves):
             actual = logs.move_target(

--- a/wp1/redis_db.py
+++ b/wp1/redis_db.py
@@ -1,7 +1,8 @@
 import logging
 
 from redis import Redis
-from wp1.credentials import ENV, CREDENTIALS
+
+from wp1.credentials import CREDENTIALS, ENV
 
 logger = logging.getLogger(__name__)
 

--- a/wp1/redis_db.py
+++ b/wp1/redis_db.py
@@ -17,6 +17,10 @@ def gen_redis_log_key(
     namespace: str | bytes,
     action: str | bytes,
     article: str | bytes,
+    date: str | bytes | None = None,
 ) -> str:
     to_str = lambda x: x.decode("utf-8") if isinstance(x, bytes) else x
-    return f"wp1:logs:{to_str(project)}:{to_str(namespace)}:{to_str(action)}:{to_str(article)}"
+    key = f"wp1:logs:{to_str(project)}:{to_str(namespace)}:{to_str(action)}:{to_str(article)}"
+    if date is not None:
+        key += f":{to_str(date)}"
+    return key


### PR DESCRIPTION
Closes #1263.

Log keys were `wp1:logs:{project}:{ns}:{action}:{article}` — the latest log per article, `l_timestamp` mutable inside the hash. A re-log of the same article on a later day overwrote the hash, erasing the earlier date from Redis while still listed on the live log page. The #1244 guard (90c5351) then misread the missing date as Redis data loss and skipped the upload every night until the date left the 7-day window, freezing dozens of projects' log pages (see the issue for the `Draft:Techwave` evidence chain).

## Changes

- `wp1/redis_db.py`: `gen_redis_log_key` takes an optional `date` component — key becomes `wp1:logs:{project}:{ns}:{action}:{article}:{YYYYMMDD}`.
- `wp1/logic/log.py`: writes include the log's date (`l_timestamp[:8]`), so cross-day re-logs coexist and earlier dates persist until TTL; same-day repeats still dedupe. Exact-article reads match dated keys via `:*`; wildcard-article reads (the production upload path) are unchanged and match legacy undated keys, so no migration — legacy keys TTL out within 7 days.
- `wp1/logs.py`: guard docstring updated — its assumption (in-window date on page ⇒ logs in Redis) is now an actual invariant.
- `wp1/logs_test.py`: regression tests for later-day re-log preserving both dates, same-day dedupe, and legacy undated-key read compat.

Side benefit: log pages stop silently dropping an article's earlier-day entries on regeneration — an article reassessed on consecutive days now correctly appears under both dates.

Note for deploy: already-frozen pages don't instantly unfreeze (their dates are already clobbered); each self-heals within ≤7 days. This stops new freezes and the ongoing history loss.

Verified: full suite (839 tests) and `check_types.sh` pass.

---

_Written with AI assistance (Claude)._