### PR TITLE
Sort loose top-level scripts into scripts/util and scripts/wp1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           pipenv install --deploy --dev
 
       - name: Run ty
-        run: ./check_types.sh
+        run: ./scripts/util/check_types.sh
 
   docs-build:
     runs-on: ubuntu-24.04

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ id_rsa
 # Local git worktrees
 .worktrees/
 
-# Written by scripts/deploy-remote.sh on the production box
+# Written by scripts/wp1/deploy-remote.sh on the production box
 .last-deploy
 
 # Flask session

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ backend selections.
 
 ### Running parallel dev stacks (e.g. from git worktrees)
 
-The easiest way is `./create_worktree.sh <branch>`, which creates the
+The easiest way is `./scripts/util/create_worktree.sh <branch>`, which creates the
 worktree under `.worktrees/<branch>`, copies the untracked credentials and
 `.env` files, writes a worktree-local `.env` with a unique project name,
 suffix, and free port set (remapping the port-coupled app config values to
@@ -438,10 +438,10 @@ The `serve` command should print out the port to view the docs at, likely localh
 
 # Updating production
 
-Deploys are done with `scripts/deploy.sh`, run from a local checkout:
+Deploys are done with `scripts/wp1/deploy.sh`, run from a local checkout:
 
 ```bash
-./scripts/deploy.sh
+./scripts/wp1/deploy.sh
 ```
 
 This deploys the current `origin/main`. It requires push access to this
@@ -457,7 +457,7 @@ setup). The script:
   [publish workflow](https://github.com/openzim/wp1/actions/workflows/publish.yml),
   which builds and pushes the `wp1-workers`, `wp1-web` and
   `wp1-frontend` docker images.
-- Runs `scripts/deploy-remote.sh` on the production box (after a
+- Runs `scripts/wp1/deploy-remote.sh` on the production box (after a
   `git pull` there, so the remote script is the version being
   deployed), which:
   - Warns and asks for confirmation if `wp1/credentials.py.example`
@@ -479,8 +479,8 @@ setup). The script:
   - Verifies that the containers are running and that
     https://api.wp1.openzim.org and https://wp1.openzim.org respond.
 
-`scripts/deploy-remote.sh` can also be run by hand on the box
-(`cd /data/code/wp1 && sudo ./scripts/deploy-remote.sh <full git sha>`)
+`scripts/wp1/deploy-remote.sh` can also be run by hand on the box
+(`cd /data/code/wp1 && sudo ./scripts/wp1/deploy-remote.sh <full git sha>`)
 if the local half already pushed `release` but the remote half failed
 or was interrupted; it is safe to re-run.
 
@@ -506,7 +506,7 @@ for the full guide):
    ```
 
 Then `ssh mwcurator-b.mwoffliner.eqiad1.wikimedia.cloud` should log you
-in without a password, which is what `scripts/deploy.sh` needs.
+in without a password, which is what `scripts/wp1/deploy.sh` needs.
 
 ## Redis persistence
 
@@ -537,10 +537,10 @@ its GitHub packages page:
 To roll back a bad deploy, run (from a local checkout):
 
 ```bash
-./scripts/deploy.sh --rollback release-141   # or e.g. sha-73ed612
+./scripts/wp1/deploy.sh --rollback release-141   # or e.g. sha-73ed612
 ```
 
-This runs `scripts/deploy-remote.sh --rollback <tag>` on the box, which
+This runs `scripts/wp1/deploy-remote.sh --rollback <tag>` on the box, which
 pulls that version of each image, re-tags it locally as `release` (no
 registry login or push is required, the local tag is what docker
 compose uses), and recreates the containers. A successful deploy prints

--- a/docker/dev-db/README.md
+++ b/docker/dev-db/README.md
@@ -41,7 +41,7 @@ timestamps age. To refresh them, or to re-create the rows after changing them,
 run (from the repository root):
 
 ```bash
-pipenv run python seed-dev-selections.py
+pipenv run python scripts/util/seed-dev-selections.py
 ```
 
 The script talks directly to the dev database from `docker-compose-dev.yml`
@@ -53,7 +53,7 @@ rows for your own user instead (find your id with
 `SELECT u_id, u_username FROM users`):
 
 ```bash
-pipenv run python seed-dev-selections.py --user-id <your u_id> --username <your username>
+pipenv run python scripts/util/seed-dev-selections.py --user-id <your u_id> --username <your username>
 ```
 
 ## Updating the dev database dump

--- a/scripts/util/check_types.sh
+++ b/scripts/util/check_types.sh
@@ -6,10 +6,12 @@
 # this script directly, so updates here are the single source of truth.
 #
 # Usage:
-#   ./check_types.sh           # check all files in TYPED_FILES
-#   ./check_types.sh wp1/foo.py  # check a specific file (overrides the list)
+#   ./scripts/util/check_types.sh              # check all files in TYPED_FILES
+#   ./scripts/util/check_types.sh wp1/foo.py   # check a specific file (overrides the list)
 
 set -e
+
+cd "$(dirname "$0")/../.."
 
 TYPED_FILES=(
   wp1/models/wp10/builder.py

--- a/scripts/util/create_worktree.sh
+++ b/scripts/util/create_worktree.sh
@@ -11,7 +11,7 @@
 # port-coupled app config values (WP10DB_PORT, REDIS_PORT, localhost URLs)
 # to match, and optionally starts the stack.
 #
-# Usage: ./create_worktree.sh <branch> [start-point]
+# Usage: ./scripts/util/create_worktree.sh <branch> [start-point]
 #   <branch>       branch to check out in the worktree; created from
 #                  [start-point] if it doesn't exist yet
 #   [start-point]  ref a new branch is created from (default: main)
@@ -19,7 +19,7 @@
 # The worktree is created at .worktrees/<branch>.
 set -euo pipefail
 
-cd "$(dirname "$0")"
+cd "$(dirname "$0")/../.."
 
 branch="${1:?usage: $0 <branch> [start-point]}"
 start="${2:-main}"

--- a/scripts/util/run_tests.sh
+++ b/scripts/util/run_tests.sh
@@ -7,10 +7,12 @@
 # cleans dirty tables left behind by interrupted runs, then runs pytest.
 #
 # Usage:
-#   ./run_tests.sh                    # run all tests
-#   ./run_tests.sh wp1/tables_test.py # run specific tests
+#   ./scripts/util/run_tests.sh                    # run all tests
+#   ./scripts/util/run_tests.sh wp1/tables_test.py # run specific tests
 
 set -e
+
+cd "$(dirname "$0")/../.."
 
 DOCKER_DB_CONTAINER="wp1bot-test-db"
 DOCKER_REDIS_CONTAINER="wp1bot-test-redis"

--- a/scripts/util/seed-dev-selections.py
+++ b/scripts/util/seed-dev-selections.py
@@ -12,7 +12,7 @@ If your credentials.py.dev has real MWOAUTH credentials, you log in as your
 actual Wikipedia user instead; pass that user's id to seed the same data for
 it (find it with ``SELECT u_id, u_username FROM users``):
 
-    pipenv run python seed-dev-selections.py --user-id 12345678 --username You
+    pipenv run python scripts/util/seed-dev-selections.py --user-id 12345678 --username You
 
 The script connects directly to the dev database from docker-compose-dev.yml
 and is idempotent: seeded rows all have ids prefixed with ``dev-seed-`` and
@@ -20,7 +20,7 @@ the target user's seeded rows are deleted and re-created on every run.
 
 Usage:
 
-    pipenv run python seed-dev-selections.py
+    pipenv run python scripts/util/seed-dev-selections.py
 """
 
 import argparse

--- a/scripts/wp1/clear-project-table-caches.py
+++ b/scripts/wp1/clear-project-table-caches.py
@@ -1,4 +1,10 @@
 import logging
+import sys
+from pathlib import Path
+
+# Runs as `python scripts/wp1/clear-project-table-caches.py`; put the repo
+# root on sys.path so the `wp1` package resolves regardless of cwd.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from wp1 import app_logging
 from wp1.logic import project as logic_project

--- a/scripts/wp1/deploy-remote.sh
+++ b/scripts/wp1/deploy-remote.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Runs ON the production box (mwcurator), as root, invoked by
-# scripts/deploy.sh. Can also be run by hand from /data/code/wp1.
+# scripts/wp1/deploy.sh. Can also be run by hand from /data/code/wp1.
 #
 # Usage:
 #   deploy-remote.sh <full-git-sha>       deploy the images built from that sha
@@ -138,5 +138,5 @@ verify
 echo "$sha" > "$LAST_DEPLOY_FILE"
 echo "==> Deployed $sha"
 if [[ -n "$prev" ]]; then
-  echo "    Roll back with: ./scripts/deploy.sh --rollback sha-$(git rev-parse --short=7 "$prev" 2>/dev/null || echo "$prev")"
+  echo "    Roll back with: ./scripts/wp1/deploy.sh --rollback sha-$(git rev-parse --short=7 "$prev" 2>/dev/null || echo "$prev")"
 fi

--- a/scripts/wp1/deploy.sh
+++ b/scripts/wp1/deploy.sh
@@ -2,13 +2,13 @@
 # Deploy WP1 to production, or roll it back.
 #
 # Usage:
-#   ./scripts/deploy.sh                      deploy the current origin/main
-#   ./scripts/deploy.sh --rollback <tag>     roll back to a previous image tag
+#   ./scripts/wp1/deploy.sh                  deploy the current origin/main
+#   ./scripts/wp1/deploy.sh --rollback <tag> roll back to a previous image tag
 #                                            (e.g. release-141 or sha-73ed612)
 #
 # A deploy pushes origin/main to the release branch, which triggers the
 # publish workflow (.github/workflows/publish.yml) to build the three
-# docker images. It then runs scripts/deploy-remote.sh on the production
+# docker images. It then runs scripts/wp1/deploy-remote.sh on the production
 # box, which waits for the images tagged with the pushed commit's sha to
 # appear on ghcr.io, pulls them, restarts the containers and applies
 # database migrations.
@@ -31,7 +31,7 @@ if [[ "${1:-}" == "--rollback" ]]; then
   tag=${2:-}
   [[ -n "$tag" ]] || usage
   exec ssh -t "$REMOTE_HOST" \
-    "cd $REMOTE_DIR && sudo ./scripts/deploy-remote.sh --rollback '$tag'"
+    "cd $REMOTE_DIR && sudo ./scripts/wp1/deploy-remote.sh --rollback '$tag'"
 fi
 
 [[ $# -eq 0 ]] || usage
@@ -48,4 +48,4 @@ git push origin "$sha:refs/heads/release"
 # from the commit being deployed, not a stale copy.
 echo "==> Running remote deploy on $REMOTE_HOST"
 exec ssh -t "$REMOTE_HOST" \
-  "cd $REMOTE_DIR && sudo git pull --ff-only origin main && sudo ./scripts/deploy-remote.sh '$sha'"
+  "cd $REMOTE_DIR && sudo git pull --ff-only origin main && sudo ./scripts/wp1/deploy-remote.sh '$sha'"

--- a/scripts/wp1/enqueue-project.py
+++ b/scripts/wp1/enqueue-project.py
@@ -1,5 +1,10 @@
 import logging
 import sys
+from pathlib import Path
+
+# Runs as `python scripts/wp1/enqueue-project.py`; put the repo root on
+# sys.path so the `wp1` package resolves regardless of cwd.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from wp1 import app_logging, queues
 from wp1.redis_db import connect as redis_connect

--- a/scripts/wp1/warm-assessment-cache.py
+++ b/scripts/wp1/warm-assessment-cache.py
@@ -1,4 +1,10 @@
 import logging
+import sys
+from pathlib import Path
+
+# Runs as `python scripts/wp1/warm-assessment-cache.py`; put the repo root on
+# sys.path so the `wp1` package resolves regardless of cwd.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from wp1 import app_logging, queues
 from wp1.redis_db import connect as redis_connect

--- a/supervisord-dev.conf
+++ b/supervisord-dev.conf
@@ -123,7 +123,7 @@ autorestart=true
 ; the recurring (noon UTC) refresh is a cron_config.py job handled by the
 ; [scheduler] program above.
 [program:assessment-cache-seed]
-command=/usr/local/bin/python warm-assessment-cache.py
+command=/usr/local/bin/python scripts/wp1/warm-assessment-cache.py
 directory=/usr/src/app
 autostart=true
 ; Not a long-running process: don't restart on a clean (0) exit, but do retry

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -252,7 +252,7 @@ autorestart=true
 ; the recurring (noon UTC) refresh is a cron_config.py job handled by the
 ; [scheduler] program above.
 [program:assessment-cache-seed]
-command=/usr/local/bin/python warm-assessment-cache.py
+command=/usr/local/bin/python scripts/wp1/warm-assessment-cache.py
 directory=/usr/src/app
 autostart=true
 ; Not a long-running process: don't restart on a clean (0) exit, but do retry

--- a/wp1/queues.py
+++ b/wp1/queues.py
@@ -48,7 +48,7 @@ def _get_assessment_cache_queue(redis):
 def enqueue_assessment_cache_warming(redis: Redis):
     """Enqueue a one-off assessment-cache warming job to run immediately.
 
-    Called on container boot (see warm-assessment-cache.py) so that a fresh
+    Called on container boot (see scripts/wp1/warm-assessment-cache.py) so that a fresh
     deploy or a Redis restart seeds the cache right away instead of leaving the
     slow query to run inline on the first web request until the next scheduled
     (noon UTC, see cron_config.py) run.


### PR DESCRIPTION
Moves the loose scripts from the repo root into two subdirectories of `scripts/`:

- `scripts/util/` — dev tooling: `check_types.sh`, `run_tests.sh`, `create_worktree.sh`, `seed-dev-selections.py`
- `scripts/wp1/` — part of the system: `warm-assessment-cache.py`, `enqueue-project.py`, `clear-project-table-caches.py`, plus the existing `deploy.sh` / `deploy-remote.sh`

`cron_config.py` and `rate_limit_queue.py` stay at the root: RQ imports them as top-level modules from `/usr/src/app` in the workers images.

Supporting changes:

- Shell utils `cd` to the repo root so they work from any cwd.
- The `scripts/wp1` Python scripts get a `sys.path` bootstrap so `wp1` imports resolve when run as `python scripts/wp1/<script>.py` (as supervisord does).
- Callers updated: `ci.yml`, `supervisord{,-dev}.conf`, READMEs, `.gitignore` comment, and the deploy scripts' remote-path references.

Verified inside the rebuilt dev-workers image: `enqueue-project.py` and `warm-assessment-cache.py` run cleanly, and the one-shot `assessment-cache-seed` supervisord program works with the new path. The prod image build context (`COPY . app` + root `.dockerignore`) was checked to include `scripts/` where `supervisord.conf` now points.

Note for ops: the first `deploy.sh --rollback` after this lands needs the production box to have pulled `main` once (any normal deploy does that), since rollback invokes `scripts/wp1/deploy-remote.sh` from the box's existing checkout.

🤖 Written with [Claude Code](https://claude.ai/code)