### PR TITLE
Use 'Importance' instead of 'Class' for importance ratings in logs

### DIFF
--- a/wp1-frontend/cypress/fixtures/category_links_sorted_alien.json
+++ b/wp1-frontend/cypress/fixtures/category_links_sorted_alien.json
@@ -21,7 +21,7 @@
       "href": "https://en.wikipedia.org/wiki/Category:Top-importance_Alien_articles",
       "text": "Top"
     },
-    "Unassessed-Class": "No-Class",
+    "Unassessed-Class": "No-Importance",
     "Unknown-Class": {
       "href": "https://en.wikipedia.org/wiki/Category:Unknown-importance_Alien_articles",
       "text": "???"

--- a/wp1-frontend/cypress/fixtures/project_table_aesthetics.json
+++ b/wp1-frontend/cypress/fixtures/project_table_aesthetics.json
@@ -23,7 +23,7 @@
         "href": "https://en.wikipedia.org/wiki/Category:Top-importance_Aesthetics_articles",
         "text": "Top"
       },
-      "Unassessed-Class": "No-Class",
+      "Unassessed-Class": "No-Importance",
       "Unknown-Class": {
         "href": "https://en.wikipedia.org/wiki/Category:Unknown-importance_Aesthetics_articles",
         "text": "???"

--- a/wp1-frontend/cypress/fixtures/project_table_alien.json
+++ b/wp1-frontend/cypress/fixtures/project_table_alien.json
@@ -23,7 +23,7 @@
         "href": "https://en.wikipedia.org/wiki/Category:Top-importance_Alien_articles",
         "text": "Top"
       },
-      "Unassessed-Class": "No-Class",
+      "Unassessed-Class": "No-Importance",
       "Unknown-Class": {
         "href": "https://en.wikipedia.org/wiki/Category:Unknown-importance_Alien_articles",
         "text": "???"

--- a/wp1/logs_test.py
+++ b/wp1/logs_test.py
@@ -827,8 +827,8 @@ class LogsTest(BaseCombinedDbTest):
             "rev] &middot; "
             "[https://en.wikipedia.org/w/index.php?"
             "title=Talk%3ALesser-known%20tests&oldid=None "
-            "t])</span> Importance rating changed from '''Start-Class''' "
-            "to '''Unknown-Class'''. <span style=\\\"white-space: "
+            "t])</span> Importance rating changed from '''Start-Importance''' "
+            "to '''Unknown-Importance'''. <span style=\\\"white-space: "
             'nowrap;\\">([https://en.wikipedia.org/w/index.php?'
             "title=Lesser-known%20tests&oldid=18000 "
             "rev] &middot; "
@@ -875,7 +875,7 @@ class LogsTest(BaseCombinedDbTest):
             "rev] &middot; "
             "[https://en.wikipedia.org/w/index.php?"
             "title=Talk%3AImportant%20tests&oldid=None "
-            "t])</span> Importance assessed as '''Unknown-Class'''. <span "
+            "t])</span> Importance assessed as '''Unknown-Importance'''. <span "
             'style=\\"white-space: '
             'nowrap;\\">([https://en.wikipedia.org/w/index.php?'
             "title=Important%20tests&oldid=15000 "

--- a/wp1/tables.py
+++ b/wp1/tables.py
@@ -51,7 +51,7 @@ def labels_for_classes(sort_qual, sort_imp):
 
     for k in sort_imp.keys():
         imp_labels[k] = "{{%s}}" % k.decode("utf-8")
-    imp_labels[UNASSESSED_CLASS] = "No-Class"
+    imp_labels[UNASSESSED_CLASS] = "No-Importance"
 
     return qual_labels, imp_labels
 

--- a/wp1/tables_test.py
+++ b/wp1/tables_test.py
@@ -71,7 +71,7 @@ class TablesCategoryTest(unittest.TestCase):
 
         for k, actual in actual_imp.items():
             if k == tables.UNASSESSED_CLASS:
-                expected = "No-Class"
+                expected = "No-Importance"
             else:
                 expected = "{{%s}}" % k.decode("utf-8")
             self.assertEqual(expected, actual)
@@ -453,7 +453,7 @@ class TablesDbTest(BaseWpOneDbTest):
                 b"NA-Class": "{{NA-Class|category=Category:NA-importance_Catholicism_articles}}",
                 b"NotA-Class": "Other",
                 b"Top-Class": "{{Top-Class|category=Category:Top-importance_Catholicism_articles}}",
-                b"Unassessed-Class": "No-Class",
+                b"Unassessed-Class": "No-Importance",
                 b"Unknown-Class": "{{Unknown-Class|category=Category:Unknown-importance_Catholicism_articles}}",
             },
             "qual_labels": {
@@ -936,7 +936,7 @@ class TestTableOutput(unittest.TestCase):
             b"NotA-Class": "Other",
             b"Top-Class": "{{Top-Class|category=Category:Top-importance_Modern_philosophy_articles}}",
             b"Unknown-Class": "{{Unknown-Class|category=Category:Unknown-importance_Modern_philosophy_articles}}",
-            b"Unassessed-Class": "No-Class",
+            b"Unassessed-Class": "No-Importance",
         },
         "row_labels": {
             b"A-Class": "{{A-Class|category=Category:A-Class_Modern_philosophy_articles}}",
@@ -1091,7 +1091,7 @@ class TestTableOutput(unittest.TestCase):
                 "href": "https://en.wikipedia.org/wiki/Category:Unknown-importance_Modern_philosophy_articles",
                 "text": "???",
             },
-            "Unassessed-Class": "No-Class",
+            "Unassessed-Class": "No-Importance",
         },
         "row_labels": {
             "A-Class": {

--- a/wp1/templates/__init__.py
+++ b/wp1/templates/__init__.py
@@ -5,8 +5,19 @@ def commas(n):
     return "{:,d}".format(n)
 
 
+def importance_label(value):
+    """Display form of an importance rating, which is stored with a '-Class'
+    suffix (e.g. b'High-Class' -> 'High-Importance'). See openzim/wp1#115."""
+    if isinstance(value, bytes):
+        value = value.decode("utf-8")
+    if value.endswith("-Class"):
+        value = value[: -len("-Class")] + "-Importance"
+    return value
+
+
 env = Environment(
     loader=PackageLoader("wp1", "templates"),
     autoescape=select_autoescape(["html", "xml"]),
 )
 env.filters["commas"] = commas
+env.filters["importance_label"] = importance_label

--- a/wp1/templates/log_helpers.jinja2
+++ b/wp1/templates/log_helpers.jinja2
@@ -23,9 +23,9 @@
 {% macro importance(art) -%}
    {% if l[art]['importance'].l_new -%}
      {%- if not l[art]['importance'].l_old or l[art]['importance'].l_old.decode('utf-8') == 'NotA-Class' -%}
-       Importance assessed as '''{{l[art]['importance'].l_new.decode('utf-8')}}'''.
-     {%- else -%}
-       Importance rating changed from '''{{l[art]['importance'].l_old.decode('utf-8')}}''' to '''{{l[art]['importance'].l_new.decode('utf-8')}}'''.
+      Importance assessed as '''{{l[art]['importance'].l_new | importance_label}}'''.
+    {%- else -%}
+      Importance rating changed from '''{{l[art]['importance'].l_old | importance_label}}''' to '''{{l[art]['importance'].l_new | importance_label}}'''.
      {%- endif -%}
    {%- endif %}
 {%- endmacro %}
@@ -44,6 +44,6 @@
      Quality rating was '''{{l[art]['quality'].l_old.decode('utf-8')}}'''. {{revs(art, 'quality')}}
     {%- endif -%}
   {%- if l[art]['importance'] -%}
-     Importance rating was '''{{l[art]['importance'].l_old.decode('utf-8')}}'''. {{revs(art, 'importacne')}}. {{revs(art, 'importance')}}
+     Importance rating was '''{{l[art]['importance'].l_old | importance_label}}'''. {{revs(art, 'importacne')}}. {{revs(art, 'importance')}}
   {%- endif -%}
 {% endmacro %}

--- a/wp1/templates_test.py
+++ b/wp1/templates_test.py
@@ -1,0 +1,15 @@
+import unittest
+
+from wp1.templates import importance_label
+
+
+class ImportanceLabelTest(unittest.TestCase):
+    def test_replaces_class_suffix(self):
+        self.assertEqual("High-Importance", importance_label(b"High-Class"))
+        self.assertEqual("Unknown-Importance", importance_label(b"Unknown-Class"))
+
+    def test_accepts_str(self):
+        self.assertEqual("Mid-Importance", importance_label("Mid-Class"))
+
+    def test_no_class_suffix_unchanged(self):
+        self.assertEqual("NotAClass", importance_label(b"NotAClass"))

--- a/wp1/web/projects_test.py
+++ b/wp1/web/projects_test.py
@@ -63,7 +63,7 @@ class ProjectTest(BaseWebTestcase):
                 "href": "https://en.wikipedia.org/wiki/Category:Low-Class_Project_0_articles",
                 "text": "Low",
             },
-            "Unassessed-Class": "No-Class",
+            "Unassessed-Class": "No-Importance",
         },
     }
 


### PR DESCRIPTION
Fixes #115.

Importance ratings are stored with a `-Class` suffix (`Low-Class`, `High-Class`, ...) and the log templates rendered them verbatim, producing wording like "Importance rating changed from '''Low-Class''' to '''High-Class'''".

Adds an `importance_label` Jinja filter that rewrites the suffix for display (`High-Class` -> `High-Importance`) and applies it wherever the log templates render importance values. Quality wording and the `NotA-Class` sentinel comparison are unchanged.

Also fixes the same wording bug in the assessment tables: the unassessed importance column was labeled with the literal string `No-Class` (in both the wikitext tables and the web UI); it is now `No-Importance`.

Written with AI assistance (Claude).