### PR TITLE
Add production deploy/rollback scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,8 @@ id_rsa
 # Local git worktrees
 .worktrees/
 
+# Written by scripts/deploy-remote.sh on the production box
+.last-deploy
+
 # Flask session
 flask_session/

--- a/README.md
+++ b/README.md
@@ -438,26 +438,75 @@ The `serve` command should print out the port to view the docs at, likely localh
 
 # Updating production
 
-- Push to the release branch of the github repository:
-  - `git checkout main`
-  - `git pull origin main`
-  - `git checkout release`
-  - `git merge main`
-  - `git push origin release`
-- Wait for the release images [to be built](https://github.com/openzim/wp1/actions/workflows/publish.yml)
-- Log in to the box that contains the production docker images. It is
-  called mwcurator.
-- `cd /data/code/wp1/`
-- `sudo git pull origin main`
-- Pull the docker images from docker hub:
-  - `sudo docker pull ghcr.io/openzim/wp1-workers:release`
-  - `sudo docker pull ghcr.io/openzim/wp1-web:release`
-  - `sudo docker pull ghcr.io/openzim/wp1-frontend:release`
-- If you've made changes to the format or contents of `credentials.py`, update `/data/wp1bot/credentials.py`.
-- Run docker-compose to bring the production images online.
-  - `sudo docker compose up -d`
-- Run the production database migrations in the worker container:
-  - `sudo docker exec -ti -e PYTHONPATH=. wp1bot-workers yoyo -c /usr/src/app/db/production/yoyo.ini apply`
+Deploys are done with `scripts/deploy.sh`, run from a local checkout:
+
+```bash
+./scripts/deploy.sh
+```
+
+This deploys the current `origin/main`. It requires push access to this
+repository and ssh access (with sudo) to the production box,
+`mwcurator-b.mwoffliner.eqiad1.wikimedia.cloud` (override with the
+`WP1_DEPLOY_HOST` environment variable; see
+[SSH access](#ssh-access-to-the-production-box) below for one-time
+setup). The script:
+
+- Pushes `origin/main` to the `release` branch (a plain, non-forced
+  push: if `release` has diverged from `main` the push is rejected and
+  a human needs to sort it out). This triggers the
+  [publish workflow](https://github.com/openzim/wp1/actions/workflows/publish.yml),
+  which builds and pushes the `wp1-workers`, `wp1-web` and
+  `wp1-frontend` docker images.
+- Runs `scripts/deploy-remote.sh` on the production box (after a
+  `git pull` there, so the remote script is the version being
+  deployed), which:
+  - Warns and asks for confirmation if `wp1/credentials.py.example`
+    changed since the last deploy, since `/data/wp1bot/credentials.py`
+    is managed by hand and probably needs a matching update.
+  - Waits for all three images tagged `sha-<short sha>` for the exact
+    commit being deployed to appear on ghcr.io. Deploying by the
+    immutable sha tag (instead of pulling the moving `release` tag)
+    guarantees a consistent image set; the three build jobs finish at
+    different times, so `release` can briefly point at a mixed set.
+  - Pulls the three images, re-tags them locally as `release` (the tag
+    `docker-compose.yml` uses), and runs `docker compose up -d`. Only
+    those three images are ever pulled -- never `docker compose pull`,
+    which would also refresh infrastructure images like the pinned
+    redis (see [Redis persistence](#redis-persistence) below).
+  - Applies database migrations:
+    `yoyo -c /usr/src/app/db/production/yoyo.ini apply --batch` in the
+    workers container.
+  - Verifies that the containers are running and that
+    https://api.wp1.openzim.org and https://wp1.openzim.org respond.
+
+`scripts/deploy-remote.sh` can also be run by hand on the box
+(`cd /data/code/wp1 && sudo ./scripts/deploy-remote.sh <full git sha>`)
+if the local half already pushed `release` but the remote half failed
+or was interrupted; it is safe to re-run.
+
+## SSH access to the production box
+
+The production box is a [Wikimedia Cloud VPS](https://wikitech.wikimedia.org/wiki/Portal:Cloud_VPS)
+instance in the `mwoffliner` project. It is not reachable directly from
+the internet; ssh goes through the Cloud VPS bastion. One-time setup
+(see [Help:Accessing Cloud VPS instances](https://wikitech.wikimedia.org/wiki/Help:Accessing_Cloud_VPS_instances)
+for the full guide):
+
+1. [Create a Wikimedia developer account](https://idm.wikimedia.org/signup/)
+   and [upload your public SSH key](https://idm.wikimedia.org/keymanagement/).
+2. Ask an existing member to add you to the `mwoffliner` Cloud VPS project.
+3. Add the bastion jump host to your `~/.ssh/config` (use your _shell_
+   username from idm.wikimedia.org, which may differ from your account
+   username):
+
+   ```
+   Host *.wikimedia.cloud
+     User <your-shell-name>
+     ProxyJump bastion.wmcloud.org:22
+   ```
+
+Then `ssh mwcurator-b.mwoffliner.eqiad1.wikimedia.cloud` should log you
+in without a password, which is what `scripts/deploy.sh` needs.
 
 ## Redis persistence
 
@@ -485,19 +534,21 @@ its GitHub packages page:
 - https://github.com/openzim/wp1/pkgs/container/wp1-web/versions
 - https://github.com/openzim/wp1/pkgs/container/wp1-frontend/versions
 
-To roll back a bad deploy, log in to the production machine, then pull
-the previous version of each image and re-tag it locally as `release`
-(no registry login or push is required, the local tag is what
-docker compose uses):
+To roll back a bad deploy, run (from a local checkout):
 
-- `sudo docker pull ghcr.io/openzim/wp1-workers:release-41`
-- `sudo docker tag ghcr.io/openzim/wp1-workers:release-41 ghcr.io/openzim/wp1-workers:release`
-- Repeat for `wp1-web` and `wp1-frontend`, then recreate the containers:
-- `sudo docker compose up -d`
+```bash
+./scripts/deploy.sh --rollback release-141   # or e.g. sha-73ed612
+```
 
-Note that the next normal deploy (`docker pull ... :release`) rolls
-forward again. If the deploy being rolled back included database
-migrations, roll those back too:
+This runs `scripts/deploy-remote.sh --rollback <tag>` on the box, which
+pulls that version of each image, re-tags it locally as `release` (no
+registry login or push is required, the local tag is what docker
+compose uses), and recreates the containers. A successful deploy prints
+the sha tag of the version it replaced, which is the tag to pass here.
+
+Note that the next normal deploy rolls forward again. Rolling back
+database migrations is deliberately not automated; if the deploy being
+rolled back included migrations, roll those back by hand on the box:
 
 - `sudo docker exec -ti -e PYTHONPATH=. wp1bot-workers yoyo -c /usr/src/app/db/production/yoyo.ini rollback`
 

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# Runs ON the production box (mwcurator), as root, invoked by
+# scripts/deploy.sh. Can also be run by hand from /data/code/wp1.
+#
+# Usage:
+#   deploy-remote.sh <full-git-sha>       deploy the images built from that sha
+#   deploy-remote.sh --rollback <tag>     re-tag <tag> as release and restart
+#                                         (tag: release-<N> or sha-<XXXXXXX>)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+REGISTRY=ghcr.io/openzim
+IMAGES=(wp1-workers wp1-web wp1-frontend)
+CONTAINERS=(wp1bot-workers wp1bot-web wp1bot-frontend)
+LAST_DEPLOY_FILE=.last-deploy
+POLL_INTERVAL=30
+POLL_TIMEOUT=$((45 * 60))
+
+if [[ $EUID -ne 0 ]]; then
+  echo "error: must be run as root (docker access)" >&2
+  exit 1
+fi
+
+# Pull the given tag for the three wp1 images, re-tag it locally as
+# `release` (the tag docker-compose.yml uses), and recreate containers.
+#
+# Only ever pull these three images explicitly -- never `docker compose
+# pull`, which would also refresh infrastructure images like redis. A
+# surprise redis recreation from an unpinned image destroyed the queue
+# and log history once already (issue #1244).
+retag_and_up() {
+  local tag=$1 img
+  for img in "${IMAGES[@]}"; do
+    docker pull "$REGISTRY/$img:$tag"
+    docker tag "$REGISTRY/$img:$tag" "$REGISTRY/$img:release"
+  done
+  echo "==> Recreating containers"
+  docker compose up -d
+}
+
+verify() {
+  local c status ok=1
+  echo "==> Verifying containers"
+  sleep 10
+  for c in "${CONTAINERS[@]}"; do
+    status=$(docker inspect -f '{{.State.Status}}' "$c" 2>/dev/null || echo missing)
+    echo "    $c: $status"
+    [[ "$status" == "running" ]] || ok=0
+  done
+  echo "==> Verifying API (https://api.wp1.openzim.org)"
+  if curl -fsS --max-time 30 https://api.wp1.openzim.org/v1/projects/count \
+      | grep -q '"count"'; then
+    echo "    API OK"
+  else
+    echo "    API check FAILED"
+    ok=0
+  fi
+  echo "==> Verifying frontend (https://wp1.openzim.org)"
+  if curl -fsS --max-time 30 https://wp1.openzim.org/ | grep -qi '<html'; then
+    echo "    frontend OK"
+  else
+    echo "    frontend check FAILED"
+    ok=0
+  fi
+  [[ $ok -eq 1 ]]
+}
+
+if [[ "${1:-}" == "--rollback" ]]; then
+  tag=${2:?usage: deploy-remote.sh --rollback <release-N|sha-XXXXXXX>}
+  echo "==> Rolling back to $tag"
+  retag_and_up "$tag"
+  verify
+  # Deliberately does not touch $LAST_DEPLOY_FILE: the next deploy's
+  # credentials diff then spans the rolled-back range too, which is the
+  # safe direction.
+  cat <<'EOF'
+==> Rollback complete.
+    If the deploy being rolled back included database migrations, roll
+    them back by hand after checking what they were:
+      docker exec -e PYTHONPATH=. wp1bot-workers \
+        yoyo -c /usr/src/app/db/production/yoyo.ini rollback
+    The next normal deploy rolls the images forward again.
+EOF
+  exit 0
+fi
+
+sha=${1:?usage: deploy-remote.sh <full-git-sha>}
+short=$(git rev-parse --short=7 "$sha")
+prev=$(cat "$LAST_DEPLOY_FILE" 2>/dev/null || true)
+
+# credentials.py on this box (/data/wp1bot/credentials.py) is managed by
+# hand. If the template changed since the last deploy, the real file
+# probably needs a matching edit -- stop and ask.
+if [[ -n "$prev" ]] && git cat-file -e "$prev" 2>/dev/null; then
+  if [[ -n "$(git diff --name-only "$prev".."$sha" -- wp1/credentials.py.example 2>/dev/null)" ]]; then
+    cat <<EOF
+
+*** WARNING: the credentials template changed since the last deploy
+*** ($prev). Make sure /data/wp1bot/credentials.py has been
+*** updated to match before continuing.
+
+EOF
+    read -r -p "Continue with deploy? [y/N] " answer </dev/tty
+    [[ "$answer" == [yY]* ]] || { echo "Aborted."; exit 1; }
+  fi
+else
+  echo "note: no previous deploy recorded; skipping credentials-change check"
+fi
+
+# Wait for the publish workflow to push all three images for this exact
+# commit. Polling the immutable sha tag (rather than pulling the moving
+# `release` tag) guarantees a consistent image set: the three matrix
+# jobs finish at different times, and `release` can briefly point at a
+# mixed set while the workflow is mid-flight.
+echo "==> Waiting for images tagged sha-$short on $REGISTRY (timeout ${POLL_TIMEOUT}s)"
+deadline=$((SECONDS + POLL_TIMEOUT))
+for img in "${IMAGES[@]}"; do
+  until docker manifest inspect "$REGISTRY/$img:sha-$short" >/dev/null 2>&1; do
+    if ((SECONDS >= deadline)); then
+      echo "error: timed out waiting for $REGISTRY/$img:sha-$short" >&2
+      echo "check https://github.com/openzim/wp1/actions/workflows/publish.yml" >&2
+      exit 1
+    fi
+    sleep "$POLL_INTERVAL"
+  done
+  echo "    $img:sha-$short available"
+done
+
+retag_and_up "sha-$short"
+
+echo "==> Applying database migrations"
+docker exec -e PYTHONPATH=. wp1bot-workers \
+  yoyo -c /usr/src/app/db/production/yoyo.ini apply --batch
+
+verify
+
+echo "$sha" > "$LAST_DEPLOY_FILE"
+echo "==> Deployed $sha"
+if [[ -n "$prev" ]]; then
+  echo "    Roll back with: ./scripts/deploy.sh --rollback sha-$(git rev-parse --short=7 "$prev" 2>/dev/null || echo "$prev")"
+fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Deploy WP1 to production, or roll it back.
+#
+# Usage:
+#   ./scripts/deploy.sh                      deploy the current origin/main
+#   ./scripts/deploy.sh --rollback <tag>     roll back to a previous image tag
+#                                            (e.g. release-141 or sha-73ed612)
+#
+# A deploy pushes origin/main to the release branch, which triggers the
+# publish workflow (.github/workflows/publish.yml) to build the three
+# docker images. It then runs scripts/deploy-remote.sh on the production
+# box, which waits for the images tagged with the pushed commit's sha to
+# appear on ghcr.io, pulls them, restarts the containers and applies
+# database migrations.
+#
+# Requirements: push access to the GitHub repo, and ssh access (with
+# sudo) to the production box on Wikimedia Cloud VPS (override the host
+# with WP1_DEPLOY_HOST). See "Updating production" in the README for
+# the one-time Wikimedia developer account / bastion SSH setup.
+set -euo pipefail
+
+REMOTE_HOST=${WP1_DEPLOY_HOST:-mwcurator-b.mwoffliner.eqiad1.wikimedia.cloud}
+REMOTE_DIR=/data/code/wp1
+
+usage() {
+  sed -n '2,8p' "$0" | sed 's/^# \{0,1\}//'
+  exit 64
+}
+
+if [[ "${1:-}" == "--rollback" ]]; then
+  tag=${2:-}
+  [[ -n "$tag" ]] || usage
+  exec ssh -t "$REMOTE_HOST" \
+    "cd $REMOTE_DIR && sudo ./scripts/deploy-remote.sh --rollback '$tag'"
+fi
+
+[[ $# -eq 0 ]] || usage
+
+git fetch origin
+sha=$(git rev-parse origin/main)
+
+# Plain, non-forced push: if release has somehow diverged from main this
+# is rejected, and a human should sort it out locally. Never force this.
+echo "==> Pushing origin/main ($sha) to release"
+git push origin "$sha:refs/heads/release"
+
+# Pull on the box first, so the deploy-remote.sh that runs is the one
+# from the commit being deployed, not a stale copy.
+echo "==> Running remote deploy on $REMOTE_HOST"
+exec ssh -t "$REMOTE_HOST" \
+  "cd $REMOTE_DIR && sudo git pull --ff-only origin main && sudo ./scripts/deploy-remote.sh '$sha'"


### PR DESCRIPTION
Automates the manual "Updating production" runbook as `scripts/deploy.sh` (local) + `scripts/deploy-remote.sh` (runs on mwcurator).

- `./scripts/deploy.sh` pushes `origin/main` to `release` (plain push, rejected if release diverged), then runs the remote half, which waits for the `sha-<sha>` images on ghcr.io, pulls and re-tags them as `release`, recreates the containers, applies migrations (`yoyo apply --batch`) and verifies the API/frontend respond by content.
- Deploying by the immutable sha tag closes the race where the moving `release` tag can briefly point at a mixed image set while the 3-job publish matrix is mid-flight.
- Only the three wp1 images are ever pulled (never `docker compose pull`), preserving the pinned-redis protection from #1244.
- Warns and asks before deploying if `wp1/credentials.py.example` changed since the last deploy, since `/data/wp1bot/credentials.py` is managed by hand.
- `./scripts/deploy.sh --rollback <release-N|sha-XXXXXXX>` re-tags a previous image set via the same remote path; migration rollback stays manual.
- README: deploy/rollback sections rewritten around the scripts, plus one-time Cloud VPS bastion SSH setup instructions.

Tested end-to-end against production as a no-op deploy (main == release at the time, so the push was a no-op and the images matched the running version), including the rollback path. Redis was untouched throughout.

Written with AI assistance (Claude).
