### PR TITLE
Include project dbname in served selection TSV filename

### DIFF
--- a/docs/user/selections.md
+++ b/docs/user/selections.md
@@ -78,7 +78,10 @@ list once it's ready, and create a ZIM file from it.
 The final output of a selection is a **.tsv** file containing the articles in
 the selection. As mentioned before, for Simple Selections, this TSV file
 contains the same content as the list you input (except with space normalized to
-underscores and comments and extraneous whitespace removed).
+underscores and comments and extraneous whitespace removed). The downloaded
+file is named after your selection and the database name of the wiki it applies
+to, eg `MyFunSelection.enwiki.tsv` for a selection named "My Fun Selection" on
+English Wikipedia (`en.wikipedia.org`).
 
 The WP 1.0 tool must generate or **materialize** the final list from the input
 you provided. In the case of a Simple Selection this is, well, simple, but still

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -100,6 +100,7 @@ def object_key_for(
     content_type: str,
     model: str,
     name: str | None = None,
+    dbname: str | None = None,
     use_legacy_schema: bool = False,
 ) -> str:
     if not selection_id:
@@ -116,6 +117,11 @@ def object_key_for(
             "ext": ext,
         }
 
+    # Include the dbname of the wiki (eg 'enwiki') in the filename, so that
+    # downloaded selections identify the wiki their articles belong to.
+    if dbname is not None:
+        ext = "%s.%s" % (dbname, ext)
+
     return "selections/%(model)s/%(id)s/%(name)s.%(ext)s" % {
         "model": model,
         "id": selection_id,
@@ -128,6 +134,7 @@ def object_key_for_selection(
     selection: Selection,
     model: str,
     name: str | None = None,
+    dbname: str | None = None,
     use_legacy_schema: bool = False,
 ) -> str:
     if not selection:
@@ -139,6 +146,7 @@ def object_key_for_selection(
         selection.s_content_type.decode("utf-8"),
         model,
         name=name,
+        dbname=dbname,
         use_legacy_schema=use_legacy_schema,
     )
 

--- a/wp1/logic/selection_test.py
+++ b/wp1/logic/selection_test.py
@@ -277,6 +277,34 @@ class SelectionTest(BaseWpOneDbTest):
         )
         self.assertEqual("selections/foo.bar.model/deadbeef/name.tsv", actual)
 
+    def test_object_key_for_selection_with_name_and_dbname(self):
+        actual = logic_selection.object_key_for_selection(
+            self.selection, "foo.bar.model", name="name", dbname="enwiki"
+        )
+        self.assertEqual("selections/foo.bar.model/deadbeef/name.enwiki.tsv", actual)
+
+    def test_object_key_for_with_name_and_dbname(self):
+        actual = logic_selection.object_key_for(
+            "abcd-1234",
+            "text/tab-separated-values",
+            "foo.bar.model",
+            name="name",
+            dbname="frwiktionary",
+        )
+        self.assertEqual(
+            "selections/foo.bar.model/abcd-1234/name.frwiktionary.tsv", actual
+        )
+
+    def test_object_key_for_selection_with_dbname_and_legacy_schema(self):
+        actual = logic_selection.object_key_for_selection(
+            self.selection,
+            "foo.bar.model",
+            name="name",
+            dbname="enwiki",
+            use_legacy_schema=True,
+        )
+        self.assertEqual("selections/foo.bar.model/deadbeef.tsv", actual)
+
     def test_object_key_for_selection_with_name_and_legacy_schema(self):
         actual = logic_selection.object_key_for_selection(
             self.selection, "foo.bar.model", name="name", use_legacy_schema=True

--- a/wp1/selection/abstract_builder.py
+++ b/wp1/selection/abstract_builder.py
@@ -29,6 +29,7 @@ class AbstractBuilder:
             selection,
             builder.b_model.decode("utf-8"),
             name=builder.b_name.decode("utf-8"),
+            dbname=builder.dbname,
         )
 
         if selection.data is None:

--- a/wp1/selection/abstract_builder_test.py
+++ b/wp1/selection/abstract_builder_test.py
@@ -81,6 +81,7 @@ class AbstractBuilderTest(BaseWpOneDbTest):
             b_name=b"My Builder",
             b_user_id=1234,
             b_project=b"en.wikipedia.fake",
+            b_dbname=b"enwiki",
             b_model=b"wp1.selection.models.fake",
             b_params='{"list":["a","b","c"]}',
         )
@@ -115,7 +116,7 @@ class AbstractBuilderTest(BaseWpOneDbTest):
 
         self.assertEqual(
             actual.s_object_key,
-            b"selections/wp1.selection.models.fake/" b"abcd-1234/MyBuilder.tsv",
+            b"selections/wp1.selection.models.fake/" b"abcd-1234/MyBuilder.enwiki.tsv",
         )
 
     @patch(
@@ -141,7 +142,22 @@ class AbstractBuilderTest(BaseWpOneDbTest):
         object_key = self.s3.upload_fileobj.call_args[1]["key"]
         self.assertEqual(b"a\nb\nc", data.read())
         self.assertEqual(
-            "selections/wp1.selection.models.fake/abcd-1234/MyBuilder.tsv", object_key
+            "selections/wp1.selection.models.fake/abcd-1234/MyBuilder.enwiki.tsv",
+            object_key,
+        )
+
+    @patch("wp1.models.wp10.selection.uuid.uuid4", return_value="abcd-1234")
+    def test_materialize_object_key_without_dbname(self, mock_uuid4):
+        self.builder.b_dbname = None
+        self.test_builder.materialize(
+            self.s3, self.wp10db, self.builder, "text/tab-separated-values", 1
+        )
+
+        actual = get_first_selection(self.wp10db)
+
+        self.assertEqual(
+            actual.s_object_key,
+            b"selections/wp1.selection.models.fake/" b"abcd-1234/MyBuilder.tsv",
         )
 
     def test_materialize_version(self):


### PR DESCRIPTION
Fixes #1266

Served selection TSVs were named after the Selection only (`MyFunSelection.tsv`); now the object key built at materialization includes the wiki dbname: `MyFunSelection.enwiki.tsv`. The dbname comes from the builder's `b_dbname` column — real sitematrix data added in #1271, which this PR is stacked on.

Notes:
- Existing selections keep their old keys until next materialized.

Added new unit tests for the dbname in object keys.

Written with AI assistance (Claude).