### PR TITLE
Fix contradictory ZIM page state when file expired with active schedule

### DIFF
--- a/wp1-frontend/cypress/e2e/zimFile.cy.js
+++ b/wp1-frontend/cypress/e2e/zimFile.cy.js
@@ -496,6 +496,38 @@ describe('the zim file creation page', () => {
             cy.contains('Building…').should('be.visible');
           });
         });
+
+        describe('when there is an active schedule and the zim file is expired', () => {
+          beforeEach(() => {
+            cy.intercept('v1/builders/1/zim/status', {
+              fixture: 'zim_status_with_schedule_deleted.json',
+            }).as('status');
+            cy.visit('/#/selections/1/zim');
+            cy.wait('@identity');
+            cy.wait('@builder');
+            cy.wait('@status');
+          });
+
+          it('displays the active schedule warning', () => {
+            cy.contains('Active schedule found').should('be.visible');
+          });
+
+          it('displays the expired message referring to the schedule', () => {
+            cy.contains('Your ZIM file has expired');
+            cy.contains('re-created on the next scheduled run').should(
+              'be.visible'
+            );
+            cy.contains('with the button below').should('not.exist');
+          });
+
+          it('does not show the Download ZIM button', () => {
+            cy.get('#download').should('not.exist');
+          });
+
+          it('does not show the request form', () => {
+            cy.get('#request').should('not.exist');
+          });
+        });
       });
 
       describe('and the selection is over the article limit', () => {

--- a/wp1-frontend/cypress/fixtures/zim_status_with_schedule_deleted.json
+++ b/wp1-frontend/cypress/fixtures/zim_status_with_schedule_deleted.json
@@ -1,0 +1,11 @@
+{
+  "status": "FILE_READY",
+  "error_url": "https://error.fake/404",
+  "is_deleted": true,
+  "description": "Description for test",
+  "long_description": "Long Description for test",
+  "active_schedule": {
+    "interval_months": 1,
+    "next_generation_date": "2026-09-02"
+  }
+}

--- a/wp1-frontend/src/components/selections/ZimPage.vue
+++ b/wp1-frontend/src/components/selections/ZimPage.vue
@@ -127,8 +127,14 @@
             class="m-0 text-[13px] text-danger"
           >
             Your ZIM file has expired and needs to be re-created. ZIM file
-            download links are only valid for 2 weeks. You can re-create your
-            ZIM file with the button below.
+            download links are only valid for 2 weeks.
+            <span v-if="showForm"
+              >You can re-create your ZIM file with the button below.</span
+            >
+            <span v-else
+              >It will be re-created on the next scheduled run, or you can
+              delete the schedule above and request a new ZIM immediately.</span
+            >
           </p>
           <p
             v-else-if="status === 'REQUESTED'"
@@ -378,7 +384,8 @@
           <div
             v-else-if="
               !forceExpiredDisplay &&
-              (status === 'FILE_READY' || status === 'REQUESTED')
+              (status === 'REQUESTED' ||
+                (status === 'FILE_READY' && !isDeleted))
             "
             class="flex items-center gap-2.5"
           >


### PR DESCRIPTION
## Problem

When a builder has an **active schedule** and its ZIM file has **expired** (`status: FILE_READY`, `is_deleted: true`), the Create ZIM page showed a contradictory combination:

- The expired notice: *"…You can re-create your ZIM file with the button below."*
- But the button below was **Download ZIM** — an enabled link to `/zim/latest` for a file that no longer exists.

### Root cause

`showForm` is gated on `!activeSchedule`, so the request form (which normally replaces the download section in expired states via `v-else-if`) is suppressed whenever a schedule exists. The download section's condition only checked `status === 'FILE_READY'`, not `is_deleted`, so the stale download link leaked through. Without a schedule this state was unreachable, which is why the existing `zim_status_deleted.json` test never caught it.

## Changes

- **Download section**: now requires `status === 'FILE_READY' && !isDeleted` (REQUESTED behavior unchanged). A deleted file can never render a download link.
- **Expired notice**: last sentence is now conditional on `showForm`. With the form visible it keeps the existing copy; with an active schedule it instead says the ZIM will be re-created on the next scheduled run, or the schedule can be deleted to request one immediately (matching the schedule warning's own copy).

## Tests

- New fixture `zim_status_with_schedule_deleted.json` (FILE_READY + `is_deleted: true` + `active_schedule`).
- New Cypress block "when there is an active schedule and the zim file is expired" asserting: schedule warning visible, schedule-aware expired copy (and no "button below" phrasing), no `#download`, no request form.
- Full `zimFile.cy.js` spec passes: 48/48.

---

🤖 Implemented with [Claude](https://claude.com/claude-code) assistance.