### PR TITLE
Complete Cypress coverage for manual update page

### DIFF
--- a/wp1-frontend/cypress/e2e/updatePage.cy.js
+++ b/wp1-frontend/cypress/e2e/updatePage.cy.js
@@ -34,7 +34,7 @@ describe('the manual update page', () => {
       });
 
       it('navigates to the project update URL', () => {
-        cy.url().should('eq', 'http://localhost:5173/#/update/Alien');
+        cy.url().should('eq', `${Cypress.config('baseUrl')}/#/update/Alien`);
       });
 
       it('shows the update confirmation button', () => {
@@ -93,6 +93,124 @@ describe('the manual update page', () => {
       it('shows the scheduled-but-not-started progress string', () => {
         cy.wait('@progress');
         cy.contains("hasn't started yet");
+      });
+    });
+
+    describe('and a project with spaces in its name is selected', () => {
+      beforeEach(() => {
+        cy.intercept('v1/projects/Bob_Dylan/update/time', {
+          body: { next_update_time: null },
+        }).as('updateTime');
+        cy.visit('/#/update');
+        cy.get('input.search').type('Bob Dylan');
+        cy.get('.results .result').first().click();
+      });
+
+      it('requests the update time with underscores in the project id', () => {
+        cy.wait('@updateTime');
+      });
+
+      it('navigates to the project update URL', () => {
+        cy.url().should(
+          'eq',
+          `${Cypress.config('baseUrl')}/#/update/Bob%20Dylan`
+        );
+      });
+
+      describe('when the update button is clicked', () => {
+        it('POSTs to the underscored update endpoint', () => {
+          cy.wait('@updateTime');
+          cy.intercept('POST', 'v1/projects/Bob_Dylan/update', {
+            body: { next_update_time: '2026-08-01T00:00:00Z' },
+          }).as('postUpdate');
+          cy.intercept('v1/projects/Bob_Dylan/update/progress', {
+            body: { job: null, queue: { status: 'queued' } },
+          });
+          cy.contains('button', 'Manual Update').click();
+          cy.wait('@postUpdate');
+        });
+      });
+    });
+
+    describe('and the update job is running', () => {
+      beforeEach(() => {
+        cy.intercept('v1/projects/Alien/update/time', {
+          body: { next_update_time: '2026-08-01T00:00:00Z' },
+        }).as('updateTime');
+        cy.intercept('v1/projects/Alien/update/progress', {
+          body: {
+            job: { progress: 50, total: 100 },
+            queue: { status: 'started' },
+          },
+        }).as('progress');
+        cy.visit('/#/update/Alien');
+        cy.wait('@progress');
+      });
+
+      it('shows the running progress string', () => {
+        cy.contains('Your job is running, track its progress below.');
+      });
+
+      it('shows the article counts', () => {
+        cy.contains('50 / 100 articles');
+      });
+
+      it('shows a progress bar with the job progress values', () => {
+        cy.get('[role="progressbar"]')
+          .should('have.attr', 'aria-valuenow', '50')
+          .should('have.attr', 'aria-valuemax', '100');
+      });
+    });
+
+    describe('and the update job is finishing up', () => {
+      beforeEach(() => {
+        cy.intercept('v1/projects/Alien/update/time', {
+          body: { next_update_time: '2026-08-01T00:00:00Z' },
+        }).as('updateTime');
+        cy.intercept('v1/projects/Alien/update/progress', {
+          body: {
+            job: { progress: 100, total: 100 },
+            queue: { status: 'started' },
+          },
+        }).as('progress');
+        cy.visit('/#/update/Alien');
+        cy.wait('@progress');
+      });
+
+      it('shows the finishing-up progress string', () => {
+        cy.contains(
+          'Your job is almost finished, just wrapping up some tasks.'
+        );
+      });
+    });
+
+    describe('and the update job is complete', () => {
+      beforeEach(() => {
+        cy.intercept('v1/projects/Alien/update/time', {
+          body: { next_update_time: '2026-08-01T00:00:00Z' },
+        }).as('updateTime');
+        cy.intercept('v1/projects/Alien/update/progress', {
+          body: { job: null, queue: { status: 'finished' } },
+        }).as('progress');
+        cy.visit('/#/update/Alien');
+        cy.wait('@progress');
+      });
+
+      it('shows the complete progress string', () => {
+        cy.contains('Your job is complete!');
+      });
+
+      it('hides the progress bar', () => {
+        cy.contains('Your job is complete!');
+        cy.get('[role="progressbar"]').should('not.exist');
+      });
+
+      it('stops polling for progress', () => {
+        // Polling runs every 2 seconds; after the job reports finished, no
+        // further progress requests should be made.
+        cy.contains('Your job is complete!');
+        cy.wait(2500);
+        cy.get('@progress.all').should('have.length', 1);
       });
     });
   });


### PR DESCRIPTION
Fixes #321.

Covers the remaining `UpdatePage` states in `updatePage.cy.js`:

- running / finishing-up / complete progress strings
- article counts and progress bar `aria-valuenow`/`aria-valuemax`
- polling stops after the job reports finished
- underscore substitution for project names with spaces (`Bob Dylan` → `Bob_Dylan` endpoints)
- URL assertions now derive from `Cypress.config('baseUrl')` so the spec runs on any port

All 21 tests in the spec pass locally against the Vite dev server (API fully stubbed via `cy.intercept`).

Written with AI assistance (Claude).