### PR TITLE
Allow TSV export of article lists

### DIFF
--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -36,7 +36,9 @@ to, with links to more documentation.
 
 A listing of every WikiProject tracked in the WP 1.0 index. Type in the project
 name, which will be auto-completed, and select from the drop-down list in order
-to select a project
+to select a project. When viewing a project's article list (optionally filtered
+by quality or importance), a "Download all results as TSV" link is available
+that exports the entire filtered list as a tab-separated-values file.
 
 ## Selections
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -174,7 +174,7 @@ paths:
   /projects/{projectId}/articles:
     get:
       summary: 'List of articles for a project, optionally filtered by quality/importance'
-      description: 'If the projectB parameter is provided, this endpoint instead compares two projects, and each entry of the returned articles array is a two element array of the matching article in project A and project B.'
+      description: 'If the projectB parameter is provided, this endpoint instead compares two projects, and each entry of the returned articles array is a two element array of the matching article in project A and project B. If format=tsv is given, the full filtered article list (ignoring page and numRows) is returned as a tab-separated-values download instead of JSON; this is not supported together with projectB.'
       operationId: projectArticles
       tags:
         - Projects
@@ -223,8 +223,12 @@ paths:
                           maxItems: 2
                           items:
                             $ref: '#/components/schemas/Article'
+            text/tab-separated-values:
+              schema:
+                type: string
+                description: 'Returned when format=tsv: a TSV document with a header row, containing every article matching the filters (page and numRows are ignored).'
         '400':
-          description: 'The page or numRows parameter was either not a number, or less than 1'
+          description: 'The page or numRows parameter was either not a number or less than 1, the format parameter was not one of "json" or "tsv", or format=tsv was combined with projectB'
         '404':
           description: 'No project with that projectId (or projectB) was found'
     parameters:
@@ -264,6 +268,14 @@ paths:
         description: 'A string to match the article name against. If the article title is LIKE "%articlePattern%", the article is returned.'
         schema:
           type: string
+      - name: format
+        in: query
+        required: false
+        description: 'The response format, either "json" (the default) or "tsv". With "tsv", the full filtered article list is returned as a tab-separated-values download and the page and numRows parameters are ignored. Not supported together with projectB.'
+        schema:
+          type: string
+          enum: [json, tsv]
+          default: json
       - name: projectB
         in: query
         required: false

--- a/wp1-frontend/cypress/e2e/article.cy.js
+++ b/wp1-frontend/cypress/e2e/article.cy.js
@@ -30,6 +30,25 @@ describe('the article page', () => {
       });
   });
 
+  it('links to a TSV download of the full filtered list', () => {
+    cy.visit('/#/project/Alien/articles');
+    cy.intercept('v1/projects/Alien/articles?quality=B-Class', {
+      fixture: 'articles_alien_top_b.json',
+    }).as('BArticles');
+
+    cy.contains('Select Quality/Importance').click();
+    cy.get('.custom-select').eq(0).select('B');
+    cy.get('#updateRating').click();
+    cy.wait('@BArticles');
+
+    cy.contains('a', 'Download all results as TSV')
+      .should('have.attr', 'href')
+      .and(
+        'match',
+        /\/v1\/projects\/Alien\/articles\?quality=B-Class&format=tsv$/
+      );
+  });
+
   it('displays article on wikipedia', () => {
     // Serve a minimal stand-in for the Wikipedia article page, echoing the
     // requested title, so the test doesn't depend on wikipedia.org.

--- a/wp1-frontend/src/components/ArticleTable.vue
+++ b/wp1-frontend/src/components/ArticleTable.vue
@@ -35,6 +35,11 @@
           page<span v-if="articleData.pagination.total_pages !== 1">s</span>)
         </p>
       </div>
+      <div v-if="tableData.length > 0 && !projectIdB" class="my-0 row">
+        <p class="pages-cont">
+          <a :href="tsvUrl" download>Download all results as TSV</a>
+        </p>
+      </div>
       <ArticleTablePagination
         v-if="articleData && articleData.pagination.total_pages > 1"
         class="row justify-content-between my-0"
@@ -179,6 +184,11 @@ export default {
       }
       return this.articleData['articles'];
     },
+    tsvUrl: function () {
+      const url = this.articlesUrl(false);
+      url.searchParams.append('format', 'tsv');
+      return url.toString();
+    },
   },
   created: function () {
     this.updateTable();
@@ -229,23 +239,7 @@ export default {
     onUpdatePage: function (page) {
       this.$emit('update-page', page);
     },
-    classLabel: function (qualOrImp) {
-      if (!this.categoryLinks[qualOrImp]) {
-        return '';
-      }
-      return (
-        this.categoryLinks[qualOrImp].text || this.categoryLinks[qualOrImp]
-      );
-    },
-    getCategoryLinks: async function () {
-      const response = await fetch(
-        `${import.meta.env.VITE_API_URL}/projects/${
-          this.projectId
-        }/category_links`
-      );
-      this.categoryLinks = await response.json();
-    },
-    updateTable: async function () {
+    articlesUrl: function (includePagination) {
       const url = new URL(
         `${import.meta.env.VITE_API_URL}/projects/${this.projectId}/articles`
       );
@@ -265,18 +259,40 @@ export default {
       if (this.qualityB) {
         params.qualityB = this.qualityB;
       }
-      if (this.page) {
-        params.page = this.page;
-      }
-      if (this.numRows) {
-        params.numRows = this.numRows;
-      }
       if (this.articlePattern) {
         params.articlePattern = this.articlePattern;
+      }
+      if (includePagination) {
+        if (this.page) {
+          params.page = this.page;
+        }
+        if (this.numRows) {
+          params.numRows = this.numRows;
+        }
       }
       Object.keys(params).forEach((key) =>
         url.searchParams.append(key, params[key])
       );
+      return url;
+    },
+    classLabel: function (qualOrImp) {
+      if (!this.categoryLinks[qualOrImp]) {
+        return '';
+      }
+      return (
+        this.categoryLinks[qualOrImp].text || this.categoryLinks[qualOrImp]
+      );
+    },
+    getCategoryLinks: async function () {
+      const response = await fetch(
+        `${import.meta.env.VITE_API_URL}/projects/${
+          this.projectId
+        }/category_links`
+      );
+      this.categoryLinks = await response.json();
+    },
+    updateTable: async function () {
+      const url = this.articlesUrl(true);
 
       let finishedRequest = false;
       setTimeout(() => {

--- a/wp1/constants.py
+++ b/wp1/constants.py
@@ -33,6 +33,9 @@ MAX_LOGS_PER_DAY = 100000
 
 WIKI_BASE = "https://en.wikipedia.org/wiki/"
 FRONTEND_WIKI_BASE = "https://en.wikipedia.org/w/"
+# The database name of the wiki that the ratings tables track. The rating
+# system is en.wikipedia.org-only (see WIKI_BASE above).
+WIKI_DBNAME = "enwiki"
 
 PAGE_SIZE = 100
 

--- a/wp1/logic/rating.py
+++ b/wp1/logic/rating.py
@@ -198,11 +198,49 @@ def _project_rating_query(
     if page is not None:
         page = int(page) - 1
         query += " LIMIT %s,%s" % (page * limit, limit)
-    else:
+    elif limit is not None:
         query += " LIMIT %s" % limit
 
     logger.debug(query)
     return query
+
+
+def _project_rating_params(
+    project_name,
+    quality=None,
+    importance=None,
+    project_b_name=None,
+    quality_b=None,
+    importance_b=None,
+    pattern=None,
+):
+    params = {
+        "r_project": project_name,
+        "r_quality": quality,
+        "r_importance": importance,
+    }
+
+    if pattern is not None:
+        params["article_pattern_compiled"] = "%" + pattern + "%"
+    if project_b_name is not None:
+        params["r_project_b"] = project_b_name
+    if quality_b is not None:
+        params["r_quality_b"] = quality_b
+    if importance_b is not None:
+        params["r_importance_b"] = importance_b
+
+    return params
+
+
+def _rating_pair_from_row(res):
+    rating_b = Rating(
+        r_project=res.pop("rating_b.r_project"),
+        r_article=res.pop("rating_b.r_article"),
+        r_namespace=res.pop("rating_b.r_namespace"),
+        r_quality=res.pop("rating_b.r_quality"),
+        r_importance=res.pop("rating_b.r_importance"),
+    )
+    return (Rating(**res), rating_b)
 
 
 def get_project_rating_count_by_type(
@@ -226,21 +264,15 @@ def get_project_rating_count_by_type(
         count=True,
     )
 
-    params = {
-        "r_project": project_name,
-        "r_quality": quality,
-        "r_importance": importance,
-    }
-
-    if pattern is not None:
-        params["article_pattern_compiled"] = "%" + pattern + "%"
-    if project_b_name is not None:
-        params["r_project_b"] = project_b_name
-    if quality_b is not None:
-        params["r_quality_b"] = quality_b
-    if importance_b is not None:
-        params["r_importance_b"] = importance_b
-
+    params = _project_rating_params(
+        project_name,
+        quality=quality,
+        importance=importance,
+        project_b_name=project_b_name,
+        quality_b=quality_b,
+        importance_b=importance_b,
+        pattern=pattern,
+    )
     with wp10db.cursor() as cursor:
         cursor.execute(query, params)
         res = cursor.fetchone()
@@ -279,38 +311,60 @@ def get_project_rating_by_type(
         page=page,
         limit=limit,
     )
-    params = {
-        "r_project": project_name,
-        "r_quality": quality,
-        "r_importance": importance,
-    }
-
-    if pattern is not None:
-        params["article_pattern_compiled"] = "%" + pattern + "%"
-    if project_b_name is not None:
-        params["r_project_b"] = project_b_name
-    if quality_b is not None:
-        params["r_quality_b"] = quality_b
-    if importance_b is not None:
-        params["r_importance_b"] = importance_b
+    params = _project_rating_params(
+        project_name,
+        quality=quality,
+        importance=importance,
+        project_b_name=project_b_name,
+        quality_b=quality_b,
+        importance_b=importance_b,
+        pattern=pattern,
+    )
 
     with wp10db.cursor() as cursor:
         cursor.execute(query, params)
         if project_b_name is None:
             return [Rating(**db_rating) for db_rating in cursor.fetchall()]
 
-        results = []
-        for res in cursor.fetchall():
-            rating_b = Rating(
-                r_project=res.pop("rating_b.r_project"),
-                r_article=res.pop("rating_b.r_article"),
-                r_namespace=res.pop("rating_b.r_namespace"),
-                r_quality=res.pop("rating_b.r_quality"),
-                r_importance=res.pop("rating_b.r_importance"),
-            )
-            rating_a = Rating(**res)
-            results.append((rating_a, rating_b))
-        return results
+        return [_rating_pair_from_row(res) for res in cursor.fetchall()]
+
+
+def iterate_project_rating_by_type(
+    wp10db,
+    project_name,
+    quality=None,
+    importance=None,
+    pattern=None,
+    batch_size=500,
+):
+    """Yields every Rating matching the filters, without pagination.
+
+    Rows are fetched from the server-side cursor in batches of batch_size,
+    so arbitrarily large result sets can be streamed without buffering them
+    in memory.
+    """
+    query = _project_rating_query(
+        project_name,
+        quality=quality,
+        importance=importance,
+        pattern=pattern,
+        limit=None,
+    )
+    params = _project_rating_params(
+        project_name,
+        quality=quality,
+        importance=importance,
+        pattern=pattern,
+    )
+
+    with wp10db.cursor() as cursor:
+        cursor.execute(query, params)
+        while True:
+            rows = cursor.fetchmany(batch_size)
+            if not rows:
+                return
+            for res in rows:
+                yield Rating(**res)
 
 
 def get_random_article(

--- a/wp1/logic/rating_test.py
+++ b/wp1/logic/rating_test.py
@@ -419,6 +419,49 @@ class GetProjectRatingByTypeTest(BaseWpOneDbTest):
             self.assertEqual(b"Project 0", r[0].r_project)
             self.assertEqual(b"Project 1", r[1].r_project)
 
+    def test_iterate_returns_all_rows(self):
+        self._add_ratings()
+        ratings = list(
+            logic_rating.iterate_project_rating_by_type(self.wp10db, b"Project 0")
+        )
+
+        # All 150 ratings are returned, not just the first page of 100.
+        self.assertEqual(150, len(ratings))
+        for rating in ratings:
+            self.assertEqual(b"Project 0", rating.r_project)
+
+    def test_iterate_batches_smaller_than_total(self):
+        self._add_ratings()
+        ratings = list(
+            logic_rating.iterate_project_rating_by_type(
+                self.wp10db, b"Project 0", batch_size=7
+            )
+        )
+
+        self.assertEqual(150, len(ratings))
+
+    def test_iterate_quality(self):
+        self._add_ratings()
+        ratings = list(
+            logic_rating.iterate_project_rating_by_type(
+                self.wp10db, b"Project 0", quality=b"FA-Class"
+            )
+        )
+
+        self.assertEqual(50, len(ratings))
+        for rating in ratings:
+            self.assertEqual(b"FA-Class", rating.r_quality)
+
+    def test_iterate_pattern(self):
+        self._add_ratings()
+        ratings = list(
+            logic_rating.iterate_project_rating_by_type(
+                self.wp10db, b"Project 0", pattern="xyz"
+            )
+        )
+
+        self.assertEqual(0, len(ratings))
+
 
 class GetRandomArticleTest(BaseWpOneDbTest):
 

--- a/wp1/web/projects.py
+++ b/wp1/web/projects.py
@@ -5,8 +5,9 @@ import flask
 
 import wp1.logic.project as logic_project
 import wp1.logic.rating as logic_rating
+import wp1.logic.util as logic_util
 from wp1 import queues, tables
-from wp1.constants import PAGE_SIZE
+from wp1.constants import PAGE_SIZE, WIKI_DBNAME
 from wp1.web import authenticate
 from wp1.web.db import get_db
 from wp1.web.redis import get_redis
@@ -92,6 +93,68 @@ def category_links_sorted(project_name):
     return flask.jsonify(data)
 
 
+def _articles_tsv_response(wp10db, project_name, ratings):
+    def generate():
+        yield (
+            "article\tarticle_link\timportance\timportance_updated"
+            "\tquality\tquality_updated\n"
+        )
+        for rating in ratings:
+            row = rating.to_web_dict(wp10db)
+            yield "%s\t%s\t%s\t%s\t%s\t%s\n" % (
+                row["article"],
+                row["article_link"],
+                row["importance"],
+                row["importance_updated"] or "",
+                row["quality"],
+                row["quality_updated"] or "",
+            )
+
+    response = flask.Response(
+        flask.stream_with_context(generate()),
+        content_type="text/tab-separated-values; charset=utf-8",
+    )
+    response.headers["Content-Disposition"] = (
+        'attachment; filename="%s_articles.%s.tsv"'
+        % (logic_util.safe_name(project_name), WIKI_DBNAME)
+    )
+    return response
+
+
+def _positive_int_param(name, default):
+    """Returns the named query arg as an int, aborting 400 if it is invalid."""
+    value = flask.request.args.get(name)
+    if value is None:
+        return default
+    try:
+        value = int(value)
+    except ValueError:
+        flask.abort(400)
+    if value < 1:
+        flask.abort(400)
+    return value
+
+
+def _project_b_args(wp10db):
+    """Parses the projectB comparison args, aborting 404 for an unknown projectB.
+
+    Returns (project_b_name, project_b_name_bytes, quality_b, importance_b),
+    all None when no projectB was given.
+    """
+    project_b_name = flask.request.args.get("projectB")
+    if project_b_name is None:
+        return None, None, None, None
+    project_b_name_bytes = project_b_name.encode("utf-8")
+    if logic_project.get_project_by_name(wp10db, project_b_name_bytes) is None:
+        flask.abort(404)
+    return (
+        project_b_name,
+        project_b_name_bytes,
+        flask.request.args.get("qualityB"),
+        flask.request.args.get("importanceB"),
+    )
+
+
 @projects.route("/<project_name>/articles")
 def articles(project_name):
     wp10db = get_db("wp10db")
@@ -100,42 +163,15 @@ def articles(project_name):
     if project is None:
         return flask.abort(404)
 
-    project_b_name_bytes = None
-    quality_b = None
-    importance_b = None
-    project_b_name = flask.request.args.get("projectB")
-    if project_b_name is not None:
-        project_b_name_bytes = project_b_name.encode("utf-8")
-        project_b = logic_project.get_project_by_name(wp10db, project_b_name_bytes)
-        if project_b is None:
-            return flask.abort(404)
-
-        quality_b = flask.request.args.get("qualityB")
-        importance_b = flask.request.args.get("importanceB")
+    project_b_name, project_b_name_bytes, quality_b, importance_b = _project_b_args(
+        wp10db
+    )
 
     quality = flask.request.args.get("quality")
     importance = flask.request.args.get("importance")
     page = flask.request.args.get("page")
-    page_int = 1
-    limit = flask.request.args.get("numRows")
-    limit_int = 100
-    if page is not None:
-        try:
-            page_int = int(page)
-        except ValueError:
-            return flask.abort(400)
-        if page_int < 1:
-            return flask.abort(400)
-
-    if limit is not None:
-        try:
-            limit_int = int(limit)
-        except ValueError:
-            return flask.abort(400)
-        if limit_int < 1:
-            return flask.abort(400)
-        if limit_int > 500:
-            limit_int = 500
+    page_int = _positive_int_param("page", 1)
+    limit_int = min(_positive_int_param("numRows", 100), 500)
 
     if quality:
         quality = quality.encode("utf-8")
@@ -143,6 +179,23 @@ def articles(project_name):
         importance = importance.encode("utf-8")
 
     article_pattern = flask.request.args.get("articlePattern")
+
+    response_format = flask.request.args.get("format", "json")
+    if response_format not in ("json", "tsv"):
+        return flask.abort(400)
+
+    if response_format == "tsv":
+        # TSV export is not supported for projectB comparisons.
+        if project_b_name is not None:
+            return flask.abort(400)
+        ratings = logic_rating.iterate_project_rating_by_type(
+            wp10db,
+            project_name_bytes,
+            quality=quality,
+            importance=importance,
+            pattern=article_pattern,
+        )
+        return _articles_tsv_response(wp10db, project_name, ratings)
 
     total = logic_rating.get_project_rating_count_by_type(
         wp10db,

--- a/wp1/web/projects_test.py
+++ b/wp1/web/projects_test.py
@@ -364,6 +364,58 @@ class ProjectTest(BaseWebTestcase):
             )
             self.assertEqual("200 OK", rv.status)
 
+    def test_articles_tsv(self):
+        with self.override_db(self.app), self.app.test_client() as client:
+            rv = client.get("/v1/projects/Project 0/articles?format=tsv")
+            self.assertEqual("200 OK", rv.status)
+            self.assertTrue(rv.content_type.startswith("text/tab-separated-values"))
+            self.assertEqual(
+                'attachment; filename="Project0_articles.enwiki.tsv"',
+                rv.headers["Content-Disposition"],
+            )
+
+            lines = rv.data.decode("utf-8").splitlines()
+            self.assertEqual(
+                "article\tarticle_link\timportance\timportance_updated"
+                "\tquality\tquality_updated",
+                lines[0],
+            )
+            # All 150 articles are returned, not just the first page of 100.
+            self.assertEqual(151, len(lines))
+            for line in lines[1:]:
+                self.assertEqual(6, len(line.split("\t")))
+
+    def test_articles_tsv_quality_filter(self):
+        with self.override_db(self.app), self.app.test_client() as client:
+            rv = client.get(
+                "/v1/projects/Project 0/articles?format=tsv&quality=FA-Class"
+            )
+            self.assertEqual("200 OK", rv.status)
+
+            lines = rv.data.decode("utf-8").splitlines()
+            self.assertEqual(51, len(lines))
+            for line in lines[1:]:
+                self.assertEqual("FA-Class", line.split("\t")[4])
+
+    def test_articles_tsv_400_project_b(self):
+        with self.override_db(self.app), self.app.test_client() as client:
+            rv = client.get(
+                "/v1/projects/Project 0/articles?format=tsv&projectB=Project 1"
+            )
+            self.assertEqual("400 BAD REQUEST", rv.status)
+
+    def test_articles_tsv_format_json(self):
+        with self.override_db(self.app), self.app.test_client() as client:
+            rv = client.get("/v1/projects/Project 0/articles?format=json")
+            self.assertEqual("200 OK", rv.status)
+            data = json.loads(rv.data)
+            self.assertEqual(100, len(data["articles"]))
+
+    def test_articles_400_invalid_format(self):
+        with self.override_db(self.app), self.app.test_client() as client:
+            rv = client.get("/v1/projects/Project 0/articles?format=csv")
+            self.assertEqual("400 BAD REQUEST", rv.status)
+
     def test_random_article(self):
         with self.override_db(self.app), self.app.test_client() as client:
             rv = client.get("/v1/projects/Project 0/articles/random")


### PR DESCRIPTION
Fixes #1177

Adds a `format=tsv` query parameter to `/v1/projects/<name>/articles` that streams the **entire** filtered article list (ignoring `page`/`numRows`) as a tab-separated-values download.

## Backend

- New `logic_rating.iterate_project_rating_by_type()`: same filters as `get_project_rating_by_type` but no LIMIT, draining the server-side cursor (`SSDictCursor`) in 500-row batches so arbitrarily large lists stream without buffering in memory.
- The response is generated with `stream_with_context` so the DB connection stays open for the duration of the download, and is served as an attachment (`<project>_articles.enwiki.tsv`, following the #1267 naming convention of including the wiki dbname) with columns `article, article_link, importance, importance_updated, quality, quality_updated`.
- `format=tsv` combined with `projectB` comparisons is not supported and returns 400, as does any unknown `format` value.
- Deduplicated the query-params dict and projectB pair-row conversion in `logic/rating.py` into shared helpers.

## Frontend

- The article table shows a "Download all results as TSV" link carrying the active quality/importance/pattern filters. It is hidden on the compare-projects view.

## Docs/tests

- `openapi.yml` documents the new parameter, TSV response and 400 cases; short mention in the user docs.
- Unit tests for the iterator and the endpoint (all formats, filters, 400s); Cypress test asserting the link href.

Verified against the dev stack: unfiltered export of a project returned 924 rows (past the 500-row page cap), gzip path byte-identical, `Content-Disposition` filename correct.

🤖 Written with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5)
