### PR TITLE
Mark combinators with failed referenced selections as errored

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1348,7 +1348,33 @@ components:
                 description: 'The extension for the selection for which materialization was attempted'
               status:
                 type: string
-                description: 'Either "CAN_RETRY" if the error is retryable, or "FATAL" if not'
+                description: 'Either "CAN_RETRY" if the error is retryable, or "FAILED" if not'
+              referenced_builder_errors:
+                type: array
+                description: 'For Combinators, details of each referenced Builder whose latest selection is broken. Present both when the Combinator build recorded the failures and when they are derived at read time from the current status of the referenced selections.'
+                items:
+                  type: object
+                  properties:
+                    builder_id:
+                      type: string
+                      nullable: true
+                    builder_name:
+                      type: string
+                      nullable: true
+                    builder_model:
+                      type: string
+                      nullable: true
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    action:
+                      type: string
+                    status:
+                      type: string
+                      description: 'Either "CAN_RETRY" or "FAILED".'
+                    code:
+                      type: string
     ActiveSchedule:
       type: object
       nullable: true
@@ -1435,6 +1461,9 @@ components:
           type: boolean
           nullable: true
           description: 'True if this Builder has a recurring ZIM generation schedule with generations remaining, null otherwise. See /builders/{builderId}/zim/status for the details of that schedule.'
+        has_failed_references:
+          type: boolean
+          description: 'For Combinators, true when the latest TSV selection of any referenced Builder (include or exclude) is FAILED or CAN_RETRY, so the Combinator needs attention even if its own cached selection is still OK. Always false for non-Combinator Builders.'
     Project:
       type: object
       properties:

--- a/wp1-frontend/cypress/e2e/myLists.cy.js
+++ b/wp1-frontend/cypress/e2e/myLists.cy.js
@@ -48,6 +48,9 @@ describe('the selections page', () => {
       cy.contains('.wp1r-railrow', 'updated list').contains('Processing');
       cy.contains('.wp1r-railrow', 'permanent error').contains('Failed');
       cy.contains('.wp1r-railrow', 'zim failed').contains('Failed');
+      cy.contains('.wp1r-railrow', 'combinator broken reference').contains(
+        'Failed'
+      );
       cy.contains('.wp1r-railrow', 'selection ready, no zim').contains(
         'No ZIM'
       );
@@ -55,10 +58,10 @@ describe('the selections page', () => {
     });
 
     it('shows the count chips', () => {
-      cy.contains('button', 'All 14');
-      cy.contains('button', 'Needs attention 6');
+      cy.contains('button', 'All 15');
+      cy.contains('button', 'Needs attention 7');
       cy.contains('button', 'Up to date 1');
-      cy.contains('button', 'No ZIM 9');
+      cy.contains('button', 'No ZIM 10');
       cy.contains('button', 'Scheduled 1');
     });
 
@@ -165,11 +168,11 @@ describe('the selections page', () => {
     });
 
     it('filters by status when a chip is clicked', () => {
-      cy.contains('button', 'Needs attention 6').click();
+      cy.contains('button', 'Needs attention 7').click();
       cy.contains('.wp1r-railrow', 'permanent error');
       cy.contains('.wp1r-railrow', 'simple list').should('not.exist');
       // Clicking again clears the filter.
-      cy.contains('button', 'Needs attention 6').click();
+      cy.contains('button', 'Needs attention 7').click();
       cy.contains('.wp1r-railrow', 'simple list');
     });
 

--- a/wp1-frontend/cypress/fixtures/list_data.json
+++ b/wp1-frontend/cypress/fixtures/list_data.json
@@ -255,6 +255,25 @@
       "z_url": null,
       "z_status": "NOT_REQUESTED",
       "z_is_deleted": null
+    },
+    {
+      "created_at": 1685733000,
+      "id": "combo-broken-ref",
+      "model": "wp1.selection.models.combinator",
+      "name": "combinator broken reference",
+      "project": "en.wikipedia.org",
+      "s_content_type": "text/tab-separated-values",
+      "s_extension": "tsv",
+      "s_id": "combo-selection-002",
+      "s_status": "OK",
+      "s_updated_at": 1685733500,
+      "s_url": "https://www.example.fake/combo-selection-002",
+      "updated_at": 1685733150,
+      "z_updated_at": null,
+      "z_url": null,
+      "z_status": "NOT_REQUESTED",
+      "z_is_deleted": null,
+      "has_failed_references": true
     }
   ]
 }

--- a/wp1-frontend/src/lib/selections.js
+++ b/wp1-frontend/src/lib/selections.js
@@ -121,7 +121,11 @@ export function selectionIsPending(item) {
 }
 
 export function selectionHasError(item) {
-  return !!item.s_status && item.s_status !== 'OK';
+  // has_failed_references marks a combinator whose referenced selections
+  // are failed even though its own cached selection is still OK.
+  return (
+    (!!item.s_status && item.s_status !== 'OK') || !!item.has_failed_references
+  );
 }
 
 export function deriveSelectionStatus(item) {

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -48,6 +48,22 @@ logger = logging.getLogger(__name__)
 
 META_BUILDER_MODELS = {"wp1.selection.models.combinator"}
 
+# How a referenced builder's broken TSV selection is described to users, both
+# when a Combinator build hits it (wp1.selection.meta_builder) and when the
+# failure is derived at read time for display.
+REFERENCE_FAILURE_INFO = {
+    "FAILED": {
+        "code": "REFERENCED_SELECTION_FAILED",
+        "reason": "latest selection failed",
+        "action": "Open this list, fix the failed selection, then update this Combinator.",
+    },
+    "CAN_RETRY": {
+        "code": "REFERENCED_SELECTION_RETRYABLE_FAILURE",
+        "reason": "latest selection failed but can be retried",
+        "action": "Open this list and retry it, then retry this Combinator.",
+    },
+}
+
 
 def builder_label_by_id(wp10db: Connection, builder_id: str | bytes) -> str:
     try:
@@ -86,6 +102,22 @@ def _group_builder_ids(params: dict[str, Any], group_name: str) -> list[str]:
     return [builder_id for builder_id in builders if isinstance(builder_id, str)]
 
 
+def _parse_builder_params(raw_params: bytes | None) -> dict[str, Any] | None:
+    try:
+        params = json.loads(raw_params or b"{}")
+    except json.decoder.JSONDecodeError:
+        return None
+    if not isinstance(params, dict):
+        return None
+    return params
+
+
+def _referenced_builder_ids(params: dict[str, Any]) -> list[str]:
+    """All builder ids referenced by meta-builder params, include and exclude."""
+    ids = _group_builder_ids(params, "include") + _group_builder_ids(params, "exclude")
+    return list(dict.fromkeys(ids))
+
+
 def _remove_builder_reference_from_params(
     params: dict[str, Any], target_builder_id: str
 ) -> tuple[dict[str, Any], bool]:
@@ -112,13 +144,9 @@ def _remove_builder_reference_from_params(
 def _combinator_reference_record(
     combinator: Builder, target_builder_id: str
 ) -> dict[str, Any] | None:
-    try:
-        params = json.loads(combinator.b_params or b"{}")
-    except json.decoder.JSONDecodeError:
+    params = _parse_builder_params(combinator.b_params)
+    if params is None:
         logger.warning("Could not parse params for builder id=%s", combinator.id)
-        return None
-
-    if not isinstance(params, dict):
         return None
 
     include_builders = _group_builder_ids(params, "include")
@@ -945,6 +973,92 @@ def latest_selections_with_errors(
     return res
 
 
+def failed_reference_errors(
+    wp10db: Connection, builder: Builder
+) -> list[dict[str, Any]]:
+    """Read-time failure info for selections referenced by a meta builder.
+
+    Returns one entry per referenced builder whose latest TSV selection is
+    FAILED or CAN_RETRY, in the same shape as
+    Wp1MetaBuilderProcessError.to_user_messages().
+    """
+    if not is_meta_builder(builder):
+        return []
+    params = _parse_builder_params(builder.b_params)
+    if params is None:
+        return []
+    reference_ids = _referenced_builder_ids(params)
+    if not reference_ids:
+        return []
+
+    with wp10db.cursor() as cursor:
+        cursor.execute(
+            """SELECT b.b_id, b.b_name, b.b_model, s.s_status
+           FROM builders b
+           LEFT JOIN selections s
+             ON s.s_builder_id = b.b_id
+             AND s.s_version = b.b_current_version
+             AND s.s_content_type = 'text/tab-separated-values'
+           WHERE b.b_id IN ({placeholders})
+        """.format(placeholders=", ".join(["%s"] * len(reference_ids))),
+            tuple(reference_ids),
+        )
+        rows = cursor.fetchall()
+
+    rows_by_id = {logic_util.as_text(row["b_id"]): row for row in rows}
+    errors = []
+    for reference_id in reference_ids:
+        row = rows_by_id.get(reference_id)
+        if row is None:
+            continue
+        status = (
+            logic_util.as_text(row["s_status"]) if row["s_status"] is not None else None
+        )
+        info = REFERENCE_FAILURE_INFO.get(status)
+        if info is None:
+            continue
+        label = (
+            logic_util.as_text(row["b_name"])
+            if row["b_name"] is not None
+            else reference_id
+        )
+        errors.append(
+            {
+                "builder_id": reference_id,
+                "builder_name": label,
+                "builder_model": logic_util.as_text(row["b_model"]),
+                "message": f"Referenced builder {label} {info['reason']}",
+                "status": status,
+                **info,
+            }
+        )
+    return errors
+
+
+def derived_selection_error(
+    wp10db: Connection, builder: Builder
+) -> dict[str, Any] | None:
+    """A synthesized selection error for a meta builder with failed references.
+
+    A Combinator is normally marked errored by its own rebuild after a
+    referenced selection fails. If that rebuild never ran (missed enqueue,
+    manually restored data), the Combinator's stored selection stays OK while
+    its references are broken. This derives the error at read time so the
+    Combinator still reports as errored.
+    """
+    reference_errors = failed_reference_errors(wp10db, builder)
+    if not reference_errors:
+        return None
+
+    has_fatal = any(error["status"] == "FAILED" for error in reference_errors)
+    return {
+        "status": "FAILED" if has_fatal else "CAN_RETRY",
+        "ext": "tsv",
+        "error_messages": [error["message"] for error in reference_errors],
+        "referenced_builder_errors": reference_errors,
+    }
+
+
 def request_zim_file_task_for_builder(
     redis: Redis, wp10db: Connection, builder: Builder, zim_schedule_id: bytes
 ) -> ZimTask | None:
@@ -1286,6 +1400,31 @@ def _get_active_schedule_data(
     return data
 
 
+def _annotate_failed_references(
+    db_rows: list[dict[str, Any]], rows: list[dict[str, Any]]
+) -> None:
+    """Flags meta-builder rows whose referenced TSV selections are failed.
+
+    Referenced builders always belong to the same user (enforced at validate
+    time), so their statuses are already present in the user's own rows.
+    """
+    tsv_status_by_id = {
+        row["id"]: row["s_status"]
+        for db_row, row in zip(db_rows, rows)
+        if db_row["s_content_type"] == b"text/tab-separated-values"
+    }
+    for db_row, row in zip(db_rows, rows):
+        if logic_util.as_text(db_row["b_model"]) not in META_BUILDER_MODELS:
+            continue
+        params = _parse_builder_params(db_row["b_params"])
+        if params is None:
+            continue
+        row["has_failed_references"] = any(
+            tsv_status_by_id.get(reference_id) in REFERENCE_FAILURE_INFO
+            for reference_id in _referenced_builder_ids(params)
+        )
+
+
 def get_builders_with_selections(
     wp10db: Connection, user_id: str | bytes
 ) -> list[dict[str, Any]]:
@@ -1325,6 +1464,9 @@ def get_builders_with_selections(
         builder.update(_get_selection_data(db_builder))
         builder.update(_get_zimfile_data(db_builder))
         builder.update(_get_active_schedule_data(db_builder))
+        builder["has_failed_references"] = False
         result.append(builder)
+
+    _annotate_failed_references(data, result)
 
     return result

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -56,6 +56,7 @@ class BuilderTest(BaseWpOneDbTest):
             "z_status": "NOT_REQUESTED",
             "z_is_deleted": None,
             "active_schedule": None,
+            "has_failed_references": False,
         }
     ]
 
@@ -78,6 +79,7 @@ class BuilderTest(BaseWpOneDbTest):
             "z_status": "NOT_REQUESTED",
             "z_is_deleted": None,
             "active_schedule": None,
+            "has_failed_references": False,
         },
         {
             "id": "1a-2b-3c-4d",
@@ -97,6 +99,7 @@ class BuilderTest(BaseWpOneDbTest):
             "z_status": "NOT_REQUESTED",
             "z_is_deleted": None,
             "active_schedule": None,
+            "has_failed_references": False,
         },
     ]
 
@@ -119,6 +122,7 @@ class BuilderTest(BaseWpOneDbTest):
             "z_status": None,
             "z_is_deleted": None,
             "active_schedule": None,
+            "has_failed_references": False,
         }
     ]
 
@@ -141,6 +145,7 @@ class BuilderTest(BaseWpOneDbTest):
             "z_status": "NOT_REQUESTED",
             "z_is_deleted": None,
             "active_schedule": None,
+            "has_failed_references": False,
         }
     ]
 
@@ -163,6 +168,7 @@ class BuilderTest(BaseWpOneDbTest):
             "z_status": "FILE_READY",
             "z_is_deleted": True,
             "active_schedule": None,
+            "has_failed_references": False,
         }
     ]
 
@@ -291,14 +297,16 @@ class BuilderTest(BaseWpOneDbTest):
         zim_task_id="5678",
         skip_zim=False,
         zim_schedule_id=b"schedule_123",
+        status=None,
     ):
-        if has_errors:
-            status = "CAN_RETRY"
-            if error_messages is None:
-                error_messages = '{"error_messages":["There was an error"]}'
-        else:
-            status = "OK"
-            error_messages = None
+        if status is None:
+            if has_errors:
+                status = "CAN_RETRY"
+                if error_messages is None:
+                    error_messages = '{"error_messages":["There was an error"]}'
+            else:
+                status = "OK"
+                error_messages = None
 
         zimfarm_status = b"NOT_REQUESTED"
         zim_file_updated_at = None
@@ -759,6 +767,140 @@ class BuilderTest(BaseWpOneDbTest):
         self.assertObjectListsEqual(
             self.expected_list_with_zimfarm_status, article_data
         )
+
+    def _insert_combinator_scenario(self, exclude_status="FAILED", include_status="OK"):
+        """(ref-a OR ref-b) NOT ref-c, with a stale-OK combinator selection."""
+        self._insert_builder_record("ref-a", "Ref A", current_version=1)
+        self._insert_selection(
+            "sel-a", "text/tab-separated-values", builder_id=b"ref-a", skip_zim=True
+        )
+        self._insert_builder_record("ref-b", "Ref B", current_version=1)
+        self._insert_selection(
+            "sel-b",
+            "text/tab-separated-values",
+            builder_id=b"ref-b",
+            skip_zim=True,
+            status=include_status,
+        )
+        self._insert_builder_record("ref-c", "Ref C", current_version=1)
+        self._insert_selection(
+            "sel-c",
+            "text/tab-separated-values",
+            builder_id=b"ref-c",
+            skip_zim=True,
+            status=exclude_status,
+        )
+        self._insert_builder_record(
+            "combo",
+            "My Combinator",
+            model="wp1.selection.models.combinator",
+            current_version=1,
+            params={
+                "include": {"builders": ["ref-a", "ref-b"], "operation": "union"},
+                "exclude": {"builders": ["ref-c"], "operation": "union"},
+            },
+        )
+        self._insert_selection(
+            "sel-combo", "text/tab-separated-values", builder_id=b"combo", skip_zim=True
+        )
+
+    def test_get_builders_flags_failed_exclude_reference(self):
+        self._insert_combinator_scenario(exclude_status="FAILED")
+
+        article_data = logic_builder.get_builders_with_selections(self.wp10db, "1234")
+
+        by_id = {row["id"]: row for row in article_data}
+        self.assertTrue(by_id["combo"]["has_failed_references"])
+        self.assertFalse(by_id["ref-a"]["has_failed_references"])
+        self.assertFalse(by_id["ref-c"]["has_failed_references"])
+
+    def test_get_builders_flags_retryable_include_reference(self):
+        self._insert_combinator_scenario(
+            exclude_status="OK", include_status="CAN_RETRY"
+        )
+
+        article_data = logic_builder.get_builders_with_selections(self.wp10db, "1234")
+
+        by_id = {row["id"]: row for row in article_data}
+        self.assertTrue(by_id["combo"]["has_failed_references"])
+
+    def test_get_builders_no_flag_when_references_ok(self):
+        self._insert_combinator_scenario(exclude_status="OK")
+
+        article_data = logic_builder.get_builders_with_selections(self.wp10db, "1234")
+
+        by_id = {row["id"]: row for row in article_data}
+        self.assertFalse(by_id["combo"]["has_failed_references"])
+
+    def test_failed_reference_errors_for_exclude_reference(self):
+        self._insert_combinator_scenario(exclude_status="FAILED")
+        builder = logic_builder.get_builder(self.wp10db, b"combo")
+
+        actual = logic_builder.failed_reference_errors(self.wp10db, builder)
+
+        self.assertEqual(
+            [
+                {
+                    "builder_id": "ref-c",
+                    "builder_name": "Ref C",
+                    "builder_model": "wp1.selection.models.simple",
+                    "message": "Referenced builder Ref C latest selection failed",
+                    "status": "FAILED",
+                    "code": "REFERENCED_SELECTION_FAILED",
+                    "reason": "latest selection failed",
+                    "action": "Open this list, fix the failed selection, then update this Combinator.",
+                }
+            ],
+            actual,
+        )
+
+    def test_failed_reference_errors_for_non_meta_builder(self):
+        self._insert_builder()
+        builder = logic_builder.get_builder(self.wp10db, b"1a-2b-3c-4d")
+
+        actual = logic_builder.failed_reference_errors(self.wp10db, builder)
+
+        self.assertEqual([], actual)
+
+    def test_derived_selection_error_fatal(self):
+        self._insert_combinator_scenario(
+            exclude_status="FAILED", include_status="CAN_RETRY"
+        )
+        builder = logic_builder.get_builder(self.wp10db, b"combo")
+
+        actual = logic_builder.derived_selection_error(self.wp10db, builder)
+
+        self.assertEqual("FAILED", actual["status"])
+        self.assertEqual("tsv", actual["ext"])
+        self.assertEqual(
+            ["ref-b", "ref-c"],
+            [error["builder_id"] for error in actual["referenced_builder_errors"]],
+        )
+        self.assertEqual(
+            [
+                "Referenced builder Ref B latest selection failed but can be retried",
+                "Referenced builder Ref C latest selection failed",
+            ],
+            actual["error_messages"],
+        )
+
+    def test_derived_selection_error_retryable(self):
+        self._insert_combinator_scenario(
+            exclude_status="CAN_RETRY", include_status="OK"
+        )
+        builder = logic_builder.get_builder(self.wp10db, b"combo")
+
+        actual = logic_builder.derived_selection_error(self.wp10db, builder)
+
+        self.assertEqual("CAN_RETRY", actual["status"])
+
+    def test_derived_selection_error_none_when_references_ok(self):
+        self._insert_combinator_scenario(exclude_status="OK")
+        builder = logic_builder.get_builder(self.wp10db, b"combo")
+
+        actual = logic_builder.derived_selection_error(self.wp10db, builder)
+
+        self.assertIsNone(actual)
 
     def test_update_builder_doesnt_exist(self):
         actual = logic_builder.update_builder(self.wp10db, self.builder)

--- a/wp1/selection/meta_builder.py
+++ b/wp1/selection/meta_builder.py
@@ -35,28 +35,25 @@ class MetaBuilder(AbstractBuilder):
 
         status = logic_util.as_text(selection.s_status)
         if status == "FAILED":
+            failure_info = logic_builder.REFERENCE_FAILURE_INFO["FAILED"]
             raise Wp1FatalMetaSelectionError(
-                f"Referenced builder {label} latest selection failed",
-                code="REFERENCED_SELECTION_FAILED",
-                reason="latest selection failed",
-                action="Open this list, fix the failed selection, then update this Combinator.",
+                f"Referenced builder {label} {failure_info['reason']}",
+                **failure_info,
             )
 
         if status != "OK":
-            if status == "CAN_RETRY":
-                code = "REFERENCED_SELECTION_RETRYABLE_FAILURE"
-                reason = "latest selection failed but can be retried"
-                action = "Open this list and retry it, then retry this Combinator."
-            else:
-                code = "REFERENCED_SELECTION_NOT_READY"
-                reason = "latest selection is not ready yet"
-                action = "Wait for this list to finish processing, then retry this Combinator."
+            failure_info = logic_builder.REFERENCE_FAILURE_INFO.get(
+                status,
+                {
+                    "code": "REFERENCED_SELECTION_NOT_READY",
+                    "reason": "latest selection is not ready yet",
+                    "action": "Wait for this list to finish processing, then retry this Combinator.",
+                },
+            )
 
             raise Wp1RetryableMetaSelectionError(
-                f"Referenced builder {label} {reason}",
-                code=code,
-                reason=reason,
-                action=action,
+                f"Referenced builder {label} {failure_info['reason']}",
+                **failure_info,
             )
 
         # OK selections can have no stored data when materialization produced empty

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -131,6 +131,12 @@ def get_builder(builder_id):
         flask.abort(401, "Unauthorized")
 
     selection_errors = logic_builder.latest_selections_with_errors(wp10db, builder_id)
+    if not selection_errors:
+        # A Combinator whose own selection is stale-OK while a referenced
+        # selection has failed still needs to report as errored.
+        derived_error = logic_builder.derived_selection_error(wp10db, builder)
+        if derived_error is not None:
+            selection_errors = [derived_error]
     res = builder.to_web_dict()
     res.update(selection_errors=selection_errors)
     return flask.jsonify(res)

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -246,6 +246,50 @@ class BuildersTest(BaseWebTestcase):
 
             self.assertEqual("401 UNAUTHORIZED", rv.status)
 
+    def test_get_builder_derives_failed_reference_errors(self):
+        self.app = create_app()
+        with self.app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess["user"] = self.USER
+            self._insert_builder_record("ref-ok", "Ref OK")
+            self._insert_builder_record("ref-bad", "Ref Bad")
+            self._insert_builder_record(
+                "combo",
+                "My Combinator",
+                model="wp1.selection.models.combinator",
+                params={
+                    "include": {"builders": ["ref-ok"], "operation": "union"},
+                    "exclude": {"builders": ["ref-bad"], "operation": "union"},
+                },
+            )
+            with self.wp10db.cursor() as cursor:
+                cursor.execute("""UPDATE builders SET b_current_version = 1
+               WHERE b_id IN ('ref-ok', 'ref-bad', 'combo')""")
+                cursor.executemany(
+                    """INSERT INTO selections
+                 (s_id, s_builder_id, s_content_type, s_updated_at, s_version,
+                  s_status)
+               VALUES (%s, %s, 'text/tab-separated-values', '20201225105544',
+                       1, %s)""",
+                    [
+                        ("s-ok", "ref-ok", "OK"),
+                        ("s-bad", "ref-bad", "FAILED"),
+                        ("s-combo", "combo", "OK"),
+                    ],
+                )
+            self.wp10db.commit()
+
+            rv = client.get("/v1/builders/combo")
+
+            self.assertEqual("200 OK", rv.status)
+            selection_errors = rv.get_json()["selection_errors"]
+            self.assertEqual(1, len(selection_errors))
+            self.assertEqual("FAILED", selection_errors[0]["status"])
+            self.assertEqual("tsv", selection_errors[0]["ext"])
+            referenced = selection_errors[0]["referenced_builder_errors"]
+            self.assertEqual(["ref-bad"], [e["builder_id"] for e in referenced])
+            self.assertEqual("REFERENCED_SELECTION_FAILED", referenced[0]["code"])
+
     def test_create_unsuccessful(self):
         self.app = create_app()
         with self.app.test_client() as client:

--- a/wp1/web/selection_test.py
+++ b/wp1/web/selection_test.py
@@ -32,6 +32,7 @@ class SelectionTest(BaseWebTestcase):
                 "z_status": "NOT_REQUESTED",
                 "z_is_deleted": None,
                 "active_schedule": None,
+                "has_failed_references": False,
             }
         ],
     }
@@ -56,6 +57,7 @@ class SelectionTest(BaseWebTestcase):
                 "z_status": "NOT_REQUESTED",
                 "z_is_deleted": None,
                 "active_schedule": None,
+                "has_failed_references": False,
             },
             {
                 "id": "1a-2b-3c-4d",
@@ -75,6 +77,7 @@ class SelectionTest(BaseWebTestcase):
                 "z_status": "NOT_REQUESTED",
                 "z_is_deleted": None,
                 "active_schedule": None,
+                "has_failed_references": False,
             },
         ]
     }
@@ -99,6 +102,7 @@ class SelectionTest(BaseWebTestcase):
                 "z_status": None,
                 "z_is_deleted": None,
                 "active_schedule": None,
+                "has_failed_references": False,
             }
         ]
     }


### PR DESCRIPTION
Fixes #1257

A combinator's errored state was only a cached materialization result, so a combinator whose stored selection stayed OK while a referenced selection failed (missed rebuild, restored data) reported OK indefinitely.

Derive referenced-selection health at read time, symmetric for include and exclude:

- `/selection/lists` rows gain `has_failed_references` (computed in-memory from the same query).
- `GET /builders/<id>` synthesizes a `selection_errors` entry when the combinator is stale-OK but references are broken, reusing the existing `referenced_builder_errors` rendering.
- `selectionHasError()` folds the flag into the Failed chip, attention filter, `tsvReady` and `canRequestZim`.
- Shared failure wording between `MetaBuilder` and the read-time derivation; `openapi.yml` updated.

All backend tests (860), type checks and Cypress specs pass; verified live in the dev stack with the exact issue expression.

_Written with Claude._