### PR TITLE
Add dbname column to builders, cached from the sitematrix

### DIFF
--- a/db/migrations/20260823_01_add_dbname_to_builders.py
+++ b/db/migrations/20260823_01_add_dbname_to_builders.py
@@ -1,0 +1,14 @@
+"""
+Add dbname column to builders table, cached from the sitematrix
+"""
+
+from yoyo import step
+
+__depends__ = {"20260324_01_add_flavour_to_zim_schedules"}
+
+steps = [
+    step(
+        "ALTER TABLE builders " "  ADD COLUMN b_dbname VARBINARY(255) NULL",
+        "ALTER TABLE builders " "  DROP COLUMN b_dbname",
+    )
+]

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -556,7 +556,7 @@ def _refresh_builder_dbname(redis: Redis, wp10db: Connection, builder: Builder) 
         dbname = logic_sites.dbname_for_project(
             redis, builder.b_project.decode("utf-8")
         )
-    except Exception:
+    except logic_sites.FETCH_ERRORS:
         logger.exception("Could not resolve dbname for project=%s", builder.b_project)
         return
     if dbname is None:

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -13,6 +13,7 @@ from pymysql.connections import Connection
 from redis import Redis
 from redis.exceptions import RedisError
 import wp1.logic.selection as logic_selection
+import wp1.logic.sites as logic_sites
 import wp1.logic.util as logic_util
 import wp1.logic.zim_files as logic_zim_tasks
 import wp1.logic.zim_schedules as logic_zim_schedules
@@ -251,10 +252,10 @@ def insert_builder(wp10db: Connection, builder: Builder) -> bytes:
     with wp10db.cursor() as cursor:
         cursor.execute(
             """INSERT INTO builders
-             (b_id, b_name, b_user_id, b_project, b_params, b_model,
+             (b_id, b_name, b_user_id, b_project, b_dbname, b_params, b_model,
               b_created_at, b_updated_at)
            VALUES
-             (%(b_id)s, %(b_name)s, %(b_user_id)s, %(b_project)s,
+             (%(b_id)s, %(b_name)s, %(b_user_id)s, %(b_project)s, %(b_dbname)s,
               %(b_params)s, %(b_model)s, %(b_created_at)s,
               %(b_updated_at)s)
         """,
@@ -544,6 +545,35 @@ def get_builder(wp10db: Connection, id_: str | bytes) -> Builder:
         return Builder(**db_builder)
 
 
+def _refresh_builder_dbname(redis: Redis, wp10db: Connection, builder: Builder) -> None:
+    """Resolves and persists the dbname for the builder's project, if needed.
+
+    The dbname (eg 'enwiki') is looked up in the redis-cached sitematrix. Any
+    failure to resolve it is logged and ignored, so that materialization can
+    proceed without it.
+    """
+    try:
+        dbname = logic_sites.dbname_for_project(
+            redis, builder.b_project.decode("utf-8")
+        )
+    except Exception:
+        logger.exception("Could not resolve dbname for project=%s", builder.b_project)
+        return
+    if dbname is None:
+        logger.warning("No dbname found for project=%s", builder.b_project)
+        return
+    encoded = dbname.encode("utf-8")
+    if encoded == builder.b_dbname:
+        return
+    builder.b_dbname = encoded
+    with wp10db.cursor() as cursor:
+        cursor.execute(
+            "UPDATE builders SET b_dbname = %(b_dbname)s WHERE b_id = %(b_id)s",
+            {"b_dbname": builder.b_dbname, "b_id": builder.b_id},
+        )
+    wp10db.commit()
+
+
 def materialize_builder(
     builder_cls: type[AbstractBuilder],
     builder: Builder,
@@ -569,6 +599,7 @@ def materialize_builder(
     if builder.b_id is None:
         raise ValueError("Cannot materialize builder without b_id")
 
+    _refresh_builder_dbname(redis, wp10db, builder)
     try:
         materializer = builder_cls()
         next_version = logic_selection.get_next_version(

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -28,6 +28,7 @@ class BuilderTest(BaseWpOneDbTest):
         "b_name": b"My Builder",
         "b_user_id": b"1234",
         "b_project": b"en.wikipedia.fake",
+        "b_dbname": None,
         "b_model": b"wp1.selection.models.simple",
         "b_params": b'{"list": ["a", "b", "c"]}',
         "b_created_at": b"20191225044444",
@@ -475,7 +476,8 @@ class BuilderTest(BaseWpOneDbTest):
         self.builder.b_id = id_
         self.assertEqual(self.builder, actual)
 
-    def test_materialize_builder_with_connections(self):
+    @patch("wp1.logic.builder.logic_sites.dbname_for_project", return_value="enwiki")
+    def test_materialize_builder_with_connections(self, mock_dbname_for_project):
         s3 = MagicMock()
         redis = MagicMock()
 
@@ -497,16 +499,63 @@ class BuilderTest(BaseWpOneDbTest):
         materialize_mock.materialize.assert_called_once_with(
             ANY, ANY, self.builder, "text/tab-separated-values", 2
         )
+        mock_dbname_for_project.assert_called_once_with(redis, "en.wikipedia.fake")
+        self.assertEqual(b"enwiki", self.builder.b_dbname)
 
         actual = self._get_builder_by_user_id()
         expected = dict(**self.expected_builder)
         expected["b_current_version"] = 2
         expected["b_selection_zim_version"] = 2
+        expected["b_dbname"] = b"enwiki"
         self.assertEqual(expected, actual)
 
+    @patch("wp1.logic.builder.logic_sites.dbname_for_project", return_value=None)
+    def test_materialize_builder_dbname_not_found(self, mock_dbname_for_project):
+        TestBuilderClass = MagicMock()
+        TestBuilderClass.return_value = MagicMock()
+
+        self._insert_builder()
+        self._insert_selection(1, "text/tab-separated-values")
+
+        logic_builder.materialize_builder(
+            TestBuilderClass,
+            self.builder,
+            "text/tab-separated-values",
+            MagicMock(),
+            MagicMock(),
+            self.wp10db,
+        )
+        self.assertIsNone(self.builder.b_dbname)
+        self.assertIsNone(self._get_builder_by_user_id()["b_dbname"])
+
+    @patch(
+        "wp1.logic.builder.logic_sites.dbname_for_project",
+        side_effect=ValueError("sitematrix down"),
+    )
+    def test_materialize_builder_dbname_resolution_error(self, mock_dbname_for_project):
+        TestBuilderClass = MagicMock()
+        TestBuilderClass.return_value = MagicMock()
+
+        self._insert_builder()
+        self._insert_selection(1, "text/tab-separated-values")
+
+        logic_builder.materialize_builder(
+            TestBuilderClass,
+            self.builder,
+            "text/tab-separated-values",
+            MagicMock(),
+            MagicMock(),
+            self.wp10db,
+        )
+        self.assertIsNone(self.builder.b_dbname)
+        self.assertIsNone(self._get_builder_by_user_id()["b_dbname"])
+
+    @patch("wp1.logic.builder.logic_sites.dbname_for_project", return_value=None)
     @patch("wp1.logic.builder.wp10_connect")
     @patch("wp1.logic.builder.connect_storage")
-    def test_materialize_builder(self, mock_connect_storage, mock_connect_wp10):
+    def test_materialize_builder(
+        self, mock_connect_storage, mock_connect_wp10, mock_dbname_for_project
+    ):
         mock_connect_wp10.return_value = self.wp10db
         TestBuilderClass = MagicMock()
         materialize_mock = MagicMock()
@@ -533,6 +582,7 @@ class BuilderTest(BaseWpOneDbTest):
         expected["b_selection_zim_version"] = 2
         self.assertEqual(expected, actual)
 
+    @patch("wp1.logic.builder.logic_sites.dbname_for_project", return_value=None)
     @patch("wp1.logic.builder.wp10_connect")
     @patch("wp1.logic.builder.redis_connect")
     @patch("wp1.logic.builder.connect_storage")
@@ -543,6 +593,7 @@ class BuilderTest(BaseWpOneDbTest):
         mock_connect_storage,
         mock_redis_connect,
         mock_connect_wp10,
+        mock_dbname_for_project,
     ):
         s3 = MagicMock()
         redis = MagicMock()

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -530,7 +530,7 @@ class BuilderTest(BaseWpOneDbTest):
 
     @patch(
         "wp1.logic.builder.logic_sites.dbname_for_project",
-        side_effect=ValueError("sitematrix down"),
+        side_effect=RedisError("sitematrix down"),
     )
     def test_materialize_builder_dbname_resolution_error(self, mock_dbname_for_project):
         TestBuilderClass = MagicMock()

--- a/wp1/logic/sites.py
+++ b/wp1/logic/sites.py
@@ -1,0 +1,61 @@
+import json
+import logging
+from datetime import timedelta
+
+import mwclient
+from redis import Redis
+
+from wp1.api import MW_USER_AGENT
+
+logger = logging.getLogger(__name__)
+
+CACHE_KEY = "site_data"
+CACHE_TTL = timedelta(days=1)
+
+
+def _fetch_site_data() -> dict:
+    """Fetches the sitematrix from meta.wikimedia.org.
+
+    Returns a dict with 'projects', the ordered list of language project
+    domains (eg 'en.wikipedia.org'), and 'dbnames', a mapping of every site
+    domain (including specials) to its database name (eg 'enwiki').
+    """
+    site = mwclient.Site("meta.wikimedia.org", clients_useragent=MW_USER_AGENT)
+    sitematrix = site.api("sitematrix")["sitematrix"]
+
+    projects = []
+    dbnames = {}
+    for key, value in sitematrix.items():
+        if key == "count":
+            continue
+        sites = value if key == "specials" else value["site"]
+        for s in sites:
+            domain = s["url"].replace("https://", "")
+            dbnames[domain] = s["dbname"]
+            if key != "specials":
+                projects.append(domain)
+
+    return {"projects": projects, "dbnames": dbnames}
+
+
+def get_site_data(redis: Redis) -> dict:
+    """Returns the sitematrix data, from the redis cache if possible."""
+    raw = redis.get(CACHE_KEY)
+    if raw is not None:
+        try:
+            return json.loads(raw)
+        except ValueError:
+            logger.warning("Discarding unparseable cached site data")
+    data = _fetch_site_data()
+    redis.setex(CACHE_KEY, CACHE_TTL, value=json.dumps(data))
+    return data
+
+
+def get_projects(redis: Redis) -> list[str]:
+    """Returns the list of language project domains, eg 'en.wikipedia.org'."""
+    return get_site_data(redis)["projects"]
+
+
+def dbname_for_project(redis: Redis, project: str) -> str | None:
+    """Returns the dbname (eg 'enwiki') for a project domain, or None."""
+    return get_site_data(redis)["dbnames"].get(project)

--- a/wp1/logic/sites.py
+++ b/wp1/logic/sites.py
@@ -3,7 +3,10 @@ import logging
 from datetime import timedelta
 
 import mwclient
+import mwclient.errors
+import requests
 from redis import Redis
+from redis.exceptions import RedisError
 
 from wp1.api import MW_USER_AGENT
 
@@ -11,6 +14,14 @@ logger = logging.getLogger(__name__)
 
 CACHE_KEY = "site_data"
 CACHE_TTL = timedelta(days=1)
+
+# The service failures that fetching the site data can raise: redis errors,
+# HTTP/connection errors, and MediaWiki API errors.
+FETCH_ERRORS = (
+    RedisError,
+    requests.exceptions.RequestException,
+    mwclient.errors.MwClientError,
+)
 
 
 def _fetch_site_data() -> dict:

--- a/wp1/logic/sites_test.py
+++ b/wp1/logic/sites_test.py
@@ -1,0 +1,130 @@
+import json
+from datetime import timedelta
+from unittest.mock import patch
+
+from wp1.base_db_test import BaseWpOneDbTest
+from wp1.logic import sites as logic_sites
+
+SITEMATRIX_RESULT = {
+    "sitematrix": {
+        "count": 3,
+        "0": {
+            "code": "aa",
+            "name": "Qaf\u00e1r af",
+            "site": [
+                {
+                    "url": "https://aa.wikipedia.org",
+                    "dbname": "aawiki",
+                    "code": "wiki",
+                    "sitename": "Wikipedia",
+                    "closed": "",
+                },
+                {
+                    "url": "https://aa.wiktionary.org",
+                    "dbname": "aawiktionary",
+                    "code": "wiktionary",
+                    "sitename": "Wiktionary",
+                    "closed": "",
+                },
+            ],
+            "dir": "ltr",
+            "localname": "Afar",
+        },
+        "1": {
+            "code": "ab",
+            "name": "\u0410\u04a7\u0441\u0448\u04d9\u0430",
+            "site": [
+                {
+                    "url": "https://ab.wikipedia.org",
+                    "dbname": "abwiki",
+                    "code": "wiki",
+                    "sitename": "\u0410\u0432\u0438\u043a\u0438\u043f\u0435\u0434\u0438\u0430",
+                },
+            ],
+            "dir": "ltr",
+            "localname": "Abkhazian",
+        },
+        "specials": [
+            {
+                "url": "https://commons.wikimedia.org",
+                "dbname": "commonswiki",
+                "code": "commons",
+                "lang": "commons",
+                "sitename": "Wikimedia Commons",
+            },
+        ],
+    },
+}
+
+EXPECTED_PROJECTS = ["aa.wikipedia.org", "aa.wiktionary.org", "ab.wikipedia.org"]
+
+EXPECTED_DBNAMES = {
+    "aa.wikipedia.org": "aawiki",
+    "aa.wiktionary.org": "aawiktionary",
+    "ab.wikipedia.org": "abwiki",
+    "commons.wikimedia.org": "commonswiki",
+}
+
+
+class SitesTest(BaseWpOneDbTest):
+
+    @patch("wp1.logic.sites.mwclient.Site")
+    def test_get_site_data_fetches_and_caches(self, patched_site):
+        patched_site.return_value.api.return_value = SITEMATRIX_RESULT
+
+        actual = logic_sites.get_site_data(self.redis)
+
+        self.assertEqual(EXPECTED_PROJECTS, actual["projects"])
+        self.assertEqual(EXPECTED_DBNAMES, actual["dbnames"])
+
+        cached = json.loads(self.redis.get(logic_sites.CACHE_KEY))
+        self.assertEqual(actual, cached)
+
+        # A second call is served from the cache, without another fetch.
+        self.assertEqual(actual, logic_sites.get_site_data(self.redis))
+        patched_site.assert_called_once()
+
+    @patch("wp1.logic.sites.mwclient.Site")
+    def test_get_site_data_cached(self, patched_site):
+        data = {"projects": EXPECTED_PROJECTS, "dbnames": EXPECTED_DBNAMES}
+        self.redis.setex(
+            logic_sites.CACHE_KEY, timedelta(days=1), value=json.dumps(data)
+        )
+
+        actual = logic_sites.get_site_data(self.redis)
+
+        self.assertEqual(data, actual)
+        patched_site.assert_not_called()
+
+    @patch("wp1.logic.sites.mwclient.Site")
+    def test_get_projects(self, patched_site):
+        patched_site.return_value.api.return_value = SITEMATRIX_RESULT
+        self.assertEqual(EXPECTED_PROJECTS, logic_sites.get_projects(self.redis))
+
+    @patch("wp1.logic.sites.mwclient.Site")
+    def test_dbname_for_project(self, patched_site):
+        patched_site.return_value.api.return_value = SITEMATRIX_RESULT
+        self.assertEqual(
+            "aawiki", logic_sites.dbname_for_project(self.redis, "aa.wikipedia.org")
+        )
+        self.assertEqual(
+            "commonswiki",
+            logic_sites.dbname_for_project(self.redis, "commons.wikimedia.org"),
+        )
+
+    @patch("wp1.logic.sites.mwclient.Site")
+    def test_dbname_for_project_unknown(self, patched_site):
+        patched_site.return_value.api.return_value = SITEMATRIX_RESULT
+        self.assertIsNone(
+            logic_sites.dbname_for_project(self.redis, "not.a.project.fake")
+        )
+
+    @patch("wp1.logic.sites.mwclient.Site")
+    def test_get_site_data_unparseable_cache(self, patched_site):
+        patched_site.return_value.api.return_value = SITEMATRIX_RESULT
+        self.redis.setex(logic_sites.CACHE_KEY, timedelta(days=1), value=b"{not json")
+
+        actual = logic_sites.get_site_data(self.redis)
+
+        self.assertEqual(EXPECTED_PROJECTS, actual["projects"])
+        patched_site.assert_called_once()

--- a/wp1/models/wp10/builder.py
+++ b/wp1/models/wp10/builder.py
@@ -33,6 +33,9 @@ class Builder:
     b_updated_at: bytes | None = attr.ib(default=None)
     b_current_version: int = attr.ib(default=0)
     b_selection_zim_version: int = attr.ib(default=0)
+    # The database name of the wiki that b_project refers to (eg b'enwiki').
+    # Cached from the sitematrix, may be None if not yet resolved.
+    b_dbname: bytes | None = attr.ib(default=None)
 
     @property
     def id(self) -> str:
@@ -49,6 +52,12 @@ class Builder:
     @property
     def project(self) -> str:
         return logic_util.as_text(self.b_project)
+
+    @property
+    def dbname(self) -> str | None:
+        if self.b_dbname is None:
+            return None
+        return logic_util.as_text(self.b_dbname)
 
     @property
     def model(self) -> str:

--- a/wp1/web/sites.py
+++ b/wp1/web/sites.py
@@ -1,30 +1,11 @@
 import flask
-import mwclient
-from datetime import timedelta
-from wp1.api import MW_USER_AGENT
+
+import wp1.logic.sites as logic_sites
 from wp1.web.redis import get_redis
 
 sites = flask.Blueprint("sites", __name__)
-site = None
 
 
 @sites.route("/")
 def get_sites():
-    redis = get_redis()
-    sites_data = redis.get("sites")
-    if sites_data is not None:
-        return {"sites": sites_data.decode("utf-8").split(",")}
-
-    site = mwclient.Site("meta.wikimedia.org", clients_useragent=MW_USER_AGENT)
-    sitematrix = site.api("sitematrix")["sitematrix"]
-    sitematrix.pop("specials")
-    sitematrix.pop("count")
-
-    sites_data = []
-    for i in sitematrix:
-        for j in sitematrix[i]["site"]:
-            project = j["url"].replace("https://", "")
-            sites_data.append(project)
-
-    redis.setex("sites_data", timedelta(days=1), value=",".join(sites_data))
-    return {"sites": sites_data}
+    return {"sites": logic_sites.get_projects(get_redis())}

--- a/wp1/web/sites_test.py
+++ b/wp1/web/sites_test.py
@@ -1,10 +1,13 @@
+import json
 from datetime import timedelta
 from unittest.mock import patch
+
+import wp1.logic.sites as logic_sites
 from wp1.web.app import create_app
 from wp1.web.base_web_testcase import BaseWebTestcase
 
 
-class IdentifyTest(BaseWebTestcase):
+class SitesTest(BaseWebTestcase):
 
     result = {
         "sitematrix": {
@@ -52,16 +55,20 @@ class IdentifyTest(BaseWebTestcase):
     }
     sites = ["aa.wikipedia.org", "ab.wikipedia.org"]
 
-    @patch("wp1.web.sites.site")
+    @patch("wp1.logic.sites.mwclient.Site")
     def test_get_cached_sites(self, patched_site):
         self.app = create_app()
         with self.override_db(self.app), self.app.test_client() as client:
-            self.redis.setex("sites", timedelta(days=1), value=",".join(self.sites))
+            self.redis.setex(
+                logic_sites.CACHE_KEY,
+                timedelta(days=1),
+                value=json.dumps({"projects": self.sites, "dbnames": {}}),
+            )
             rv = client.get("/v1/sites/")
             self.assertEqual({"sites": self.sites}, rv.get_json())
             self.assertEqual(patched_site.called, False)
 
-    @patch("wp1.web.sites.mwclient.Site")
+    @patch("wp1.logic.sites.mwclient.Site")
     def test_get_uncached_sites(self, patched_site):
         patched_site.return_value.api.return_value = self.result
         self.app = create_app()

--- a/wp10_test.up.sql
+++ b/wp10_test.up.sql
@@ -86,6 +86,7 @@ CREATE TABLE `builders` (
   b_name VARBINARY(255) NOT NULL,
   b_user_id VARCHAR(255) NOT NULL,
   b_project VARBINARY(255) NOT NULL,
+  b_dbname VARBINARY(255),
   b_model VARBINARY(255) NOT NULL,
   b_current_version int(11) NOT NULL DEFAULT 0,
   b_params BLOB,


### PR DESCRIPTION
Fixes #1268

Adds `b_dbname` to the `builders` table, holding the database name (`enwiki`) of the wiki `b_project` refers to — real data from the meta.wikimedia.org sitematrix, not derived from the domain.

- New `wp1/logic/sites.py` fetches the sitematrix and caches the project list + domain→dbname map in redis for a day. `/v1/sites/` now delegates to it, which also fixes a latent bug where the endpoint wrote its cache under `sites_data` but read `sites`, so the cache never hit.
- `b_dbname` is resolved and persisted at the start of every materialization, so existing builders backfill on their next materialize and project edits are picked up. Resolution failures are logged and skipped — materialization never blocks on the sitematrix.
- Migration `20260823_01_add_dbname_to_builders` (nullable VARBINARY(255)); test schema updated.

Smoke-tested against the live sitematrix: 948 projects / 1072 dbnames parsed; `en.wikipedia.org→enwiki`, `commons.wikimedia.org→commonswiki`, `be-tarask.wikipedia.org→be_x_oldwiki`. Full backend suite passes (847).

#1267 will be rebased on top of this to use `b_dbname` for the served TSV filename instead of a heuristic.

Written with AI assistance (Claude).