### PR TITLE
Adopt existing Zimfarm recipe on 409 during creation

### DIFF
--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -482,6 +482,23 @@ def create_or_update_zimfarm_schedule(
             zim_schedule_id_to_set = zim_schedule.s_id.decode("utf-8")
         else:
             r = requests.post("%s/recipes" % base_url, headers=headers, json=params)
+            if r.status_code == 409:
+                # The recipe already exists on the Zimfarm even though there is
+                # no matching local schedule row (e.g. it was orphaned by an
+                # earlier failure between recipe creation and the local
+                # insert). Adopt it: overwrite its config with the current
+                # params and record it locally below, making this operation
+                # idempotent instead of permanently stuck on 409.
+                schedule_name = get_zimfarm_schedule_name(builder_id)
+                logger.info(
+                    "Recipe %s already exists on the Zimfarm, adopting it",
+                    schedule_name,
+                )
+                r = requests.patch(
+                    "%s/recipes/%s" % (base_url, schedule_name),
+                    headers=headers,
+                    json=params,
+                )
             r.raise_for_status()
             zim_schedule_id = str(uuid.uuid4())
             zim_schedule = ZimSchedule(

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -823,6 +823,89 @@ class ZimFarmTest(BaseWpOneDbTest):
     @patch("wp1.zimfarm.requests")
     @patch("wp1.zimfarm.token_provider")
     @patch("wp1.zimfarm._get_params")
+    def test_create_or_update_zimfarm_schedule_adopts_orphaned_recipe(
+        self, get_params_mock, mock_token_provider, mock_requests
+    ):
+        """A 409 on recipe creation adopts the existing recipe via PATCH."""
+        redis = MagicMock()
+        get_params_mock.return_value = {"name": "bar"}
+        mock_token_provider.get_access_token.return_value = "abcdef"
+        post_response = MagicMock()
+        post_response.status_code = 409
+        mock_requests.post.return_value = post_response
+        mock_requests.patch.return_value = MagicMock()
+
+        zimfarm.create_or_update_zimfarm_schedule(
+            redis,
+            self.wp10db,
+            self.builder,
+            "Test Title",
+            "Test Description",
+            None,
+            None,
+        )
+
+        expected_headers = {
+            "Authorization": "Bearer abcdef",
+            "User-Agent": "WP 1.0 bot 1.0.0/Audiodude <audiodude@gmail.com>",
+        }
+        mock_requests.post.assert_called_once_with(
+            "https://fake.farm/v2/recipes",
+            headers=expected_headers,
+            json={"name": "bar"},
+        )
+        mock_requests.patch.assert_called_once_with(
+            "https://fake.farm/v2/recipes/wp1_selection_3c4d",
+            headers=expected_headers,
+            json={"name": "bar"},
+        )
+        # The adopted recipe gets a local schedule row.
+        with self.wp10db.cursor() as cursor:
+            cursor.execute(
+                "SELECT * FROM zim_schedules WHERE s_title = %s", (b"Test Title",)
+            )
+            result = cursor.fetchone()
+            self.assertIsNotNone(result)
+            self.assertEqual(self.builder.b_id, result["s_builder_id"])
+
+    @patch("wp1.zimfarm.requests")
+    @patch("wp1.zimfarm.token_provider")
+    @patch("wp1.zimfarm._get_params")
+    def test_create_or_update_zimfarm_schedule_adopt_patch_fails(
+        self, get_params_mock, mock_token_provider, mock_requests
+    ):
+        """If the adopting PATCH fails, the error propagates and no row is inserted."""
+        redis = MagicMock()
+        get_params_mock.return_value = {"name": "bar"}
+        mock_token_provider.get_access_token.return_value = "abcdef"
+        mock_requests.exceptions.HTTPError = requests.exceptions.HTTPError
+        post_response = MagicMock()
+        post_response.status_code = 409
+        mock_requests.post.return_value = post_response
+        patch_response = MagicMock()
+        patch_response.raise_for_status.side_effect = requests.exceptions.HTTPError
+        mock_requests.patch.return_value = patch_response
+
+        with self.assertRaises(ZimFarmError):
+            zimfarm.create_or_update_zimfarm_schedule(
+                redis,
+                self.wp10db,
+                self.builder,
+                "Test Title",
+                "Test Description",
+                None,
+                None,
+            )
+
+        with self.wp10db.cursor() as cursor:
+            cursor.execute(
+                "SELECT * FROM zim_schedules WHERE s_title = %s", (b"Test Title",)
+            )
+            self.assertIsNone(cursor.fetchone())
+
+    @patch("wp1.zimfarm.requests")
+    @patch("wp1.zimfarm.token_provider")
+    @patch("wp1.zimfarm._get_params")
     def test_create_or_update_zimfarm_schedule_http_error(
         self, get_params_mock, mock_token_provider, mock_requests
     ):


### PR DESCRIPTION
Fixes #1234.

If anything failed between `POST /v2/recipes` and the local `zim_schedules` insert, the recipe was orphaned on the Zimfarm and every retry took the create path and 409'd forever.

Now a 409 on the create path adopts the existing recipe: PATCH it with the current params and insert the local row, making the operation idempotent. A failing PATCH still raises `ZimFarmError`, with no local row inserted.

Note: for a builder with an active recurring schedule, a one-off request now succeeds (PATCHes the shared recipe, adds a separate schedule row) instead of 409ing. The recurring row's `s_remaining_generations` is untouched, but future scheduled generations pick up the one-off's metadata, since there is one recipe per builder.

Written with Claude.