### PR TITLE
Exclude empty projects from project list and count

### DIFF
--- a/wp1/logic/project.py
+++ b/wp1/logic/project.py
@@ -47,7 +47,7 @@ RE_REJECT_GENERIC = re.compile(ARTICLES_LABEL + b"_" + BY_QUALITY, re.I)
 
 def count_projects(wp10db):
     with wp10db.cursor() as cursor:
-        cursor.execute("SELECT COUNT(*) AS count FROM projects")
+        cursor.execute("SELECT COUNT(*) AS count FROM projects WHERE p_count > 0")
         res = cursor.fetchone()
 
     return res and res["count"]
@@ -157,8 +157,11 @@ def project_names_to_update(wikidb):
 
 def list_all_projects(wp10db):
     with wp10db.cursor() as cursor:
+        # Empty projects are usually leftover category redirects from a
+        # renamed WikiProject (openzim/wp1#425), so don't offer them.
         cursor.execute("""
       SELECT p_project, p_timestamp, p_count, p_qcount, p_icount FROM projects
+      WHERE p_count > 0
       """)
         return [Project(**db_project) for db_project in cursor.fetchall()]
 

--- a/wp1/logic/project_test.py
+++ b/wp1/logic/project_test.py
@@ -1439,9 +1439,9 @@ class GlobalCountAndListTest(BaseWpOneDbTest):
             cursor.executemany(
                 """
           INSERT INTO projects
-            (p_project, p_timestamp)
+            (p_project, p_timestamp, p_count)
           VALUES
-            (%s, '20181225001122')
+            (%s, '20181225001122', 100)
       """,
                 [("Test Project %s" % i,) for i in range(50)],
             )
@@ -1476,6 +1476,32 @@ class GlobalCountAndListTest(BaseWpOneDbTest):
             self.assertEqual(50, len(projects))
         finally:
             self.wp10db.close = orig_close
+
+    def test_list_all_projects_excludes_empty(self):
+        with self.wp10db.cursor() as cursor:
+            cursor.execute("""
+          INSERT INTO projects
+            (p_project, p_timestamp, p_count)
+          VALUES
+            ('Empty Redirect Project', '20181225001122', 0)
+      """)
+        self.wp10db.commit()
+
+        projects = logic_project.list_all_projects(self.wp10db)
+        self.assertEqual(50, len(projects))
+        self.assertNotIn(b"Empty Redirect Project", [p.p_project for p in projects])
+
+    def test_count_projects_excludes_empty(self):
+        with self.wp10db.cursor() as cursor:
+            cursor.execute("""
+          INSERT INTO projects
+            (p_project, p_timestamp, p_count)
+          VALUES
+            ('Empty Redirect Project', '20181225001122', 0)
+      """)
+        self.wp10db.commit()
+
+        self.assertEqual(50, logic_project.count_projects(self.wp10db))
 
 
 class UpdateProjectByNameTest(BaseCombinedDbTest):

--- a/wp1/web/projects_test.py
+++ b/wp1/web/projects_test.py
@@ -75,6 +75,7 @@ class ProjectTest(BaseWebTestcase):
                 {
                     "p_project": b"Project %s" % str(i).encode("utf-8"),
                     "p_timestamp": b"20181225000000",
+                    "p_count": 150,
                 }
             )
 
@@ -130,8 +131,8 @@ class ProjectTest(BaseWebTestcase):
 
         with self.wp10db.cursor() as cursor:
             cursor.executemany(
-                "INSERT INTO projects (p_project, p_timestamp) "
-                "VALUES (%(p_project)s, %(p_timestamp)s)",
+                "INSERT INTO projects (p_project, p_timestamp, p_count) "
+                "VALUES (%(p_project)s, %(p_timestamp)s, %(p_count)s)",
                 projects,
             )
             cursor.executemany(
@@ -156,6 +157,22 @@ class ProjectTest(BaseWebTestcase):
             data = json.loads(rv.data)
             self.assertEqual(101, len(data))
 
+    def test_list_excludes_empty_projects(self):
+        with self.wp10db.cursor() as cursor:
+            cursor.execute(
+                "INSERT INTO projects (p_project, p_timestamp, p_count) "
+                "VALUES ('Empty_Redirect_Project', '20100101000000', 0)"
+            )
+        self.wp10db.commit()
+
+        with self.override_db(self.app), self.app.test_client() as client:
+            rv = client.get("/v1/projects/")
+            data = json.loads(rv.data)
+            self.assertEqual(101, len(data))
+            self.assertNotIn(
+                "Empty Redirect Project", [project["name"] for project in data]
+            )
+
     def test_individual_project(self):
         with self.override_db(self.app), self.app.test_client() as client:
             rv = client.get("/v1/projects/Project 0")
@@ -170,6 +187,19 @@ class ProjectTest(BaseWebTestcase):
             self.assertEqual("404 NOT FOUND", rv.status)
 
     def test_count(self):
+        with self.override_db(self.app), self.app.test_client() as client:
+            rv = client.get("/v1/projects/count")
+            data = json.loads(rv.data)
+            self.assertEqual(101, data["count"])
+
+    def test_count_excludes_empty_projects(self):
+        with self.wp10db.cursor() as cursor:
+            cursor.execute(
+                "INSERT INTO projects (p_project, p_timestamp, p_count) "
+                "VALUES ('Empty_Redirect_Project', '20100101000000', 0)"
+            )
+        self.wp10db.commit()
+
         with self.override_db(self.app), self.app.test_client() as client:
             rv = client.get("/v1/projects/count")
             data = json.loads(rv.data)


### PR DESCRIPTION
Fixes #425

Leftover category redirects from renamed WikiProjects (e.g. `Category:Beyoncé Knowles articles by quality`) produce projects with zero articles. These rows were still served by `/v1/projects/`, so the frontend autocomplete offered dead-end projects next to the real one, and they inflated the project count.

`list_all_projects` and `count_projects` now filter `p_count > 0`. The count change also affects the published on-wiki bot count (`User:WP 1.0 bot/Data/Count`) — redirects are not projects.

Tests added for both the logic functions and the `/v1/projects/` + `/v1/projects/count` endpoints.

Written with AI assistance (Claude).