### PR TITLE
Return JSON error messages from API error statuses

### DIFF
--- a/wp1/web/app.py
+++ b/wp1/web/app.py
@@ -7,6 +7,7 @@ import flask_cors
 import flask_gzip
 import redis
 from flask_session import Session
+from werkzeug.exceptions import HTTPException
 
 import wp1.logic.project as logic_project
 from wp1 import environment
@@ -88,6 +89,12 @@ def create_app(session_type="redis"):
             # pymysql raises if the connection is closed twice.
             conn = flask.g.pop("wp10db")
             conn.close()
+
+    @app.errorhandler(HTTPException)
+    def handle_http_exception(e):
+        # Return errors as JSON, with the description passed to flask.abort()
+        # (or the werkzeug default), instead of the default HTML error page.
+        return flask.jsonify({"error": e.description}), e.code
 
     @app.route("/")
     def index():

--- a/wp1/web/app_test.py
+++ b/wp1/web/app_test.py
@@ -19,3 +19,11 @@ class AppTest(BaseWebTestcase):
         with self.override_db(self.app), self.app.test_client() as client:
             rv = client.get("/v1/openapi.yml")
             self.assertTrue(b"title: 'WP 1.0 Frontend'" in rv.data)
+
+    def test_http_errors_return_json_body(self):
+        with self.override_db(self.app), self.app.test_client() as client:
+            rv = client.get("/v1/no/such/endpoint")
+            self.assertEqual("404 NOT FOUND", rv.status)
+            data = rv.get_json()
+            self.assertIsNotNone(data)
+            self.assertIn("error", data)

--- a/wp1/web/articles.py
+++ b/wp1/web/articles.py
@@ -20,4 +20,6 @@ def redirect():
             "%sindex.php?title=%s&oldid=%s" % (FRONTEND_WIKI_BASE, name, revid)
         )
 
-    return flask.abort(404)
+    return flask.abort(
+        404, "No revision found for the given article name and timestamp"
+    )

--- a/wp1/web/builders.py
+++ b/wp1/web/builders.py
@@ -45,7 +45,7 @@ def _create_or_update_builder(wp10db, data, builder_id=None):
         builder_cls = logic_builder.get_builder_module_class(model)
     except ImportError as e:
         logger.warning(str(e))
-        flask.abort(400)
+        flask.abort(400, "Unrecognized builder model: %s" % model)
 
     user_id = flask.session["user"]["identity"]["sub"]
     builder_obj = builder_cls()
@@ -77,7 +77,7 @@ def _create_or_update_builder(wp10db, data, builder_id=None):
     # Either the builder was not found or the user ID was not correct. Nothing was
     # updated, return 404.
     if builder_id is None:
-        flask.abort(404)
+        flask.abort(404, "Builder not found or is not owned by you")
 
     builder = logic_builder.get_builder(wp10db, builder_id)
 
@@ -115,7 +115,7 @@ def get_builder(builder_id):
     try:
         builder = logic_builder.get_builder(wp10db, builder_id)
     except ObjectNotFoundError:
-        flask.abort(404)
+        flask.abort(404, "No builder found with id = %s" % builder_id)
 
     # Don't return the builder unless it belongs to this user.
     user = flask.session.get("user")
@@ -151,9 +151,9 @@ def get_builder_delete_impact(builder_id):
     try:
         impact = logic_builder.get_builder_delete_impact(wp10db, user_id, builder_id)
     except UserNotAuthorizedError:
-        flask.abort(403)
+        flask.abort(403, "Builder with id = %s does not belong to you" % builder_id)
     except ObjectNotFoundError:
-        flask.abort(404)
+        flask.abort(404, "No builder found with id = %s" % builder_id)
 
     return flask.jsonify(impact)
 
@@ -181,9 +181,9 @@ def delete_builder(builder_id):
             confirm_builder_name=confirm_builder_name,
         )
     except UserNotAuthorizedError as e:
-        flask.abort(403)
+        flask.abort(403, "Builder with id = %s does not belong to you" % builder_id)
     except ObjectNotFoundError:
-        flask.abort(404)
+        flask.abort(404, "No builder found with id = %s" % builder_id)
     except BuilderDeleteConfirmationError as e:
         return flask.jsonify({"error_messages": [str(e)]}), 400
 
@@ -204,7 +204,10 @@ def latest_selection_for_builder(builder_id, ext):
 
     url = logic_builder.latest_selection_url(wp10db, builder_id, ext)
     if not url:
-        flask.abort(404)
+        flask.abort(
+            404,
+            "No %s selection found for builder with id = %s" % (ext, builder_id),
+        )
 
     return flask.redirect(url, code=302)
 
@@ -215,7 +218,10 @@ def latest_zimfarm_selection_for_builder(builder_id, ext):
 
     url = logic_builder.latest_selection_url(wp10db, builder_id, ext, zimfarm_s3=True)
     if not url:
-        flask.abort(404)
+        flask.abort(
+            404,
+            "No %s selection found for builder with id = %s" % (ext, builder_id),
+        )
 
     return flask.redirect(url, code=302)
 
@@ -243,7 +249,7 @@ def latest_selection_article_count_for_builder(builder_id):
         wp10db, builder_id, EXT_TO_CONTENT_TYPE["tsv"]
     )
     if not selection:
-        flask.abort(404)
+        flask.abort(404, "No TSV selection found for builder with id = %s" % builder_id)
 
     return flask.jsonify(
         {
@@ -356,12 +362,12 @@ def update_zimfarm_status():
     token = CREDENTIALS[ENV].get("ZIMFARM", {}).get("hook_token")
     provided_token = flask.request.args.get("token")
     if token and provided_token != token:
-        flask.abort(403)
+        flask.abort(403, "Missing or invalid token")
 
     data = flask.request.get_json()
     task_id = data.get("id")
     if task_id is None:
-        flask.abort(400)
+        flask.abort(400, "Missing task id ('id') in request data")
 
     wp10db = get_db("wp10db")
 
@@ -402,11 +408,11 @@ def latest_zim_file_for_builder(builder_id):
 
     url = logic_builder.latest_zim_file_url_for(wp10db, builder_id)
     if not url:
-        flask.abort(404)
+        flask.abort(404, "No ZIM file found for builder with id = %s" % builder_id)
 
     head = requests.head(url)
     if head.status_code == 404:
-        flask.abort(410)
+        flask.abort(410, "ZIM file has expired and is no longer available")
 
     return flask.redirect(url, code=302)
 

--- a/wp1/web/builders_test.py
+++ b/wp1/web/builders_test.py
@@ -235,6 +235,9 @@ class BuildersTest(BaseWebTestcase):
             rv = client.get("/v1/builders/1234")
 
             self.assertEqual("404 NOT FOUND", rv.status)
+            self.assertEqual(
+                {"error": "No builder found with id = 1234"}, rv.get_json()
+            )
 
     def test_get_builder_unauthorized(self):
         self.app = create_app()

--- a/wp1/web/projects.py
+++ b/wp1/web/projects.py
@@ -43,7 +43,7 @@ def project(project_name):
     project_name_bytes = project_name.encode("utf-8")
     project = logic_project.get_project_by_name(wp10db, project_name_bytes)
     if project is None:
-        return flask.abort(404)
+        return flask.abort(404, "Project with name %s not found" % project_name)
 
     return flask.jsonify(project.to_web_dict())
 
@@ -54,7 +54,7 @@ def table(project_name):
     project_name_bytes = project_name.encode("utf-8")
     project = logic_project.get_project_by_name(wp10db, project_name_bytes)
     if project is None:
-        return flask.abort(404)
+        return flask.abort(404, "Project with name %s not found" % project_name)
 
     data = tables.generate_project_table_data(wp10db, project_name_bytes)
     logger = logging.getLogger(__name__)
@@ -72,7 +72,7 @@ def category_links(project_name):
     project_name_bytes = project_name.encode("utf-8")
     project = logic_project.get_project_by_name(wp10db, project_name_bytes)
     if project is None:
-        return flask.abort(404)
+        return flask.abort(404, "Project with name %s not found" % project_name)
 
     data = tables.generate_project_table_data(wp10db, project_name_bytes)
     data = tables.get_project_category_links(data)
@@ -86,7 +86,7 @@ def category_links_sorted(project_name):
     project_name_bytes = project_name.encode("utf-8")
     project = logic_project.get_project_by_name(wp10db, project_name_bytes)
     if project is None:
-        return flask.abort(404)
+        return flask.abort(404, "Project with name %s not found" % project_name)
     data = tables.generate_project_table_data(wp10db, project_name_bytes)
     data = tables.get_project_category_links(data, sort=True)
 
@@ -129,9 +129,9 @@ def _positive_int_param(name, default):
     try:
         value = int(value)
     except ValueError:
-        flask.abort(400)
+        flask.abort(400, "Parameter %s must be an integer, was: %s" % (name, value))
     if value < 1:
-        flask.abort(400)
+        flask.abort(400, "Parameter %s must be positive, was: %s" % (name, value))
     return value
 
 
@@ -146,7 +146,7 @@ def _project_b_args(wp10db):
         return None, None, None, None
     project_b_name_bytes = project_b_name.encode("utf-8")
     if logic_project.get_project_by_name(wp10db, project_b_name_bytes) is None:
-        flask.abort(404)
+        flask.abort(404, "Project with name %s not found" % project_b_name)
     return (
         project_b_name,
         project_b_name_bytes,
@@ -161,7 +161,7 @@ def articles(project_name):
     project_name_bytes = project_name.encode("utf-8")
     project = logic_project.get_project_by_name(wp10db, project_name_bytes)
     if project is None:
-        return flask.abort(404)
+        return flask.abort(404, "Project with name %s not found" % project_name)
 
     project_b_name, project_b_name_bytes, quality_b, importance_b = _project_b_args(
         wp10db
@@ -182,12 +182,16 @@ def articles(project_name):
 
     response_format = flask.request.args.get("format", "json")
     if response_format not in ("json", "tsv"):
-        return flask.abort(400)
+        return flask.abort(
+            400, "Unrecognized format: %s (must be json or tsv)" % response_format
+        )
 
     if response_format == "tsv":
         # TSV export is not supported for projectB comparisons.
         if project_b_name is not None:
-            return flask.abort(400)
+            return flask.abort(
+                400, "TSV export is not supported for projectB comparisons"
+            )
         ratings = logic_rating.iterate_project_rating_by_type(
             wp10db,
             project_name_bytes,
@@ -251,7 +255,7 @@ def random_article(project_name):
     project_name_bytes = project_name.encode("utf-8")
     project = logic_project.get_project_by_name(wp10db, project_name_bytes)
     if project is None:
-        return flask.abort(404)
+        return flask.abort(404, "Project with name %s not found" % project_name)
 
     quality = flask.request.args.get("quality")
     importance = flask.request.args.get("importance")
@@ -280,7 +284,7 @@ def update(project_name):
     project_name_bytes = project_name.encode("utf-8")
     project = logic_project.get_project_by_name(wp10db, project_name_bytes)
     if project is None:
-        return flask.abort(404)
+        return flask.abort(404, "Project with name %s not found" % project_name)
 
     redis = get_redis()
 
@@ -299,7 +303,7 @@ def update_time(project_name):
     project_name_bytes = project_name.encode("utf-8")
     project = logic_project.get_project_by_name(wp10db, project_name_bytes)
     if project is None:
-        return flask.abort(404)
+        return flask.abort(404, "Project with name %s not found" % project_name)
 
     redis = get_redis()
 
@@ -313,7 +317,7 @@ def update_progress(project_name):
     project_name_bytes = project_name.encode("utf-8")
     project = logic_project.get_project_by_name(wp10db, project_name_bytes)
     if project is None:
-        return flask.abort(404)
+        return flask.abort(404, "Project with name %s not found" % project_name)
 
     redis = get_redis()
 

--- a/wp1/web/projects_test.py
+++ b/wp1/web/projects_test.py
@@ -168,6 +168,10 @@ class ProjectTest(BaseWebTestcase):
         with self.override_db(self.app), self.app.test_client() as client:
             rv = client.get("/v1/projects/Fee Fa Fo Project")
             self.assertEqual("404 NOT FOUND", rv.status)
+            self.assertEqual(
+                {"error": "Project with name Fee Fa Fo Project not found"},
+                rv.get_json(),
+            )
 
     def test_count(self):
         with self.override_db(self.app), self.app.test_client() as client:


### PR DESCRIPTION
Fixes #587.

Bare `flask.abort(xxx)` calls returned werkzeug's default HTML error page with no useful information for API clients. This PR:

- Registers a global `HTTPException` handler in `create_app` so every error status returns JSON `{"error": "<description>"}` instead of HTML (also covers the `@authenticate` 401 and 404s for unknown routes).
- Gives each bare `abort()` call a specific description, e.g. `Project with name X not found`, `No builder found with id = 1234`, `ZIM file has expired and is no longer available`.

Endpoints that already returned `{"error_messages": [...]}` bodies are unchanged.

Written with AI assistance (Claude).