### PR TITLE
dotenv migration stage 3a: migrate mechanical bulk of consumers to get_settings()

### DIFF
--- a/cron_config.py
+++ b/cron_config.py
@@ -11,7 +11,7 @@ Cron strings are evaluated in UTC (RQ uses rq.utils.now(), which is UTC).
 from rq import cron
 
 from wp1 import constants, maintenance
-from wp1.credentials import ENV
+from wp1.config import get_settings
 from wp1.environment import Environment
 from wp1.logic import rating as logic_rating
 
@@ -35,7 +35,7 @@ cron.register(
 # pipeline to drive; this matches the old workers image, where dev ran no
 # system cron). All three go to the single-worker 'maintenance' queue, which
 # serializes them if one runs long.
-if ENV == Environment.PRODUCTION:
+if get_settings().ENV == Environment.PRODUCTION:
     cron.register(
         maintenance.enqueue_all,
         "maintenance",

--- a/wp1/api.py
+++ b/wp1/api.py
@@ -7,18 +7,18 @@ import tempfile
 import mwclient
 import requests
 
-from wp1.credentials import CREDENTIALS, ENV
+from wp1.config import get_settings
 
 logger = logging.getLogger(__name__)
 MW_USER_AGENT = "WP1.0Bot/3.0. Run by User:Audiodude. Using mwclient/0.11.0"
 
 
 def get_credentials():
-    try:
-        return CREDENTIALS[ENV]["API"]
-    except KeyError:
+    settings = get_settings()
+    if not settings.API_USER:
         # No credentials, probably in development environment.
-        pass
+        return None
+    return {"user": settings.API_USER, "pass": settings.API_PASSWORD}
 
 
 site = None

--- a/wp1/app_logging.py
+++ b/wp1/app_logging.py
@@ -4,13 +4,16 @@ from wp1.config import get_settings
 
 
 def configure_logging():
-    log_config = get_settings().LOGGING
+    settings = get_settings()
+    log_config = settings.LOGGING
 
+    # The LOGGING dict's '*' entry (per-logger overrides, code-only) wins
+    # over the flat env-backed root logger settings.
     root_config = log_config.get(
         "*",
         {
-            "level": "INFO",
-            "format": "%(levelname)s:%(asctime)s:%(name)s:%(message)s",
+            "level": settings.LOGGING_LEVEL,
+            "format": settings.LOGGING_FORMAT,
         },
     )
 

--- a/wp1/app_logging.py
+++ b/wp1/app_logging.py
@@ -1,11 +1,10 @@
 import logging
 
-from wp1.credentials import CREDENTIALS, ENV
+from wp1.config import get_settings
 
 
 def configure_logging():
-    creds = CREDENTIALS.get(ENV, {})
-    log_config = creds.get("LOGGING", {})
+    log_config = get_settings().LOGGING
 
     root_config = log_config.get(
         "*",

--- a/wp1/app_logging_test.py
+++ b/wp1/app_logging_test.py
@@ -32,3 +32,21 @@ class AppLoggingTest:
             ("root", logging.WARNING, "root warning message"),
             ("wp1.component", logging.ERROR, "component error message"),
         ]
+
+    @override_settings(LOGGING_LEVEL="DEBUG")
+    def test_root_level_from_settings(self, caplog):
+        configure_logging()
+
+        root = logging.getLogger()
+        root.debug("root debug message")
+
+        assert ("root", logging.DEBUG, "root debug message") in caplog.record_tuples
+
+    @override_settings(LOGGING_LEVEL="WARNING")
+    def test_root_level_from_settings_suppresses(self, caplog):
+        configure_logging()
+
+        root = logging.getLogger()
+        root.info("root info message")
+
+        assert caplog.record_tuples == []

--- a/wp1/app_logging_test.py
+++ b/wp1/app_logging_test.py
@@ -1,26 +1,20 @@
 import logging
-from unittest.mock import patch
 
 from wp1.app_logging import configure_logging
-from wp1.environment import Environment
+from wp1.config import override_settings
 
 
 class AppLoggingTest:
     """This is a pytest test class, because we want to use the `caplog` fixture."""
 
-    @patch(
-        "wp1.app_logging.CREDENTIALS",
-        {
-            Environment.TEST: {
-                "LOGGING": {
-                    "*": {
-                        "level": "DEBUG",
-                        "format": "%(levelname)s:test:%(message)s",
-                    },
-                    "wp1.component": {"level": "INFO"},
-                },
-            }
-        },
+    @override_settings(
+        LOGGING={
+            "*": {
+                "level": "DEBUG",
+                "format": "%(levelname)s:test:%(message)s",
+            },
+            "wp1.component": {"level": "INFO"},
+        }
     )
     def test_configure_logging(self, caplog):
         configure_logging()

--- a/wp1/base_db_test.py
+++ b/wp1/base_db_test.py
@@ -5,13 +5,19 @@ import unittest
 
 import pymysql
 
-from wp1.credentials import CREDENTIALS, ENV
+from wp1.config import get_settings
 from wp1.environment import Environment
 from wp1.models.wp10.rating import Rating
 from wp1.models.wp10.selection import Selection
 from wp1.redis_db import connect as redis_connect
 
 logger = logging.getLogger(__name__)
+
+# The settings installed by the conftest.py bootstrap, captured at import
+# time. DB connections and the TEST-env guard are deliberately pinned to
+# these so that a per-test override_settings(...) (e.g. of ENV) can never
+# redirect database connections away from the test databases.
+_bootstrap_settings = get_settings()
 
 
 _sql_cache = {}
@@ -159,19 +165,20 @@ class WpOneAssertions(unittest.TestCase):
 class BaseWpOneDbTest(WpOneAssertions):
 
     def connect_wp_one_db(self):
-        if ENV != Environment.TEST:
+        settings = _bootstrap_settings
+        if settings.ENV != Environment.TEST:
             raise ValueError(
                 "Database tests destroy data! They should only be run in the TEST env"
             )
-        creds = CREDENTIALS.get(Environment.TEST, {}).get("WP10DB")
-        if creds is None:
-            raise ValueError("No WP10DB creds found")
-
         return pymysql.connect(
-            **creds,
+            user=settings.WP10DB_USER,
+            password=settings.WP10DB_PASSWORD,
+            host=settings.WP10DB_HOST,
+            port=settings.WP10DB_PORT,
+            db=settings.WP10DB_DB,
             charset=None,
             use_unicode=False,
-            cursorclass=pymysql.cursors.DictCursor
+            cursorclass=pymysql.cursors.DictCursor,
         )
 
     def _cleanup_wp_one_db(self):
@@ -186,7 +193,7 @@ class BaseWpOneDbTest(WpOneAssertions):
         _reset_tables(self.wp10db, "wp10_test.up.sql", "wp10_test.down.sql")
 
     def connect_redis_db(self):
-        if ENV != Environment.TEST:
+        if _bootstrap_settings.ENV != Environment.TEST:
             raise ValueError(
                 "Database tests destroy data! They should only be run in the TEST env"
             )
@@ -211,19 +218,20 @@ class BaseWpOneDbTest(WpOneAssertions):
 class BaseWikiDbTest(WpOneAssertions):
 
     def connect_wiki_db(self):
-        if ENV != Environment.TEST:
+        settings = _bootstrap_settings
+        if settings.ENV != Environment.TEST:
             raise ValueError(
                 "Database tests destroy data! They should only be run in the TEST env"
             )
-        creds = CREDENTIALS.get(Environment.TEST, {}).get("WIKIDB")
-        if creds is None:
-            raise ValueError("No WIKIDB creds found")
-
         return pymysql.connect(
-            **creds,
+            user=settings.WIKIDB_USER,
+            password=settings.WIKIDB_PASSWORD,
+            host=settings.WIKIDB_HOST,
+            port=settings.WIKIDB_PORT,
+            db=settings.WIKIDB_DB,
             charset=None,
             use_unicode=False,
-            cursorclass=pymysql.cursors.DictCursor
+            cursorclass=pymysql.cursors.DictCursor,
         )
 
     def _cleanup_wiki_db(self):

--- a/wp1/conf.py
+++ b/wp1/conf.py
@@ -2,12 +2,15 @@ import os
 
 import json
 
-from wp1.credentials import CONF_LANG
+from wp1.config import get_settings
 
 
 def _get_conf_path():
     return os.path.join(
-        os.path.dirname(os.path.dirname(__file__)), "conf", CONF_LANG, "conf.json"
+        os.path.dirname(os.path.dirname(__file__)),
+        "conf",
+        get_settings().CONF_LANG,
+        "conf.json",
     )
 
 

--- a/wp1/db.py
+++ b/wp1/db.py
@@ -8,7 +8,7 @@ import pymysql.cursors
 import pymysql.err
 import socks
 
-from wp1.credentials import CREDENTIALS, ENV
+from wp1.config import get_settings
 from wp1.environment import Environment
 
 logger = logging.getLogger(__name__)
@@ -16,28 +16,46 @@ logger = logging.getLogger(__name__)
 RETRY_TIME_SECONDS = 5
 
 
-def connect(db_name: str, **overrides: object) -> pymysql.connections.Connection:
-    creds = CREDENTIALS[ENV].get(db_name)
-    if creds is None:
-        raise ValueError("db credentials for %r in ENV=%s are None" % (db_name, ENV))
+def _db_kwargs(db_name: str) -> dict[str, object]:
+    """Explicit mapping from the runtime database name to settings values."""
+    s = get_settings()
+    if db_name == "WIKIDB":
+        return {
+            "user": s.WIKIDB_USER,
+            "password": s.WIKIDB_PASSWORD or "",
+            "host": s.WIKIDB_HOST,
+            "db": s.WIKIDB_DB,
+            "port": s.WIKIDB_PORT or 3306,
+        }
+    if db_name == "WP10DB":
+        return {
+            "user": s.WP10DB_USER,
+            "password": s.WP10DB_PASSWORD or "",
+            "host": s.WP10DB_HOST,
+            "db": s.WP10DB_DB,
+            "port": s.WP10DB_PORT or 3306,
+        }
+    raise ValueError("Unknown database name: %r" % db_name)
 
+
+def connect(db_name: str, **overrides: object) -> pymysql.connections.Connection:
     kwargs: dict[str, object] = {
         "charset": None,
         "use_unicode": False,
         "cursorclass": pymysql.cursors.SSDictCursor,
-        **creds,
+        **_db_kwargs(db_name),
         **overrides,
     }
 
     tries = 4
     while True:
         try:
-            if db_name == "WIKIDB" and ENV == Environment.DEVELOPMENT:
+            if db_name == "WIKIDB" and get_settings().ENV == Environment.DEVELOPMENT:
                 # In development, connect through a SOCKS5 proxy so that hosts on
                 # *.eqiad.wmflabs can be reached.
                 s = socks.socksocket()
                 s.set_proxy(socks.SOCKS5, "localhost")
-                s.connect((kwargs["host"], kwargs.get("port", 3306)))
+                s.connect((kwargs["host"], kwargs["port"]))
                 conn = pymysql.connect(**kwargs, defer_connect=True)
                 conn.connect(sock=s)
             else:

--- a/wp1/db_test.py
+++ b/wp1/db_test.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 import pymysql.err
 import socks
 
+from wp1.config import override_settings
 from wp1.environment import Environment
 
 
@@ -15,15 +16,11 @@ class DbTest(unittest.TestCase):
         self.assertIsNotNone(connect("WP10DB"))
         self.assertIsNotNone(connect("WIKIDB"))
 
-    @patch("wp1.db.ENV", Environment.PRODUCTION)
-    def test_exception_thrown_with_empty_creds(self):
+    def test_exception_thrown_with_unknown_db_name(self):
         from wp1.db import connect
 
         with self.assertRaises(ValueError):
-            connect("WP10DB")
-
-        with self.assertRaises(ValueError):
-            self.assertIsNotNone(connect("WIKIDB"))
+            connect("NOT_A_DB")
 
     @patch("wp1.db.pymysql.connect")
     @patch("wp1.db.time.sleep")
@@ -37,7 +34,7 @@ class DbTest(unittest.TestCase):
 
     @patch("wp1.db.pymysql.connect")
     @patch("wp1.db.socks.socksocket")
-    @patch("wp1.db.ENV", Environment.DEVELOPMENT)
+    @override_settings(ENV=Environment.DEVELOPMENT)
     def test_socks_proxy(self, mock_socket, mock_connect):
         from wp1.db import connect
 
@@ -56,7 +53,7 @@ class DbTest(unittest.TestCase):
 
     @patch("wp1.db.pymysql.connect")
     @patch("wp1.db.socks.socksocket")
-    @patch("wp1.db.ENV", Environment.DEVELOPMENT)
+    @override_settings(ENV=Environment.DEVELOPMENT)
     def test_socks_proxy_not_used(self, mock_socket, mock_connect):
         from wp1.db import connect
 

--- a/wp1/logic/builder.py
+++ b/wp1/logic/builder.py
@@ -23,7 +23,7 @@ from wp1.constants import (
     EXT_TO_CONTENT_TYPE,
     TS_FORMAT_WP10,
 )
-from wp1.credentials import CREDENTIALS, ENV
+from wp1.config import get_settings
 from wp1.environment import Environment
 from wp1.exceptions import (
     BuilderDeleteConfirmationError,
@@ -777,9 +777,9 @@ def latest_url_for(builder_id: str, content_type: str) -> str | None:
             content_type,
         )
         return None
-    server_url = CREDENTIALS.get(ENV, {}).get("CLIENT_URL", {}).get("api")
+    server_url = get_settings().CLIENT_API_URL
     if server_url is None:
-        logger.warning("Could not determine server API URL. Check credentials.py")
+        logger.warning("Could not determine server API URL. Check configuration.")
         return None
     return "%s/v1/builders/%s/selection/latest.%s" % (server_url, builder_id, ext)
 
@@ -798,10 +798,10 @@ def latest_zimfarm_url_for(builder_id: str, content_type: str) -> str | None:
             content_type,
         )
         return None
-    server_url = CREDENTIALS.get(ENV, {}).get("CLIENT_URL", {}).get("backend")
+    server_url = get_settings().CLIENT_BACKEND_URL
     if server_url is None:
         logger.warning(
-            "Could not determine server backend URL for Zimfarm. Check credentials.py"
+            "Could not determine server backend URL for Zimfarm. Check configuration."
         )
         return None
     return "%s/v1/builders/%s/selection/zimfarm/latest.%s" % (
@@ -813,9 +813,9 @@ def latest_zimfarm_url_for(builder_id: str, content_type: str) -> str | None:
 
 def local_url_for_latest_zim(builder_id: str) -> str | None:
     """Returns the redirect URL for the latest ZIM file for a builder."""
-    server_url = CREDENTIALS.get(ENV, {}).get("CLIENT_URL", {}).get("api")
+    server_url = get_settings().CLIENT_API_URL
     if server_url is None:
-        logger.warning("Could not determine server API URL. Check credentials.py")
+        logger.warning("Could not determine server API URL. Check configuration.")
         return None
     return "%s/v1/builders/%s/zim/latest" % (server_url, builder_id)
 
@@ -879,9 +879,7 @@ def latest_selection_url(
     # In production, the keys 's3' and 'backend_s3' should be the same.
     s3_public_url = None
     if zimfarm_s3:
-        backend_s3 = CREDENTIALS.get(ENV, {}).get("CLIENT_URL", {}).get("backend_s3")
-        if backend_s3 is not None:
-            s3_public_url = str(backend_s3)
+        s3_public_url = get_settings().CLIENT_BACKEND_S3_URL
     return logic_selection.url_for(selection.s_object_key, s3_public_url=s3_public_url)
 
 

--- a/wp1/logic/builder_test.py
+++ b/wp1/logic/builder_test.py
@@ -6,6 +6,7 @@ import attr
 from redis.exceptions import RedisError
 
 from wp1.base_db_test import BaseWpOneDbTest
+from wp1.config import override_settings
 from wp1.environment import Environment
 from wp1.exceptions import (
     BuilderDeleteConfirmationError,
@@ -982,7 +983,7 @@ class BuilderTest(BaseWpOneDbTest):
         actual = logic_builder.latest_url_for(150, "foo/bar-baz")
         self.assertIsNone(actual)
 
-    @patch("wp1.logic.builder.CREDENTIALS", {})
+    @override_settings(CLIENT_API_URL=None)
     def test_latest_url_for_no_server_url(self):
         actual = logic_builder.latest_url_for(15, "text/tab-separated-values")
         self.assertIsNone(actual)

--- a/wp1/logic/selection.py
+++ b/wp1/logic/selection.py
@@ -9,19 +9,13 @@ import attr
 from pymysql.connections import Connection
 
 from wp1.constants import CONTENT_TYPE_TO_EXT, TS_FORMAT_WP10, ZIM_FILE_TTL
-from wp1.credentials import CREDENTIALS, ENV
+from wp1.config import get_settings
 from wp1.logic import util
 from wp1.models.wp10.selection import Selection
 from wp1.storage import connect_storage
 from wp1.timestamp import utcnow
 
-# str() collapses the union that ty infers for the adapter dict values
-# (str | int | None); the 's3' value is always a string when present.
-S3_PUBLIC_URL: str = str(
-    CREDENTIALS.get(ENV, {})
-    .get("CLIENT_URL", {})
-    .get("s3", "http://credentials.not.found.fake")
-)
+S3_PUBLIC_URL = get_settings().CLIENT_S3_URL or "http://credentials.not.found.fake"
 
 DEFAULT_SELECTION_NAME = "selection"
 

--- a/wp1/logic/zim_schedules.py
+++ b/wp1/logic/zim_schedules.py
@@ -9,7 +9,7 @@ from redis import Redis
 import wp1.queues as queues
 
 from wp1.constants import TS_FORMAT_WP10, SECONDS_PER_MONTH
-from wp1.credentials import CREDENTIALS, ENV
+from wp1.config import get_settings
 from wp1.timestamp import utcnow
 from wp1.models.wp10.builder import Builder
 from wp1.models.wp10.zim_schedule import ZimSchedule
@@ -338,7 +338,7 @@ def schedule_future_zimfile_generations(
         )
 
         token = zim_schedule.s_email_confirmation_token.decode("utf-8")
-        email_confirm_url = CREDENTIALS.get(ENV, {}).get("CLIENT_URL", {}).get("api")
+        email_confirm_url = get_settings().CLIENT_API_URL
         confirm_url = f"{email_confirm_url}/v1/zim/confirm-email?token={token}"
         unsubscribe_url = f"{email_confirm_url}/v1/zim/unsubscribe-email?token={token}"
         send_zim_email_confirmation(

--- a/wp1/maintenance.py
+++ b/wp1/maintenance.py
@@ -15,7 +15,7 @@ from rq.registry import StartedJobRegistry
 
 import wp1.logic.project as logic_project
 from wp1 import constants, queues, tables
-from wp1.credentials import ENV
+from wp1.config import get_settings
 from wp1.environment import Environment
 from wp1.redis_db import connect as redis_connect
 from wp1.wiki_db import connect as wiki_connect
@@ -72,7 +72,7 @@ def enqueue_global():
     redis = redis_connect()
     upload_q = Queue("upload", connection=redis)
 
-    if ENV == Environment.PRODUCTION:
+    if get_settings().ENV == Environment.PRODUCTION:
         logger.info("Enqueuing global table upload")
         upload_q.enqueue(tables.upload_global_table, job_timeout=constants.JOB_TIMEOUT)
 

--- a/wp1/maintenance_test.py
+++ b/wp1/maintenance_test.py
@@ -6,6 +6,7 @@ from rq.registry import StartedJobRegistry
 
 from wp1 import maintenance
 from wp1.base_db_test import BaseWpOneDbTest
+from wp1.config import override_settings
 from wp1.environment import Environment
 
 
@@ -26,7 +27,7 @@ class MaintenanceTest(BaseWpOneDbTest):
         mock_restart.assert_called_once_with()
         mock_enqueue_all.assert_called_once_with(self.redis, self.wp10db)
 
-    @patch("wp1.maintenance.ENV", Environment.PRODUCTION)
+    @override_settings(ENV=Environment.PRODUCTION)
     def test_enqueue_global_production(self):
         with patch("wp1.maintenance.redis_connect", return_value=self.redis):
             maintenance.enqueue_global()
@@ -34,7 +35,7 @@ class MaintenanceTest(BaseWpOneDbTest):
         # Global table upload plus global project count.
         self.assertEqual(2, Queue("upload", connection=self.redis).count)
 
-    @patch("wp1.maintenance.ENV", Environment.DEVELOPMENT)
+    @override_settings(ENV=Environment.DEVELOPMENT)
     def test_enqueue_global_development(self):
         with patch("wp1.maintenance.redis_connect", return_value=self.redis):
             maintenance.enqueue_global()

--- a/wp1/queues.py
+++ b/wp1/queues.py
@@ -19,7 +19,7 @@ from wp1.wiki_db import connect as wiki_connect
 from wp1 import logs
 from wp1 import tables
 from wp1.timestamp import utcnow
-from wp1.credentials import ENV
+from wp1.config import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -171,7 +171,7 @@ def enqueue_project(project_name, update_q, upload_q, redis=None, track_progress
         failure_ttl=constants.JOB_FAILURE_TTL,
     )
     set_project_update_job_id(redis, project_name, update_job.id)
-    if ENV == Environment.PRODUCTION:
+    if get_settings().ENV == Environment.PRODUCTION:
         logger.info("Enqueuing upload (dependent) %s", project_name)
         upload_q.enqueue(
             tables.upload_project_table,

--- a/wp1/queues_test.py
+++ b/wp1/queues_test.py
@@ -6,6 +6,7 @@ from rq.registry import ScheduledJobRegistry
 
 from wp1 import constants, queues
 from wp1.base_db_test import BaseWpOneDbTest
+from wp1.config import override_settings
 from wp1.environment import Environment
 from wp1 import queues
 from wp1.selection.models.simple import Builder as SimpleBuilder
@@ -21,7 +22,7 @@ class QueuesTest(BaseWpOneDbTest):
     def tearDown(self):
         super().tearDown()
 
-    @patch("wp1.queues.ENV", Environment.DEVELOPMENT)
+    @override_settings(ENV=Environment.DEVELOPMENT)
     @patch("wp1.queues.logic_project.update_project_by_name")
     def test_enqueue_project_development(self, mock_project_fn):
         update_q = MagicMock()
@@ -38,7 +39,7 @@ class QueuesTest(BaseWpOneDbTest):
         )
         upload_q.enqueue.assert_not_called()
 
-    @patch("wp1.queues.ENV", Environment.PRODUCTION)
+    @override_settings(ENV=Environment.PRODUCTION)
     @patch("wp1.queues.logic_project.update_project_by_name")
     @patch("wp1.queues.tables.upload_project_table")
     @patch("wp1.queues.logs.update_log_page_for_project")
@@ -76,7 +77,7 @@ class QueuesTest(BaseWpOneDbTest):
             failure_ttl=constants.JOB_FAILURE_TTL,
         )
 
-    @patch("wp1.queues.ENV", Environment.DEVELOPMENT)
+    @override_settings(ENV=Environment.DEVELOPMENT)
     @patch("wp1.queues.Queue")
     @patch("wp1.queues.enqueue_project")
     def test_enqueue_single_project(self, mock_enqueue_project, mock_queue):
@@ -93,7 +94,7 @@ class QueuesTest(BaseWpOneDbTest):
             b"Water", update_q, upload_q, redis=self.redis, track_progress=False
         )
 
-    @patch("wp1.queues.ENV", Environment.DEVELOPMENT)
+    @override_settings(ENV=Environment.DEVELOPMENT)
     @patch("wp1.queues.custom_tables.upload_custom_table_by_name")
     @patch("wp1.queues.Queue")
     @patch("wp1.queues.enqueue_project")
@@ -116,7 +117,7 @@ class QueuesTest(BaseWpOneDbTest):
             failure_ttl=constants.JOB_FAILURE_TTL,
         )
 
-    @patch("wp1.queues.ENV", Environment.DEVELOPMENT)
+    @override_settings(ENV=Environment.DEVELOPMENT)
     @patch("wp1.queues.logic_project.project_names_to_update")
     @patch("wp1.queues.custom_tables.all_custom_table_names")
     @patch("wp1.queues.wiki_connect")

--- a/wp1/redis_db.py
+++ b/wp1/redis_db.py
@@ -2,14 +2,14 @@ import logging
 
 from redis import Redis
 
-from wp1.credentials import CREDENTIALS, ENV
+from wp1.config import get_settings
 
 logger = logging.getLogger(__name__)
 
 
 def connect():
-    creds = CREDENTIALS[ENV]["REDIS"]
-    return Redis(**creds)
+    settings = get_settings()
+    return Redis(host=settings.REDIS_HOST, port=settings.REDIS_PORT)
 
 
 def gen_redis_log_key(

--- a/wp1/scores.py
+++ b/wp1/scores.py
@@ -10,7 +10,7 @@ import requests
 
 from wp1 import app_logging
 from wp1.constants import WP1_USER_AGENT
-from wp1.credentials import CREDENTIALS, ENV
+from wp1.config import get_settings
 from wp1.exceptions import Wp1ScoreProcessingError
 from wp1.time import get_current_datetime
 from wp1.wp10_db import connect as wp10_connect
@@ -52,7 +52,7 @@ def get_pageview_url(prev=False):
 
 
 def get_pageview_file_path(filename):
-    path = CREDENTIALS[ENV]["FILE_PATH"]["pageviews"]
+    path = get_settings().FILE_PATH_PAGEVIEWS
     os.makedirs(path, exist_ok=True)
     return os.path.join(path, filename)
 

--- a/wp1/storage.py
+++ b/wp1/storage.py
@@ -1,18 +1,21 @@
 import logging
 
 from kiwixstorage import KiwixStorage
-from wp1.credentials import CREDENTIALS, ENV
+from wp1.config import get_settings
 
 logger = logging.getLogger(__name__)
 
 
 def connect_storage():
-    if CREDENTIALS[ENV].get("STORAGE") is None:
-        raise ValueError("storage (s3) credentials in ENV=%s are None" % ENV)
-    creds = CREDENTIALS[ENV]["STORAGE"]
+    settings = get_settings()
+    if not settings.STORAGE_KEY or not settings.STORAGE_SECRET:
+        raise ValueError(
+            "storage (s3) credentials are not configured (STORAGE_KEY/STORAGE_SECRET)"
+        )
     connect_str = (
-        "%(url)s/?keyId=%(key)s&secretAccessKey=%(secret)s&bucketName=%(bucket)s"
-        % creds
+        f"{settings.STORAGE_URL or ''}/?keyId={settings.STORAGE_KEY}"
+        f"&secretAccessKey={settings.STORAGE_SECRET}"
+        f"&bucketName={settings.STORAGE_BUCKET}"
     )
     s3 = KiwixStorage(connect_str)
     s3.check_credentials(list_buckets=True, bucket=True, write=True, read=True)

--- a/wp1/storage_test.py
+++ b/wp1/storage_test.py
@@ -1,60 +1,42 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from wp1.environment import Environment
+from wp1.config import override_settings
 from wp1.storage import connect_storage
 
 
 class StorageTest(unittest.TestCase):
 
-    @patch("wp1.storage.CREDENTIALS", {Environment.TEST: {}})
-    @patch("wp1.storage.ENV", Environment.TEST)
+    @override_settings(STORAGE_KEY="", STORAGE_SECRET="")
     def test_connect_storage_raises_if_no_credentials(self):
         with self.assertRaises(ValueError):
-            actual = connect_storage()
+            connect_storage()
 
-    @patch("wp1.storage.CREDENTIALS", {Environment.TEST: {}})
-    @patch("wp1.storage.ENV", Environment.TEST)
+    @override_settings(STORAGE_KEY="")
     def test_connect_storage_raises_if_no_storage_key(self):
         with self.assertRaises(ValueError):
-            actual = connect_storage()
+            connect_storage()
 
-    @patch(
-        "wp1.storage.CREDENTIALS",
-        {
-            Environment.TEST: {
-                "STORAGE": {
-                    "url": "https://test.wasabisys.fake",
-                    "key": "test_key",
-                    "secret": "test_secret",
-                    "bucket": "org-kiwix-dev-wp1",
-                }
-            }
-        },
+    @override_settings(
+        STORAGE_URL="https://test.wasabisys.fake",
+        STORAGE_KEY="test_key",
+        STORAGE_SECRET="test_secret",
+        STORAGE_BUCKET="org-kiwix-dev-wp1",
     )
-    @patch("wp1.storage.ENV", Environment.TEST)
     @patch("wp1.storage.KiwixStorage")
     def test_connect_storage_connects_to_kiwixstorage(self, patched_kiwixstorage):
-        actual = connect_storage()
+        connect_storage()
         patched_kiwixstorage.assert_called_once_with(
             "https://test.wasabisys.fake/"
             "?keyId=test_key&secretAccessKey=test_secret&bucketName=org-kiwix-dev-wp1"
         )
 
-    @patch(
-        "wp1.storage.CREDENTIALS",
-        {
-            Environment.TEST: {
-                "STORAGE": {
-                    "url": "https://test.wasabisys.fake",
-                    "key": "test_key",
-                    "secret": "test_secret",
-                    "bucket": "org-kiwix-dev-wp1",
-                }
-            }
-        },
+    @override_settings(
+        STORAGE_URL="https://test.wasabisys.fake",
+        STORAGE_KEY="test_key",
+        STORAGE_SECRET="test_secret",
+        STORAGE_BUCKET="org-kiwix-dev-wp1",
     )
-    @patch("wp1.storage.ENV", Environment.TEST)
     @patch("wp1.storage.KiwixStorage")
     def test_connect_storage_checks_permissions(self, patched_kiwixstorage):
         s3_mock = MagicMock()

--- a/wp1/tables.py
+++ b/wp1/tables.py
@@ -10,7 +10,7 @@ from redis import Redis
 from wp1 import api, app_logging
 from wp1.conf import get_conf
 from wp1.constants import LIST_URL, LIST_V2_URL, WIKI_BASE
-from wp1.credentials import CREDENTIALS, ENV
+from wp1.config import get_settings
 from wp1.logic import project as logic_project
 from wp1.logic import util as logic_util
 from wp1.templates import env as jinja_env
@@ -20,12 +20,8 @@ logger = logging.getLogger(__name__)
 
 
 def get_redis():
-    try:
-        creds = CREDENTIALS[ENV]["REDIS"]
-        return Redis(**creds)
-    except KeyError:
-        logger.exception("Redis creds not found, returning None Redis")
-        return None
+    settings = get_settings()
+    return Redis(host=settings.REDIS_HOST, port=settings.REDIS_PORT)
 
 
 config = get_conf()

--- a/wp1/tables_test.py
+++ b/wp1/tables_test.py
@@ -776,8 +776,6 @@ class TestMakeWikiLink(unittest.TestCase):
 
 class TestTableCaching(BaseWpOneDbTest):
 
-    @patch("wp1.tables.CREDENTIALS", {"DEVELOPMENT": {"REDIS": {}}})
-    @patch("wp1.tables.ENV", "DEVELOPMENT")
     @patch("wp1.tables.Redis")
     @patch("wp1.tables.generate_table_data")
     def test_empty_cache(self, patched_table_data, patched_redis):
@@ -798,8 +796,6 @@ class TestTableCaching(BaseWpOneDbTest):
         )
         self.assertEqual(expected_table, actual)
 
-    @patch("wp1.tables.CREDENTIALS", {"DEVELOPMENT": {"REDIS": {}}})
-    @patch("wp1.tables.ENV", "DEVELOPMENT")
     @patch("wp1.tables.Redis")
     @patch("wp1.tables.generate_table_data")
     def test_full_cache(self, patched_table_data, patched_redis):

--- a/wp1/web/dev/projects.py
+++ b/wp1/web/dev/projects.py
@@ -13,29 +13,14 @@ from wp1.web import authenticate
 
 import flask
 
-from wp1.environment import Environment
+from wp1.config import get_settings
 from wp1.timestamp import utcnow
 from wp1.web.redis import get_redis
-from wp1.credentials import CREDENTIALS
 
-UPDATE_DURATION_SECS = 5 * 30
-ELAPSED_TIME_SECS = 30
-BI_DURATION_SECS = UPDATE_DURATION_SECS + ELAPSED_TIME_SECS // 2
-
-try:
-    overlay_settings = CREDENTIALS[Environment.DEVELOPMENT]["OVERLAY"]
-    UPDATE_DURATION_SECS = overlay_settings.get(
-        "update_wait_time_seconds", UPDATE_DURATION_SECS
-    )
-    ELAPSED_TIME_SECS = overlay_settings.get(
-        "job_elapsed_time_seconds", ELAPSED_TIME_SECS
-    )
-    BI_DURATION_SECS = overlay_settings.get(
-        "basic_income_total_time_seconds", BI_DURATION_SECS
-    )
-except KeyError:
-    # The default values were already set before the attempted import so nothing to do
-    pass
+_settings = get_settings()
+UPDATE_DURATION_SECS = _settings.OVERLAY_UPDATE_WAIT_TIME
+ELAPSED_TIME_SECS = _settings.OVERLAY_JOB_ELAPSED_TIME
+BI_DURATION_SECS = _settings.OVERLAY_BASIC_INCOME_TOTAL_TIME
 
 dev_projects = flask.Blueprint("dev_projects", __name__)
 

--- a/wp1/web/projects_test.py
+++ b/wp1/web/projects_test.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from wp1.logic import project as logic_project
 from wp1.web.app import create_app
 from wp1.web.base_web_testcase import BaseWebTestcase
+from wp1.config import override_settings
 from wp1.environment import Environment
 
 
@@ -503,7 +504,7 @@ class ProjectTest(BaseWebTestcase):
             rv = client.get("/v1/projects/Foo Fake Project/articles/random")
             self.assertEqual("404 NOT FOUND", rv.status)
 
-    @patch("wp1.queues.ENV", Environment.PRODUCTION)
+    @override_settings(ENV=Environment.PRODUCTION)
     @patch("wp1.queues.utcnow", return_value=datetime(2018, 12, 25, 5, 55, 55))
     def test_update(self, patched_now):
         with self.override_db(self.app), self.app.test_client() as client:
@@ -515,13 +516,13 @@ class ProjectTest(BaseWebTestcase):
             data = json.loads(rv.data)
             self.assertEqual("2018-12-25 06:55 UTC", data["next_update_time"])
 
-    @patch("wp1.queues.ENV", Environment.PRODUCTION)
+    @override_settings(ENV=Environment.PRODUCTION)
     def test_update_unauthorized_user(self):
         with self.app.test_client() as client:
             rv = client.post("/v1/projects/Project 0/update")
         self.assertEqual("401 UNAUTHORIZED", rv.status)
 
-    @patch("wp1.queues.ENV", Environment.PRODUCTION)
+    @override_settings(ENV=Environment.PRODUCTION)
     @patch("wp1.queues.utcnow", return_value=datetime(2018, 12, 25, 5, 55, 55))
     def test_update_404(self, patched_now):
         with self.override_db(self.app), self.app.test_client() as client:
@@ -530,7 +531,7 @@ class ProjectTest(BaseWebTestcase):
             rv = client.post("/v1/projects/Foo Bar Baz/update")
             self.assertEqual("404 NOT FOUND", rv.status)
 
-    @patch("wp1.queues.ENV", Environment.PRODUCTION)
+    @override_settings(ENV=Environment.PRODUCTION)
     @patch("wp1.queues.utcnow", return_value=datetime(2018, 12, 25, 5, 55, 55))
     def test_update_second_time_fails(self, patched_now):
         with self.override_db(self.app):
@@ -549,7 +550,7 @@ class ProjectTest(BaseWebTestcase):
                 data = json.loads(rv.data)
                 self.assertEqual("2018-12-25 06:55 UTC", data["next_update_time"])
 
-    @patch("wp1.queues.ENV", Environment.PRODUCTION)
+    @override_settings(ENV=Environment.PRODUCTION)
     @patch("wp1.queues.utcnow", return_value=datetime(2018, 12, 25, 5, 55, 55))
     def test_update_time(self, patched_now):
         with self.override_db(self.app), self.app.test_client() as client:
@@ -559,14 +560,14 @@ class ProjectTest(BaseWebTestcase):
             data = json.loads(rv.data)
             self.assertEqual(None, data["next_update_time"])
 
-    @patch("wp1.queues.ENV", Environment.PRODUCTION)
+    @override_settings(ENV=Environment.PRODUCTION)
     @patch("wp1.queues.utcnow", return_value=datetime(2018, 12, 25, 5, 55, 55))
     def test_update_time_404(self, patched_now):
         with self.override_db(self.app), self.app.test_client() as client:
             rv = client.get("/v1/projects/Foo Bar Baz/update/time")
             self.assertEqual("404 NOT FOUND", rv.status)
 
-    @patch("wp1.queues.ENV", Environment.PRODUCTION)
+    @override_settings(ENV=Environment.PRODUCTION)
     @patch("wp1.queues.utcnow", return_value=datetime(2018, 12, 25, 5, 55, 55))
     def test_update_time_active(self, patched_now):
         with self.override_db(self.app):
@@ -594,7 +595,7 @@ class ProjectTest(BaseWebTestcase):
             self.assertIsNone(data["queue"])
             self.assertIsNone(data["job"])
 
-    @patch("wp1.queues.ENV", Environment.PRODUCTION)
+    @override_settings(ENV=Environment.PRODUCTION)
     def test_update_progress(self):
         with self.override_db(self.app), self.app.test_client() as client:
             with client.session_transaction() as sess:
@@ -609,13 +610,13 @@ class ProjectTest(BaseWebTestcase):
             self.assertIsNone(data["job"])
             self.assertEqual({"status": "queued"}, data["queue"])
 
-    @patch("wp1.queues.ENV", Environment.PRODUCTION)
+    @override_settings(ENV=Environment.PRODUCTION)
     def test_update_progress_404(self):
         with self.override_db(self.app), self.app.test_client() as client:
             rv = client.get("/v1/projects/Foo Bar Baz/update/progress")
             self.assertEqual("404 NOT FOUND", rv.status)
 
-    @patch("wp1.queues.ENV", Environment.PRODUCTION)
+    @override_settings(ENV=Environment.PRODUCTION)
     def test_update_progress_return_job_progress(self):
         with self.override_db(self.app), self.app.test_client() as client:
             expected_total = 100
@@ -632,7 +633,7 @@ class ProjectTest(BaseWebTestcase):
             self.assertEqual(expected_total, data["job"]["total"])
             self.assertEqual(expected_progress, data["job"]["progress"])
 
-    @patch("wp1.queues.ENV", Environment.PRODUCTION)
+    @override_settings(ENV=Environment.PRODUCTION)
     @patch("wp1.web.projects.logic_project.get_project_progress")
     def test_update_progress_progress_not_ints(self, patched_progress):
         patched_progress.return_value = (b"a", b"b")

--- a/wp1/web/redis.py
+++ b/wp1/web/redis.py
@@ -2,7 +2,7 @@ import logging
 
 import flask
 from redis import Redis
-from wp1.credentials import CREDENTIALS, ENV
+from wp1.config import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -13,6 +13,8 @@ def has_redis():
 
 def get_redis():
     if not has_redis():
-        creds = CREDENTIALS[ENV]["REDIS"]
-        setattr(flask.g, "redis", Redis(**creds))
+        settings = get_settings()
+        setattr(
+            flask.g, "redis", Redis(host=settings.REDIS_HOST, port=settings.REDIS_PORT)
+        )
     return getattr(flask.g, "redis")


### PR DESCRIPTION
Part of #1292 (stage 3a). Stacked on #1294. Must not deploy before the stage-2 ops item in #1292 is verified.

Mechanical consumer migration: conf, api, app_logging, db, redis_db, scores, storage, tables, queues, maintenance, cron_config, logic/{builder,selection,zim_schedules}, base_db_test, web/redis, dev overlay. The two known non-mechanical spots from the spec: `db.connect` gets an explicit name→settings mapping, and Redis constructors take explicit kwargs instead of dict splats.

Tests swap `@patch("wp1.<mod>.ENV", ...)` / CREDENTIALS patching for `override_settings(...)`. `base_db_test` pins its connections and TEST-env guard to the bootstrap settings so a per-test override can never redirect DB connections.

🤖 Implemented with Claude Code.