### PR TITLE
use different payloads for recipe create and update

### DIFF
--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -298,29 +298,26 @@ def get_zim_filename_prefix(builder: Builder, selection: Selection) -> str:
     return f"{util.safe_name(builder_name)}-{selection_id_frag}"
 
 
-def _get_params(
-    builder: Builder,
-    selection: Selection,
-    title: str,
-    description: str,
-    long_description: str,
-    flavour: str = None,
-) -> dict:
-    if builder is None:
-        raise ValueError("Given builder was None: %r" % builder)
-
-    project = builder.b_project.decode("utf-8")
-
+def _get_image_name_and_tag() -> tuple[str, str]:
     image = CREDENTIALS[ENV].get("ZIMFARM", {}).get("image")
     if image is None:
         image = "ghcr.io/openzim/mwoffliner:latest"
         logger.warning(
             'No ZIMFARM["image"] found in credentials, using latest (%s)', image
         )
-    image_name, image_tag = image.split(":")
+    return image.split(":")
 
-    offliner_config = {
-        "offliner_id": "mwoffliner",
+
+def _get_offliner_flags(
+    builder: Builder,
+    selection: Selection,
+    title: str,
+    description: str,
+    long_description: str,
+    flavour: str | None = None,
+):
+    project = builder.b_project.decode("utf-8")
+    flags = {
         "mwUrl": "https://%s/" % project,
         "adminEmail": "contact+wp1@kiwix.org",
         "forceRender": "ActionParse",
@@ -339,8 +336,81 @@ def _get_params(
 
     # Add the format flag for mwoffliner if a flavour is specified.
     if flavour:
-        offliner_config["format"] = [ALLOWED_FLAVOURS[flavour]]
+        flags["format"] = [ALLOWED_FLAVOURS[flavour]]
 
+    cache_url = CREDENTIALS[ENV].get("ZIMFARM", {}).get("cache_url")
+    if cache_url is not None:
+        flags["optimisationCacheUrl"] = cache_url
+    else:
+        logger.warning(
+            "No cache_url found in credentials, skipping "
+            "optimisationCacheUrl URL for zimfarm request"
+        )
+    return flags
+
+
+def _get_schedule_update_params(
+    builder: Builder,
+    selection: Selection,
+    title: str,
+    description: str,
+    long_description: str,
+    flavour: str = None,
+) -> dict[str, Any]:
+    if builder is None:
+        raise ValueError("Given builder was None: %r" % builder)
+
+    image_name, image_tag = _get_image_name_and_tag()
+    flags = _get_offliner_flags(
+        builder, selection, title, description, long_description, flavour
+    )
+    version = CREDENTIALS[ENV].get("ZIMFARM", {}).get("definition_version", image_tag)
+
+    webhook_url = get_webhook_url()
+
+    return {
+        "name": get_zimfarm_schedule_name(builder.b_id.decode("utf-8")),
+        "language": "eng",
+        "periodicity": "manually",
+        "tags": ["wikipedia"],
+        "enabled": True,
+        "offliner": "mwoffliner",
+        "warehouse_path": "/wikipedia",
+        "image": {
+            "name": image_name,
+            "tag": image_tag,
+        },
+        "platform": None,
+        "resources": logic_selection.get_resource_profile(selection),
+        "monitor": False,
+        "flags": flags,
+        "context": "wikimedia",
+        "version": version,
+        "notification": {
+            "ended": {
+                "webhook": [webhook_url] if webhook_url else None,
+            },
+        },
+    }
+
+
+def _get_schedule_create_params(
+    builder: Builder,
+    selection: Selection,
+    title: str,
+    description: str,
+    long_description: str,
+    flavour: str = None,
+) -> dict:
+    if builder is None:
+        raise ValueError("Given builder was None: %r" % builder)
+
+    image_name, image_tag = _get_image_name_and_tag()
+    flags = _get_offliner_flags(
+        builder, selection, title, description, long_description, flavour
+    )
+
+    flags["offliner_id"] = "mwoffliner"
     config = {
         "warehouse_path": "/wikipedia",
         "image": {
@@ -350,35 +420,25 @@ def _get_params(
         "resources": logic_selection.get_resource_profile(selection),
         "platform": "wikimedia",
         "monitor": False,
-        "offliner": offliner_config,
+        "offliner": flags,
     }
-    cache_url = CREDENTIALS[ENV].get("ZIMFARM", {}).get("cache_url")
-    if cache_url is not None:
-        config["offliner"]["optimisationCacheUrl"] = cache_url
-    else:
-        logger.warning(
-            "No cache_url found in credentials, skipping "
-            "optimisationCacheUrl URL for zimfarm request"
-        )
-
     version = CREDENTIALS[ENV].get("ZIMFARM", {}).get("definition_version", image_tag)
-
     webhook_url = get_webhook_url()
 
     return {
         "name": get_zimfarm_schedule_name(builder.b_id.decode("utf-8")),
         "language": "eng",
-        "context": "wikimedia",
         "periodicity": "manually",
         "tags": ["wikipedia"],
         "enabled": True,
+        "version": version,
+        "config": config,
         "notification": {
             "ended": {
                 "webhook": [webhook_url] if webhook_url else None,
             },
         },
-        "config": config,
-        "version": version,
+        "context": "wikimedia",
     }
 
 
@@ -449,9 +509,6 @@ def create_or_update_zimfarm_schedule(
             )
         )
 
-    params = _get_params(
-        builder, selection, title, description, long_description, flavour=flavour
-    )
     base_url = get_zimfarm_url()
     headers = _get_zimfarm_headers(token)
 
@@ -463,6 +520,14 @@ def create_or_update_zimfarm_schedule(
     try:
         existing_zim_schedule = find_existing_schedule_in_db(wp10db, builder.b_id)
         if existing_zim_schedule and zimfarm_schedule_exists(redis, builder_id):
+            params = _get_schedule_update_params(
+                builder,
+                selection,
+                title,
+                description,
+                long_description,
+                flavour=flavour,
+            )
             schedule_name = get_zimfarm_schedule_name(builder_id)
             r = requests.patch(
                 "%s/recipes/%s" % (base_url, schedule_name),
@@ -481,6 +546,14 @@ def create_or_update_zimfarm_schedule(
             logic_zim_schedules.update_zim_schedule(wp10db, zim_schedule)
             zim_schedule_id_to_set = zim_schedule.s_id.decode("utf-8")
         else:
+            params = _get_schedule_create_params(
+                builder,
+                selection,
+                title,
+                description,
+                long_description,
+                flavour=flavour,
+            )
             r = requests.post("%s/recipes" % base_url, headers=headers, json=params)
             if r.status_code == 409:
                 # The recipe already exists on the Zimfarm even though there is
@@ -490,6 +563,14 @@ def create_or_update_zimfarm_schedule(
                 # params and record it locally below, making this operation
                 # idempotent instead of permanently stuck on 409.
                 schedule_name = get_zimfarm_schedule_name(builder_id)
+                params = _get_schedule_update_params(
+                    builder,
+                    selection,
+                    title,
+                    description,
+                    long_description,
+                    flavour=flavour,
+                )
                 logger.info(
                     "Recipe %s already exists on the Zimfarm, adopting it",
                     schedule_name,

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -187,7 +187,7 @@ class ZimFarmTest(BaseWpOneDbTest):
         with self.assertRaises(ValueError):
             zimfarm.get_zim_filename_prefix(None, None)
 
-    def test_get_params(self):
+    def test_get_schdedule_create_params(self):
         s3 = MagicMock()
         s3.client.head_object.return_value = {"ContentLength": 20000000}
         from wp1.zimfarm import CREDENTIALS
@@ -196,7 +196,7 @@ class ZimFarmTest(BaseWpOneDbTest):
             "cache_url"
         ] = "https://wasabi.fake/bucket"
 
-        actual = zimfarm._get_params(
+        actual = zimfarm._get_schedule_create_params(
             self.builder,
             self.selection,
             title="My Builder",
@@ -207,7 +207,7 @@ class ZimFarmTest(BaseWpOneDbTest):
         self.maxDiff = None
         self.assertEqual(self.expected_params, actual)
 
-    def test_get_params_image_in_env(self):
+    def test_get_schedule_create_params_image_in_env(self):
         s3 = MagicMock()
         s3.client.head_object.return_value = {"ContentLength": 20000000}
         from wp1.zimfarm import CREDENTIALS
@@ -226,7 +226,7 @@ class ZimFarmTest(BaseWpOneDbTest):
         }
         expected["version"] = "1.23.45"
 
-        actual = zimfarm._get_params(
+        actual = zimfarm._get_schedule_create_params(
             self.builder,
             self.selection,
             title="My Builder",
@@ -237,9 +237,11 @@ class ZimFarmTest(BaseWpOneDbTest):
         self.maxDiff = None
         self.assertEqual(expected, actual)
 
-    def test_get_params_missing_builder(self):
+    def test_get_schedule_create_params_missing_builder(self):
         with self.assertRaises(ValueError):
-            zimfarm._get_params(None, self.selection, "Tile", "Desc", "Long Desc")
+            zimfarm._get_schedule_create_params(
+                None, self.selection, "Tile", "Desc", "Long Desc"
+            )
 
     @patch("wp1.zimfarm.CREDENTIALS")
     def test_token_provider_init_oauth_valid(self, mock_credentials):
@@ -725,7 +727,7 @@ class ZimFarmTest(BaseWpOneDbTest):
 
     @patch("wp1.zimfarm.requests")
     @patch("wp1.zimfarm.token_provider")
-    @patch("wp1.zimfarm._get_params")
+    @patch("wp1.zimfarm._get_schedule_create_params")
     def test_create_or_update_zimfarm_schedule_creates(
         self, get_params_mock, mock_token_provider, mock_requests
     ):
@@ -769,7 +771,7 @@ class ZimFarmTest(BaseWpOneDbTest):
 
     @patch("wp1.zimfarm.requests")
     @patch("wp1.zimfarm.token_provider")
-    @patch("wp1.zimfarm._get_params")
+    @patch("wp1.zimfarm._get_schedule_update_params")
     @patch("wp1.zimfarm.zimfarm_schedule_exists", return_value=True)
     def test_create_or_update_zimfarm_schedule_updates(
         self,
@@ -807,6 +809,7 @@ class ZimFarmTest(BaseWpOneDbTest):
             "New Long Description",
             None,
         )
+        get_params_mock.assert_called_once()
 
         # Actually check that the schedule was updated in the DB
         with self.wp10db.cursor() as cursor:
@@ -822,13 +825,19 @@ class ZimFarmTest(BaseWpOneDbTest):
 
     @patch("wp1.zimfarm.requests")
     @patch("wp1.zimfarm.token_provider")
-    @patch("wp1.zimfarm._get_params")
+    @patch("wp1.zimfarm._get_schedule_create_params")
+    @patch("wp1.zimfarm._get_schedule_update_params")
     def test_create_or_update_zimfarm_schedule_adopts_orphaned_recipe(
-        self, get_params_mock, mock_token_provider, mock_requests
+        self,
+        get_update_params_mock,
+        get_create_params_mock,
+        mock_token_provider,
+        mock_requests,
     ):
         """A 409 on recipe creation adopts the existing recipe via PATCH."""
         redis = MagicMock()
-        get_params_mock.return_value = {"name": "bar"}
+        get_create_params_mock.return_value = {"name": "foo"}
+        get_update_params_mock.return_value = {"name": "bar"}
         mock_token_provider.get_access_token.return_value = "abcdef"
         post_response = MagicMock()
         post_response.status_code = 409
@@ -852,7 +861,7 @@ class ZimFarmTest(BaseWpOneDbTest):
         mock_requests.post.assert_called_once_with(
             "https://fake.farm/v2/recipes",
             headers=expected_headers,
-            json={"name": "bar"},
+            json={"name": "foo"},
         )
         mock_requests.patch.assert_called_once_with(
             "https://fake.farm/v2/recipes/wp1_selection_3c4d",
@@ -870,7 +879,7 @@ class ZimFarmTest(BaseWpOneDbTest):
 
     @patch("wp1.zimfarm.requests")
     @patch("wp1.zimfarm.token_provider")
-    @patch("wp1.zimfarm._get_params")
+    @patch("wp1.zimfarm._get_schedule_create_params")
     def test_create_or_update_zimfarm_schedule_adopt_patch_fails(
         self, get_params_mock, mock_token_provider, mock_requests
     ):
@@ -905,7 +914,7 @@ class ZimFarmTest(BaseWpOneDbTest):
 
     @patch("wp1.zimfarm.requests")
     @patch("wp1.zimfarm.token_provider")
-    @patch("wp1.zimfarm._get_params")
+    @patch("wp1.zimfarm._get_schedule_create_params")
     def test_create_or_update_zimfarm_schedule_http_error(
         self, get_params_mock, mock_token_provider, mock_requests
     ):
@@ -1007,7 +1016,7 @@ class ZimFarmTest(BaseWpOneDbTest):
 
     @patch("wp1.zimfarm.requests")
     @patch("wp1.zimfarm.token_provider")
-    @patch("wp1.zimfarm._get_params")
+    @patch("wp1.zimfarm._get_schedule_create_params")
     def test_create_or_update_zimfarm_schedule_create_empty_long_desc_ok(
         self, get_params_mock, mock_token_provider, mock_requests
     ):
@@ -1038,7 +1047,7 @@ class ZimFarmTest(BaseWpOneDbTest):
 
     @patch("wp1.zimfarm.requests")
     @patch("wp1.zimfarm.token_provider")
-    @patch("wp1.zimfarm._get_params")
+    @patch("wp1.zimfarm._get_schedule_create_params")
     def test_create_or_update_zimfarm_schedule_create_missing_long_desc_ok(
         self, get_params_mock, mock_token_provider, mock_requests
     ):
@@ -1133,7 +1142,7 @@ class ZimFarmTest(BaseWpOneDbTest):
 
     @patch("wp1.zimfarm.requests")
     @patch("wp1.zimfarm.token_provider")
-    @patch("wp1.zimfarm._get_params")
+    @patch("wp1.zimfarm._get_schedule_create_params")
     def test_create_or_update_zimfarm_schedule_valid_graphemes(
         self, get_params_mock, mock_token_provider, mock_requests
     ):
@@ -1632,7 +1641,7 @@ class ZimFarmTest(BaseWpOneDbTest):
             "cache_url"
         ] = "https://wasabi.fake/bucket"
 
-        actual = zimfarm._get_params(
+        actual = zimfarm._get_schedule_create_params(
             self.builder,
             self.selection,
             title="My Builder",
@@ -1650,7 +1659,7 @@ class ZimFarmTest(BaseWpOneDbTest):
             "cache_url"
         ] = "https://wasabi.fake/bucket"
 
-        actual = zimfarm._get_params(
+        actual = zimfarm._get_schedule_create_params(
             self.builder,
             self.selection,
             title="My Builder",
@@ -1668,7 +1677,7 @@ class ZimFarmTest(BaseWpOneDbTest):
             "cache_url"
         ] = "https://wasabi.fake/bucket"
 
-        actual = zimfarm._get_params(
+        actual = zimfarm._get_schedule_create_params(
             self.builder,
             self.selection,
             title="My Builder",
@@ -1686,7 +1695,7 @@ class ZimFarmTest(BaseWpOneDbTest):
             "cache_url"
         ] = "https://wasabi.fake/bucket"
 
-        actual = zimfarm._get_params(
+        actual = zimfarm._get_schedule_create_params(
             self.builder,
             self.selection,
             title="My Builder",
@@ -1698,7 +1707,7 @@ class ZimFarmTest(BaseWpOneDbTest):
 
     @patch("wp1.zimfarm.requests")
     @patch("wp1.zimfarm.token_provider")
-    @patch("wp1.zimfarm._get_params")
+    @patch("wp1.zimfarm._get_schedule_create_params")
     def test_create_or_update_zimfarm_schedule_with_flavour(
         self, get_params_mock, mock_token_provider, mock_requests
     ):


### PR DESCRIPTION
## Rationale
zimfarm uses different payloads for recipe creation and update but currently wp1 uses same payload for both operations. this fails silently because api schema models allow extra fields and pydantic proceeds with only with what it needs. as a consequence, recipes aren't exactly getting updated in the way wp1 expects. This PR attempts to rectify it by using two different functions for creating the payloads for each operation.

https://github.com/openzim/zimfarm/blob/41e6fa8eae723d2dfcbdfe3f49c6c0a34d4ee272/backend/src/zimfarm_backend/api/routes/recipes/models.py#L36-L46

https://github.com/openzim/zimfarm/blob/41e6fa8eae723d2dfcbdfe3f49c6c0a34d4ee272/backend/src/zimfarm_backend/api/routes/recipes/models.py#L53-L70