### PR TITLE
dotenv migration stage 3b: zimfarm + email cluster and test rewrite

### DIFF
--- a/wp1/web/emails.py
+++ b/wp1/web/emails.py
@@ -2,7 +2,7 @@ import requests
 import logging
 
 from wp1 import zimfarm
-from wp1.credentials import CREDENTIALS, ENV
+from wp1.config import get_settings
 from wp1.logic import zim_schedules
 from wp1.models.wp10.zim_file import ZimTask
 from wp1.models.wp10.zim_schedule import ZimSchedule
@@ -22,8 +22,8 @@ def send_zim_ready_email(
 ):
     """Sends an email notification when a ZIM file is ready for download."""
 
-    mailgun_config = CREDENTIALS.get(ENV, {}).get("MAILGUN", {})
-    if not mailgun_config or not mailgun_config.get("api_key"):
+    settings = get_settings()
+    if not settings.MAILGUN_API_KEY:
         logger.warning("Mailgun not configured. Email not sent.")
         return False
 
@@ -51,8 +51,8 @@ def send_zim_ready_email(
 
     try:
         response = requests.post(
-            mailgun_config["url"],
-            auth=("api", mailgun_config["api_key"]),
+            settings.MAILGUN_URL,
+            auth=("api", settings.MAILGUN_API_KEY),
             data=email_data,
             timeout=30,
         )
@@ -100,7 +100,7 @@ def notify_user_for_scheduled_zim(wp10db, zim_file: ZimTask, zim_schedule: ZimSc
     ):
         next_generation_months = zim_schedule.s_interval
 
-    email_confirm_url = CREDENTIALS.get(ENV, {}).get("CLIENT_URL", {}).get("api")
+    email_confirm_url = get_settings().CLIENT_API_URL
     unsubscribe_url = f"{email_confirm_url}/api/v1/zim/unsubscribe-notification?schedule_id={zim_schedule.s_id.decode('utf-8')}"
 
     send_zim_ready_email(

--- a/wp1/web/emails_confirmation.py
+++ b/wp1/web/emails_confirmation.py
@@ -1,7 +1,7 @@
 import requests
 import logging
 
-from wp1.credentials import CREDENTIALS, ENV
+from wp1.config import get_settings
 from wp1.templates import env as jinja_env
 
 logger = logging.getLogger(__name__)
@@ -18,8 +18,8 @@ def send_zim_email_confirmation(
 ):
     """Sends an email confirmation for ZIM file notifications."""
 
-    mailgun_config = CREDENTIALS.get(ENV, {}).get("MAILGUN", {})
-    if not mailgun_config or not mailgun_config.get("api_key"):
+    settings = get_settings()
+    if not settings.MAILGUN_API_KEY:
         logger.warning("Mailgun not configured. Confirmation email not sent.")
         return False
 
@@ -47,8 +47,8 @@ def send_zim_email_confirmation(
 
     try:
         response = requests.post(
-            mailgun_config["url"],
-            auth=("api", mailgun_config["api_key"]),
+            settings.MAILGUN_URL,
+            auth=("api", settings.MAILGUN_API_KEY),
             data=email_data,
             timeout=30,
         )

--- a/wp1/web/emails_confirmation_test.py
+++ b/wp1/web/emails_confirmation_test.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, Mock, MagicMock
 import uuid
 
 from wp1.base_db_test import BaseWpOneDbTest
+from wp1.config import override_settings
 from wp1.web.emails import respond_to_zim_task_completed
 from wp1.web.emails_confirmation import send_zim_email_confirmation
 from wp1.models.wp10.zim_file import ZimTask
@@ -93,19 +94,13 @@ class EmailConfirmationTest(BaseWpOneDbTest):
         mock_notify.assert_not_called()  # Should NOT send email
 
     @patch("wp1.web.emails_confirmation.requests.post")
-    @patch("wp1.web.emails_confirmation.CREDENTIALS")
-    @patch("wp1.web.emails_confirmation.ENV", "test")
+    @override_settings(
+        MAILGUN_API_KEY="test-api-key",
+        MAILGUN_URL="https://api.mailgun.net/v3/test.com/messages",
+    )
     @patch("wp1.web.emails_confirmation.jinja_env")
-    def test_send_zim_email_confirmation_success(
-        self, mock_jinja_env, mock_credentials, mock_post
-    ):
+    def test_send_zim_email_confirmation_success(self, mock_jinja_env, mock_post):
         """Test successful confirmation email sending."""
-        mock_credentials.get.return_value = {
-            "MAILGUN": {
-                "api_key": "test-api-key",
-                "url": "https://api.mailgun.net/v3/test.com/messages",
-            }
-        }
 
         mock_template = Mock()
         mock_template.render.return_value = "<html>Confirmation email content</html>"
@@ -158,11 +153,9 @@ class EmailConfirmationTest(BaseWpOneDbTest):
         self.assertIn("confirm your email address", email_data["text"])
         self.assertEqual(email_data["html"], "<html>Confirmation email content</html>")
 
-    @patch("wp1.web.emails.CREDENTIALS")
-    @patch("wp1.web.emails.ENV", "test")
-    def test_send_zim_email_confirmation_no_mailgun_config(self, mock_credentials):
+    @override_settings(MAILGUN_API_KEY="")
+    def test_send_zim_email_confirmation_no_mailgun_config(self):
         """Test confirmation email sending when Mailgun is not configured."""
-        mock_credentials.get.return_value = {}
 
         result = send_zim_email_confirmation(
             recipient_username="testuser",
@@ -176,20 +169,14 @@ class EmailConfirmationTest(BaseWpOneDbTest):
 
         self.assertFalse(result)
 
-    @patch("wp1.web.emails.requests.post")
-    @patch("wp1.web.emails.CREDENTIALS")
-    @patch("wp1.web.emails.ENV", "test")
-    @patch("wp1.web.emails.jinja_env")
-    def test_send_zim_email_confirmation_api_error(
-        self, mock_jinja_env, mock_credentials, mock_post
-    ):
+    @patch("wp1.web.emails_confirmation.requests.post")
+    @override_settings(
+        MAILGUN_API_KEY="test-api-key",
+        MAILGUN_URL="https://api.mailgun.net/v3/test.com/messages",
+    )
+    @patch("wp1.web.emails_confirmation.jinja_env")
+    def test_send_zim_email_confirmation_api_error(self, mock_jinja_env, mock_post):
         """Test confirmation email sending when API returns error."""
-        mock_credentials.get.return_value = {
-            "MAILGUN": {
-                "api_key": "test-api-key",
-                "url": "https://api.mailgun.net/v3/test.com/messages",
-            }
-        }
 
         mock_template = Mock()
         mock_template.render.return_value = "<html>Confirmation email content</html>"

--- a/wp1/web/emails_test.py
+++ b/wp1/web/emails_test.py
@@ -2,6 +2,7 @@ import uuid
 from unittest.mock import ANY, MagicMock, Mock, patch
 
 from wp1.base_db_test import BaseWpOneDbTest
+from wp1.config import override_settings
 from wp1.constants import TS_FORMAT_WP10
 from wp1.models.wp10.zim_file import ZimTask
 from wp1.models.wp10.zim_schedule import ZimSchedule
@@ -73,17 +74,13 @@ class EmailsTest(BaseWpOneDbTest):
         self.wp10db.commit()
 
     @patch("wp1.web.emails.requests.post")
-    @patch("wp1.web.emails.CREDENTIALS")
-    @patch("wp1.web.emails.ENV", "test")
+    @override_settings(
+        MAILGUN_API_KEY="test-api-key",
+        MAILGUN_URL="https://api.mailgun.net/v3/test.com/messages",
+    )
     @patch("wp1.web.emails.jinja_env")
-    def test_send_zim_ready_email(self, mock_jinja_env, mock_credentials, mock_post):
+    def test_send_zim_ready_email(self, mock_jinja_env, mock_post):
         """Test successful email sending."""
-        mock_credentials.get.return_value = {
-            "MAILGUN": {
-                "api_key": "test-api-key",
-                "url": "https://api.mailgun.net/v3/test.com/messages",
-            }
-        }
 
         mock_template = Mock()
         mock_template.render.return_value = "<html>Test email content</html>"
@@ -137,19 +134,13 @@ class EmailsTest(BaseWpOneDbTest):
         self.assertEqual(email_data["html"], "<html>Test email content</html>")
 
     @patch("wp1.web.emails.requests.post")
-    @patch("wp1.web.emails.CREDENTIALS")
-    @patch("wp1.web.emails.ENV", "test")
+    @override_settings(
+        MAILGUN_API_KEY="test-api-key",
+        MAILGUN_URL="https://api.mailgun.net/v3/test.com/messages",
+    )
     @patch("wp1.web.emails.jinja_env")
-    def test_send_zim_ready_email_with_defaults(
-        self, mock_jinja_env, mock_credentials, mock_post
-    ):
+    def test_send_zim_ready_email_with_defaults(self, mock_jinja_env, mock_post):
         """Test email sending with default URLs."""
-        mock_credentials.get.return_value = {
-            "MAILGUN": {
-                "api_key": "test-api-key",
-                "url": "https://api.mailgun.net/v3/test.com/messages",
-            }
-        }
 
         mock_template = Mock()
         mock_template.render.return_value = "<html>Test email content</html>"
@@ -177,11 +168,9 @@ class EmailsTest(BaseWpOneDbTest):
             next_generation_months=None,
         )
 
-    @patch("wp1.web.emails.CREDENTIALS")
-    @patch("wp1.web.emails.ENV", "test")
-    def test_send_zim_ready_email_no_mailgun_config(self, mock_credentials):
+    @override_settings(MAILGUN_API_KEY="")
+    def test_send_zim_ready_email_no_mailgun_config(self):
         """Test email sending when Mailgun is not configured."""
-        mock_credentials.get.return_value = {}
 
         result = send_zim_ready_email(
             recipient_username="testuser",
@@ -192,13 +181,12 @@ class EmailsTest(BaseWpOneDbTest):
 
         self.assertFalse(result)
 
-    @patch("wp1.web.emails.CREDENTIALS")
-    @patch("wp1.web.emails.ENV", "test")
-    def test_send_zim_ready_email_no_api_key(self, mock_credentials):
+    @override_settings(
+        MAILGUN_API_KEY="",
+        MAILGUN_URL="https://api.mailgun.net/v3/test.com/messages",
+    )
+    def test_send_zim_ready_email_no_api_key(self):
         """Test email sending when API key is missing."""
-        mock_credentials.get.return_value = {
-            "MAILGUN": {"url": "https://api.mailgun.net/v3/test.com/messages"}
-        }
 
         result = send_zim_ready_email(
             recipient_username="testuser",
@@ -210,19 +198,13 @@ class EmailsTest(BaseWpOneDbTest):
         self.assertFalse(result)
 
     @patch("wp1.web.emails.requests.post")
-    @patch("wp1.web.emails.CREDENTIALS")
-    @patch("wp1.web.emails.ENV", "test")
+    @override_settings(
+        MAILGUN_API_KEY="test-api-key",
+        MAILGUN_URL="https://api.mailgun.net/v3/test.com/messages",
+    )
     @patch("wp1.web.emails.jinja_env")
-    def test_send_zim_ready_email_api_error(
-        self, mock_jinja_env, mock_credentials, mock_post
-    ):
+    def test_send_zim_ready_email_api_error(self, mock_jinja_env, mock_post):
         """Test email sending when API returns an error."""
-        mock_credentials.get.return_value = {
-            "MAILGUN": {
-                "api_key": "test-api-key",
-                "url": "https://api.mailgun.net/v3/test.com/messages",
-            }
-        }
 
         mock_template = Mock()
         mock_template.render.return_value = "<html>Test email content</html>"
@@ -243,19 +225,13 @@ class EmailsTest(BaseWpOneDbTest):
         self.assertFalse(result)
 
     @patch("wp1.web.emails.requests.post")
-    @patch("wp1.web.emails.CREDENTIALS")
-    @patch("wp1.web.emails.ENV", "test")
+    @override_settings(
+        MAILGUN_API_KEY="test-api-key",
+        MAILGUN_URL="https://api.mailgun.net/v3/test.com/messages",
+    )
     @patch("wp1.web.emails.jinja_env")
-    def test_send_zim_ready_email_request_exception(
-        self, mock_jinja_env, mock_credentials, mock_post
-    ):
+    def test_send_zim_ready_email_request_exception(self, mock_jinja_env, mock_post):
         """Test email sending when request raises an exception."""
-        mock_credentials.get.return_value = {
-            "MAILGUN": {
-                "api_key": "test-api-key",
-                "url": "https://api.mailgun.net/v3/test.com/messages",
-            }
-        }
 
         mock_template = Mock()
         mock_template.render.return_value = "<html>Test email content</html>"

--- a/wp1/zimfarm.py
+++ b/wp1/zimfarm.py
@@ -13,7 +13,7 @@ import wp1.logic.selection as logic_selection
 import wp1.logic.zim_schedules as logic_zim_schedules
 from wp1 import constants
 from wp1.constants import WP1_USER_AGENT
-from wp1.credentials import CREDENTIALS, ENV
+from wp1.config import get_settings
 from wp1.exceptions import (
     InvalidZimDescriptionError,
     InvalidZimFlavourError,
@@ -30,6 +30,13 @@ from wp1.models.wp10.zim_schedule import ZimSchedule
 from wp1.timestamp import naive_utcnow
 
 REDIS_AUTH_KEY = "zimfarm.auth"
+
+# Timeout in seconds for requests to the Zimfarm API.
+REQUESTS_TIMEOUT = 30
+
+# Renew the Zimfarm access token when it is within this many seconds of
+# expiring.
+TOKEN_RENEWAL_WINDOW = 300
 
 # ZIM metadata limits as per https://wiki.openzim.org/wiki/Metadata
 ZIM_TITLE_MAX_LENGTH = 30
@@ -71,52 +78,56 @@ class ZimfarmClientTokenProvider:
         self._access_token: str | None = None
         self._refresh_token: str | None = None
         self._expires_at: datetime = datetime.fromtimestamp(0, UTC).replace(tzinfo=None)
-        self._zimfarm_creds: dict[str, Any] = CREDENTIALS[ENV].get("ZIMFARM", {})
+
+    @property
+    def _settings(self):
+        return get_settings()
 
     def _validate_creds(self):
-        if self._zimfarm_creds.get("auth_mode") == "local":
-            if not (
-                self._zimfarm_creds.get("user") and self._zimfarm_creds.get("password")
-            ):
+        settings = self._settings
+        if settings.ZIMFARM_AUTH_MODE == "local":
+            if not (settings.ZIMFARM_USER and settings.ZIMFARM_PASSWORD):
                 raise ZimFarmError(
-                    "user and password must be set in Zimfarm site credentials "
-                    "when auth mode is 'local' "
+                    "ZIMFARM_USER and ZIMFARM_PASSWORD must be set "
+                    "when ZIMFARM_AUTH_MODE is 'local'"
                 )
-        elif self._zimfarm_creds.get("auth_mode") == "oauth":
+        elif settings.ZIMFARM_AUTH_MODE == "oauth":
             if not (
-                self._zimfarm_creds.get("oauth_issuer")
-                and self._zimfarm_creds.get("oauth_client_id")
-                and self._zimfarm_creds.get("oauth_client_secret")
-                and self._zimfarm_creds.get("oauth_audience_id")
+                settings.ZIMFARM_OAUTH_ISSUER
+                and settings.ZIMFARM_OAUTH_CLIENT_ID
+                and settings.ZIMFARM_OAUTH_CLIENT_SECRET
+                and settings.ZIMFARM_OAUTH_AUDIENCE_ID
             ):
                 raise ZimFarmError(
-                    "oauth_client_secret, oauth_client_id and oauth_audience_id must be set "
-                    "in Zimfarm site credentials when auth mode is 'oauth'"
+                    "ZIMFARM_OAUTH_CLIENT_SECRET, ZIMFARM_OAUTH_CLIENT_ID and "
+                    "ZIMFARM_OAUTH_AUDIENCE_ID must be set "
+                    "when ZIMFARM_AUTH_MODE is 'oauth'"
                 )
         else:
             raise ZimFarmError(
-                f"Unknown auth mode {self._zimfarm_creds.get('auth_mode')}. "
+                f"Unknown auth mode {settings.ZIMFARM_AUTH_MODE}. "
                 "Allowed values are 'local' and 'oauth'."
             )
 
     def _generate_oauth_access_token(self) -> None:
         """Generate oauth access token and update expires_at."""
 
+        settings = self._settings
         logger.debug(
             "Requesting auth token from %s with oauth credentials",
-            self._zimfarm_creds.get("oauth_issuer"),
+            settings.ZIMFARM_OAUTH_ISSUER,
         )
         response = requests.post(
-            f"{self._zimfarm_creds.get('oauth_issuer')}/oauth2/token",
+            f"{settings.ZIMFARM_OAUTH_ISSUER}/oauth2/token",
             data={
                 "grant_type": "client_credentials",
-                "audience": self._zimfarm_creds.get("oauth_audience_id"),
+                "audience": settings.ZIMFARM_OAUTH_AUDIENCE_ID,
             },
             auth=HTTPBasicAuth(
-                self._zimfarm_creds.get("oauth_client_id"),
-                self._zimfarm_creds.get("oauth_client_secret"),
+                settings.ZIMFARM_OAUTH_CLIENT_ID,
+                settings.ZIMFARM_OAUTH_CLIENT_SECRET,
             ),
-            timeout=self._zimfarm_creds.get("requests_timeout", 30),
+            timeout=REQUESTS_TIMEOUT,
             headers={"User-Agent": WP1_USER_AGENT},
         )
 
@@ -140,7 +151,7 @@ class ZimfarmClientTokenProvider:
                 json={
                     "refresh_token": self._refresh_token,
                 },
-                timeout=self._zimfarm_creds.get("requests_timeout", 30),
+                timeout=REQUESTS_TIMEOUT,
                 headers={"User-Agent": WP1_USER_AGENT},
             )
         else:
@@ -151,10 +162,10 @@ class ZimfarmClientTokenProvider:
             response = requests.post(
                 f"{get_zimfarm_url()}/auth/authorize",
                 json={
-                    "username": self._zimfarm_creds.get("user"),
-                    "password": self._zimfarm_creds.get("password"),
+                    "username": self._settings.ZIMFARM_USER,
+                    "password": self._settings.ZIMFARM_PASSWORD,
                 },
-                timeout=self._zimfarm_creds.get("requests_timeout", 30),
+                timeout=REQUESTS_TIMEOUT,
                 headers={"User-Agent": WP1_USER_AGENT},
             )
 
@@ -186,13 +197,12 @@ class ZimfarmClientTokenProvider:
 
         now = naive_utcnow()
         if self._access_token is None or now >= (
-            self._expires_at
-            - timedelta(seconds=self._zimfarm_creds.get("token_renewal_window", 300))
+            self._expires_at - timedelta(seconds=TOKEN_RENEWAL_WINDOW)
         ):
             logger.debug("Refreshing Zimfarm acess token")
-            if self._zimfarm_creds.get("auth_mode") == "oauth":
+            if self._settings.ZIMFARM_AUTH_MODE == "oauth":
                 self._generate_oauth_access_token()
-            elif self._zimfarm_creds.get("auth_mode") == "local":
+            elif self._settings.ZIMFARM_AUTH_MODE == "local":
                 self._generate_local_access_token()
 
             if self._access_token:
@@ -214,21 +224,20 @@ token_provider = ZimfarmClientTokenProvider()
 
 
 def get_zimfarm_url():
-    url = CREDENTIALS[ENV].get("ZIMFARM", {}).get("url")
+    url = get_settings().ZIMFARM_URL
     if url is None:
-        raise ZimFarmError(
-            'CREDENTIALS did not contain ["ZIMFARM"]["url"], environment = %s' % ENV
-        )
+        raise ZimFarmError("Configuration error, ZIMFARM_URL is not set")
     return url
 
 
 def get_webhook_url():
-    token = CREDENTIALS[ENV].get("ZIMFARM", {}).get("hook_token")
+    settings = get_settings()
+    token = settings.ZIMFARM_HOOK_TOKEN
     if token is None:
         return None
 
-    base_url = CREDENTIALS[ENV].get("CLIENT_URL", {}).get("backend")
-    if base_url is None:
+    base_url = settings.CLIENT_BACKEND_URL
+    if not base_url:
         return None
 
     return "%s/v1/builders/zim/status?token=%s" % (base_url, urllib.parse.quote(token))
@@ -299,12 +308,10 @@ def get_zim_filename_prefix(builder: Builder, selection: Selection) -> str:
 
 
 def _get_image_name_and_tag() -> tuple[str, str]:
-    image = CREDENTIALS[ENV].get("ZIMFARM", {}).get("image")
+    image = get_settings().ZIMFARM_IMAGE or None
     if image is None:
         image = "ghcr.io/openzim/mwoffliner:latest"
-        logger.warning(
-            'No ZIMFARM["image"] found in credentials, using latest (%s)', image
-        )
+        logger.warning("ZIMFARM_IMAGE is not configured, using latest (%s)", image)
     return image.split(":")
 
 
@@ -338,12 +345,12 @@ def _get_offliner_flags(
     if flavour:
         flags["format"] = [ALLOWED_FLAVOURS[flavour]]
 
-    cache_url = CREDENTIALS[ENV].get("ZIMFARM", {}).get("cache_url")
+    cache_url = get_settings().ZIMFARM_CACHE_URL
     if cache_url is not None:
         flags["optimisationCacheUrl"] = cache_url
     else:
         logger.warning(
-            "No cache_url found in credentials, skipping "
+            "ZIMFARM_CACHE_URL is not configured, skipping "
             "optimisationCacheUrl URL for zimfarm request"
         )
     return flags
@@ -364,7 +371,7 @@ def _get_schedule_update_params(
     flags = _get_offliner_flags(
         builder, selection, title, description, long_description, flavour
     )
-    version = CREDENTIALS[ENV].get("ZIMFARM", {}).get("definition_version", image_tag)
+    version = get_settings().ZIMFARM_DEFINITION_VERSION or image_tag
 
     webhook_url = get_webhook_url()
 
@@ -422,7 +429,7 @@ def _get_schedule_create_params(
         "monitor": False,
         "offliner": flags,
     }
-    version = CREDENTIALS[ENV].get("ZIMFARM", {}).get("definition_version", image_tag)
+    version = get_settings().ZIMFARM_DEFINITION_VERSION or image_tag
     webhook_url = get_webhook_url()
 
     return {
@@ -698,11 +705,9 @@ def zim_file_url_for_task_id(task_id):
             "Could not get warehouse path for ZIM file, task_id = %s" % task_id
         )
 
-    base_url = CREDENTIALS[ENV].get("ZIMFARM", {}).get("s3_url")
+    base_url = get_settings().ZIMFARM_S3_URL
     if base_url is None:
-        raise ZimFarmError(
-            'Configuration error, could not find ZIMFARM["s3_url"] in credentials'
-        )
+        raise ZimFarmError("Configuration error, ZIMFARM_S3_URL is not set")
 
     return f"{base_url}{warehouse_path}/{name}"
 

--- a/wp1/zimfarm_test.py
+++ b/wp1/zimfarm_test.py
@@ -6,7 +6,7 @@ import requests
 
 from wp1 import zimfarm
 from wp1.base_db_test import BaseWpOneDbTest
-from wp1.environment import Environment
+from wp1.config import override_settings
 from wp1.exceptions import (
     InvalidZimDescriptionError,
     InvalidZimFlavourError,
@@ -190,19 +190,15 @@ class ZimFarmTest(BaseWpOneDbTest):
     def test_get_schdedule_create_params(self):
         s3 = MagicMock()
         s3.client.head_object.return_value = {"ContentLength": 20000000}
-        from wp1.zimfarm import CREDENTIALS
 
-        CREDENTIALS[Environment.TEST]["ZIMFARM"][
-            "cache_url"
-        ] = "https://wasabi.fake/bucket"
-
-        actual = zimfarm._get_schedule_create_params(
-            self.builder,
-            self.selection,
-            title="My Builder",
-            description="This is the short description",
-            long_description="This is the long description",
-        )
+        with override_settings(ZIMFARM_CACHE_URL="https://wasabi.fake/bucket"):
+            actual = zimfarm._get_schedule_create_params(
+                self.builder,
+                self.selection,
+                title="My Builder",
+                description="This is the short description",
+                long_description="This is the long description",
+            )
 
         self.maxDiff = None
         self.assertEqual(self.expected_params, actual)
@@ -210,14 +206,6 @@ class ZimFarmTest(BaseWpOneDbTest):
     def test_get_schedule_create_params_image_in_env(self):
         s3 = MagicMock()
         s3.client.head_object.return_value = {"ContentLength": 20000000}
-        from wp1.zimfarm import CREDENTIALS
-
-        CREDENTIALS[Environment.TEST]["ZIMFARM"][
-            "cache_url"
-        ] = "https://wasabi.fake/bucket"
-        CREDENTIALS[Environment.TEST]["ZIMFARM"][
-            "image"
-        ] = "ghcr.io/openzim/mwoffliner-advanced:1.23.45"
 
         expected = self.expected_params.copy()
         expected["config"]["image"] = {
@@ -226,13 +214,17 @@ class ZimFarmTest(BaseWpOneDbTest):
         }
         expected["version"] = "1.23.45"
 
-        actual = zimfarm._get_schedule_create_params(
-            self.builder,
-            self.selection,
-            title="My Builder",
-            description="This is the short description",
-            long_description="This is the long description",
-        )
+        with override_settings(
+            ZIMFARM_CACHE_URL="https://wasabi.fake/bucket",
+            ZIMFARM_IMAGE="ghcr.io/openzim/mwoffliner-advanced:1.23.45",
+        ):
+            actual = zimfarm._get_schedule_create_params(
+                self.builder,
+                self.selection,
+                title="My Builder",
+                description="This is the short description",
+                long_description="This is the long description",
+            )
 
         self.maxDiff = None
         self.assertEqual(expected, actual)
@@ -243,17 +235,14 @@ class ZimFarmTest(BaseWpOneDbTest):
                 None, self.selection, "Tile", "Desc", "Long Desc"
             )
 
-    @patch("wp1.zimfarm.CREDENTIALS")
-    def test_token_provider_init_oauth_valid(self, mock_credentials):
-        mock_credentials.__getitem__.return_value = {
-            "ZIMFARM": {
-                "auth_mode": "oauth",
-                "oauth_client_id": "test_client_id",
-                "oauth_client_secret": "test_client_secret",
-                "oauth_audience_id": "test_audience",
-                "oauth_issuer": "https://oauth.example.com",
-            }
-        }
+    @override_settings(
+        ZIMFARM_AUTH_MODE="oauth",
+        ZIMFARM_OAUTH_CLIENT_ID="test_client_id",
+        ZIMFARM_OAUTH_CLIENT_SECRET="test_client_secret",
+        ZIMFARM_OAUTH_AUDIENCE_ID="test_audience",
+        ZIMFARM_OAUTH_ISSUER="https://oauth.example.com",
+    )
+    def test_token_provider_init_oauth_valid(self):
 
         provider = ZimfarmClientTokenProvider()
         provider._validate_creds()
@@ -261,15 +250,12 @@ class ZimFarmTest(BaseWpOneDbTest):
         self.assertIsNone(provider._access_token)
         self.assertIsNone(provider._refresh_token)
 
-    @patch("wp1.zimfarm.CREDENTIALS")
-    def test_token_provider_init_local_valid(self, mock_credentials):
-        mock_credentials.__getitem__.return_value = {
-            "ZIMFARM": {
-                "auth_mode": "local",
-                "user": "test_user",
-                "password": "test_pass",
-            }
-        }
+    @override_settings(
+        ZIMFARM_AUTH_MODE="local",
+        ZIMFARM_USER="test_user",
+        ZIMFARM_PASSWORD="test_pass",
+    )
+    def test_token_provider_init_local_valid(self):
 
         provider = ZimfarmClientTokenProvider()
         provider._validate_creds()
@@ -277,56 +263,46 @@ class ZimFarmTest(BaseWpOneDbTest):
         self.assertIsNone(provider._access_token)
         self.assertIsNone(provider._refresh_token)
 
-    @patch("wp1.zimfarm.CREDENTIALS")
-    def test_token_provider_init_oauth_missing_credentials(self, mock_credentials):
-        mock_credentials.__getitem__.return_value = {
-            "ZIMFARM": {
-                "auth_mode": "oauth",
-                "oauth_client_id": "test_client_id",
-            }
-        }
+    @override_settings(
+        ZIMFARM_AUTH_MODE="oauth",
+        ZIMFARM_OAUTH_CLIENT_ID="test_client_id",
+        ZIMFARM_OAUTH_CLIENT_SECRET=None,
+        ZIMFARM_OAUTH_AUDIENCE_ID=None,
+    )
+    def test_token_provider_init_oauth_missing_credentials(self):
 
         with self.assertRaises(ZimFarmError):
             ZimfarmClientTokenProvider()._validate_creds()
 
-    @patch("wp1.zimfarm.CREDENTIALS")
-    def test_token_provider_init_local_missing_credentials(self, mock_credentials):
-        mock_credentials.__getitem__.return_value = {
-            "ZIMFARM": {
-                "auth_mode": "local",
-                "user": "test_user",
-            }
-        }
+    @override_settings(
+        ZIMFARM_AUTH_MODE="local",
+        ZIMFARM_USER="test_user",
+        ZIMFARM_PASSWORD="",
+    )
+    def test_token_provider_init_local_missing_credentials(self):
 
         with self.assertRaises(ZimFarmError):
             ZimfarmClientTokenProvider()._validate_creds()
 
-    @patch("wp1.zimfarm.CREDENTIALS")
-    def test_token_provider_init_unknown_auth_mode(self, mock_credentials):
-        mock_credentials.__getitem__.return_value = {
-            "ZIMFARM": {"auth_mode": "unknown"}
-        }
+    @override_settings(ZIMFARM_AUTH_MODE="unknown")
+    def test_token_provider_init_unknown_auth_mode(self):
 
         with self.assertRaises(ZimFarmError):
             ZimfarmClientTokenProvider()._validate_creds()
 
-    @patch("wp1.zimfarm.CREDENTIALS")
+    @override_settings(
+        ZIMFARM_AUTH_MODE="oauth",
+        ZIMFARM_OAUTH_CLIENT_ID="test_client_id",
+        ZIMFARM_OAUTH_CLIENT_SECRET="test_client_secret",
+        ZIMFARM_OAUTH_AUDIENCE_ID="test_audience",
+        ZIMFARM_OAUTH_ISSUER="https://oauth.example.com",
+    )
     @patch("wp1.zimfarm.requests")
     @patch("wp1.zimfarm.naive_utcnow")
     def test_token_provider_generate_oauth_access_token_success(
-        self, mock_naive_utcnow, mock_requests, mock_credentials
+        self, mock_naive_utcnow, mock_requests
     ):
         """Test _generate_oauth_access_token successfully generates token"""
-        mock_credentials.__getitem__.return_value = {
-            "ZIMFARM": {
-                "auth_mode": "oauth",
-                "oauth_client_id": "test_client_id",
-                "oauth_client_secret": "test_client_secret",
-                "oauth_audience_id": "test_audience",
-                "oauth_issuer": "https://oauth.example.com",
-                "requests_timeout": 30,
-            }
-        }
 
         mock_naive_utcnow.return_value = datetime.datetime(
             2023, 1, 1, 0, 0, 0, tzinfo=None
@@ -344,20 +320,15 @@ class ZimFarmTest(BaseWpOneDbTest):
         self.assertEqual(provider._access_token, "oauth_token_123")
         self.assertEqual(provider._expires_at, datetime.datetime(2023, 1, 1, 1, 0, 0))
 
-    @patch("wp1.zimfarm.CREDENTIALS")
+    @override_settings(
+        ZIMFARM_AUTH_MODE="oauth",
+        ZIMFARM_OAUTH_CLIENT_ID="test_client_id",
+        ZIMFARM_OAUTH_CLIENT_SECRET="test_client_secret",
+        ZIMFARM_OAUTH_AUDIENCE_ID="test_audience",
+        ZIMFARM_OAUTH_ISSUER="https://oauth.example.com",
+    )
     @patch("wp1.zimfarm.requests")
-    def test_token_provider_generate_oauth_access_token_http_error(
-        self, mock_requests, mock_credentials
-    ):
-        mock_credentials.__getitem__.return_value = {
-            "ZIMFARM": {
-                "auth_mode": "oauth",
-                "oauth_client_id": "test_client_id",
-                "oauth_client_secret": "test_client_secret",
-                "oauth_audience_id": "test_audience",
-                "oauth_issuer": "https://oauth.example.com",
-            }
-        }
+    def test_token_provider_generate_oauth_access_token_http_error(self, mock_requests):
 
         mock_response = MagicMock()
         mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError
@@ -369,20 +340,16 @@ class ZimFarmTest(BaseWpOneDbTest):
         with self.assertRaises(ZimFarmError):
             provider._generate_oauth_access_token()
 
-    @patch("wp1.zimfarm.CREDENTIALS")
+    @override_settings(
+        ZIMFARM_AUTH_MODE="local",
+        ZIMFARM_USER="test_user",
+        ZIMFARM_PASSWORD="test_pass",
+    )
     @patch("wp1.zimfarm.requests")
     @patch("wp1.zimfarm.get_zimfarm_url")
     def test_token_provider_generate_local_access_token_no_refresh(
-        self, mock_get_url, mock_requests, mock_credentials
+        self, mock_get_url, mock_requests
     ):
-        mock_credentials.__getitem__.return_value = {
-            "ZIMFARM": {
-                "auth_mode": "local",
-                "user": "test_user",
-                "password": "test_pass",
-                "requests_timeout": 30,
-            }
-        }
         mock_get_url.return_value = "https://fake.farm/v2"
 
         mock_response = MagicMock()
@@ -400,20 +367,16 @@ class ZimFarmTest(BaseWpOneDbTest):
         self.assertEqual(provider._refresh_token, "refresh_token_123")
         self.assertEqual(provider._expires_at, datetime.datetime(2023, 1, 1, 12, 0, 0))
 
-    @patch("wp1.zimfarm.CREDENTIALS")
+    @override_settings(
+        ZIMFARM_AUTH_MODE="local",
+        ZIMFARM_USER="test_user",
+        ZIMFARM_PASSWORD="test_pass",
+    )
     @patch("wp1.zimfarm.requests")
     @patch("wp1.zimfarm.get_zimfarm_url")
     def test_token_provider_generate_local_access_token_with_refresh(
-        self, mock_get_url, mock_requests, mock_credentials
+        self, mock_get_url, mock_requests
     ):
-        mock_credentials.__getitem__.return_value = {
-            "ZIMFARM": {
-                "auth_mode": "local",
-                "user": "test_user",
-                "password": "test_pass",
-                "requests_timeout": 30,
-            }
-        }
         mock_get_url.return_value = "https://fake.farm/v2"
 
         mock_response = MagicMock()
@@ -437,19 +400,16 @@ class ZimFarmTest(BaseWpOneDbTest):
             headers={"User-Agent": "WP 1.0 bot 1.0.0/Audiodude <audiodude@gmail.com>"},
         )
 
-    @patch("wp1.zimfarm.CREDENTIALS")
+    @override_settings(
+        ZIMFARM_AUTH_MODE="local",
+        ZIMFARM_USER="test_user",
+        ZIMFARM_PASSWORD="test_pass",
+    )
     @patch("wp1.zimfarm.requests")
     @patch("wp1.zimfarm.get_zimfarm_url")
     def test_token_provider_generate_local_access_token_http_error(
-        self, mock_get_url, mock_requests, mock_credentials
+        self, mock_get_url, mock_requests
     ):
-        mock_credentials.__getitem__.return_value = {
-            "ZIMFARM": {
-                "auth_mode": "local",
-                "user": "test_user",
-                "password": "test_pass",
-            }
-        }
         mock_get_url.return_value = "https://fake.farm/v2"
 
         mock_response = MagicMock()
@@ -462,19 +422,13 @@ class ZimFarmTest(BaseWpOneDbTest):
         with self.assertRaises(ZimFarmError):
             provider._generate_local_access_token()
 
-    @patch("wp1.zimfarm.CREDENTIALS")
+    @override_settings(
+        ZIMFARM_AUTH_MODE="local",
+        ZIMFARM_USER="test_user",
+        ZIMFARM_PASSWORD="test_pass",
+    )
     @patch("wp1.zimfarm.naive_utcnow")
-    def test_token_provider_get_access_token_not_expired(
-        self, mock_naive_utcnow, mock_credentials
-    ):
-        mock_credentials.__getitem__.return_value = {
-            "ZIMFARM": {
-                "auth_mode": "local",
-                "user": "test_user",
-                "password": "test_pass",
-                "token_renewal_window": 300,
-            }
-        }
+    def test_token_provider_get_access_token_not_expired(self, mock_naive_utcnow):
 
         mock_naive_utcnow.return_value = datetime.datetime(
             2023, 1, 1, 11, 50, 0, tzinfo=None
@@ -493,22 +447,18 @@ class ZimFarmTest(BaseWpOneDbTest):
         self.assertEqual(token, "existing_token")
         redis.hset.assert_not_called()
 
-    @patch("wp1.zimfarm.CREDENTIALS")
+    @override_settings(
+        ZIMFARM_AUTH_MODE="oauth",
+        ZIMFARM_OAUTH_CLIENT_ID="test_client_id",
+        ZIMFARM_OAUTH_CLIENT_SECRET="test_client_secret",
+        ZIMFARM_OAUTH_AUDIENCE_ID="test_audience",
+        ZIMFARM_OAUTH_ISSUER="https://oauth.example.com",
+    )
     @patch("wp1.zimfarm.naive_utcnow")
     @patch("wp1.zimfarm.requests")
     def test_token_provider_get_access_token_expired_oauth(
-        self, mock_requests, mock_naive_utcnow, mock_credentials
+        self, mock_requests, mock_naive_utcnow
     ):
-        mock_credentials.__getitem__.return_value = {
-            "ZIMFARM": {
-                "auth_mode": "oauth",
-                "oauth_client_id": "test_client_id",
-                "oauth_client_secret": "test_client_secret",
-                "oauth_audience_id": "test_audience",
-                "oauth_issuer": "https://oauth.example.com",
-                "token_renewal_window": 300,
-            }
-        }
 
         mock_naive_utcnow.return_value = datetime.datetime(
             2023, 1, 1, 12, 0, 0, tzinfo=None
@@ -534,22 +484,18 @@ class ZimFarmTest(BaseWpOneDbTest):
         self.assertEqual(token, "new_oauth_token")
         redis.hset.assert_called_once()
 
-    @patch("wp1.zimfarm.CREDENTIALS")
+    @override_settings(
+        ZIMFARM_AUTH_MODE="local",
+        ZIMFARM_USER="test_user",
+        ZIMFARM_PASSWORD="test_pass",
+    )
     @patch("wp1.zimfarm.naive_utcnow")
     @patch("wp1.zimfarm.requests")
     @patch("wp1.zimfarm.get_zimfarm_url")
     def test_token_provider_get_access_token_expired_local(
-        self, mock_get_url, mock_requests, mock_naive_utcnow, mock_credentials
+        self, mock_get_url, mock_requests, mock_naive_utcnow
     ):
         """Test get_access_token refreshes token when expired (local mode)"""
-        mock_credentials.__getitem__.return_value = {
-            "ZIMFARM": {
-                "auth_mode": "local",
-                "user": "test_user",
-                "password": "test_pass",
-                "token_renewal_window": 300,
-            }
-        }
         mock_get_url.return_value = "https://fake.farm/v2"
 
         mock_naive_utcnow.return_value = datetime.datetime(
@@ -577,21 +523,18 @@ class ZimFarmTest(BaseWpOneDbTest):
         self.assertEqual(token, "new_local_token")
         redis.hset.assert_called_once()
 
-    @patch("wp1.zimfarm.CREDENTIALS")
+    @override_settings(
+        ZIMFARM_AUTH_MODE="oauth",
+        ZIMFARM_OAUTH_CLIENT_ID="test_client_id",
+        ZIMFARM_OAUTH_CLIENT_SECRET="test_client_secret",
+        ZIMFARM_OAUTH_AUDIENCE_ID="test_audience",
+        ZIMFARM_OAUTH_ISSUER="https://oauth.example.com",
+    )
     @patch("wp1.zimfarm.naive_utcnow")
     @patch("wp1.zimfarm.requests")
     def test_token_provider_get_access_token_no_redis_data_oauth(
-        self, mock_requests, mock_naive_utcnow, mock_credentials
+        self, mock_requests, mock_naive_utcnow
     ):
-        mock_credentials.__getitem__.return_value = {
-            "ZIMFARM": {
-                "auth_mode": "oauth",
-                "oauth_client_id": "test_client_id",
-                "oauth_client_secret": "test_client_secret",
-                "oauth_audience_id": "test_audience",
-                "oauth_issuer": "https://oauth.example.com",
-            }
-        }
 
         mock_naive_utcnow.return_value = datetime.datetime(
             2023, 1, 1, 12, 0, 0, tzinfo=None
@@ -613,20 +556,17 @@ class ZimFarmTest(BaseWpOneDbTest):
         self.assertEqual(token, "fresh_oauth_token")
         redis.hset.assert_called_once()
 
-    @patch("wp1.zimfarm.CREDENTIALS")
+    @override_settings(
+        ZIMFARM_AUTH_MODE="local",
+        ZIMFARM_USER="test_user",
+        ZIMFARM_PASSWORD="test_pass",
+    )
     @patch("wp1.zimfarm.naive_utcnow")
     @patch("wp1.zimfarm.requests")
     @patch("wp1.zimfarm.get_zimfarm_url")
     def test_token_provider_get_access_token_no_redis_data_local(
-        self, mock_get_url, mock_requests, mock_naive_utcnow, mock_credentials
+        self, mock_get_url, mock_requests, mock_naive_utcnow
     ):
-        mock_credentials.__getitem__.return_value = {
-            "ZIMFARM": {
-                "auth_mode": "local",
-                "user": "test_user",
-                "password": "test_pass",
-            }
-        }
         mock_get_url.return_value = "https://fake.farm/v2"
 
         mock_naive_utcnow.return_value = datetime.datetime(
@@ -650,20 +590,15 @@ class ZimFarmTest(BaseWpOneDbTest):
         self.assertEqual(token, "fresh_local_token")
         redis.hset.assert_called_once()
 
-    @patch("wp1.zimfarm.CREDENTIALS")
+    @override_settings(
+        ZIMFARM_AUTH_MODE="oauth",
+        ZIMFARM_OAUTH_CLIENT_ID="test_client_id",
+        ZIMFARM_OAUTH_CLIENT_SECRET="test_client_secret",
+        ZIMFARM_OAUTH_AUDIENCE_ID="test_audience",
+        ZIMFARM_OAUTH_ISSUER="https://oauth.example.com",
+    )
     @patch("wp1.zimfarm.naive_utcnow")
-    def test_token_provider_get_access_token_stores_in_redis(
-        self, mock_naive_utcnow, mock_credentials
-    ):
-        mock_credentials.__getitem__.return_value = {
-            "ZIMFARM": {
-                "auth_mode": "oauth",
-                "oauth_client_id": "test_client_id",
-                "oauth_client_secret": "test_client_secret",
-                "oauth_audience_id": "test_audience",
-                "oauth_issuer": "https://oauth.example.com",
-            }
-        }
+    def test_token_provider_get_access_token_stores_in_redis(self, mock_naive_utcnow):
 
         mock_naive_utcnow.return_value = datetime.datetime(
             2023, 1, 1, 12, 0, 0, tzinfo=None
@@ -1321,7 +1256,7 @@ class ZimFarmTest(BaseWpOneDbTest):
             zimfarm.zim_file_url_for_task_id("foo-bar")
 
     @patch("wp1.zimfarm.requests.get")
-    @patch("wp1.zimfarm.CREDENTIALS", {Environment.TEST: {}})
+    @override_settings(ZIMFARM_S3_URL=None)
     def test_zim_file_url_for_task_id_missing_s3_url(self, patched_get):
         resp = MagicMock()
         resp.json.return_value = {
@@ -1634,13 +1569,8 @@ class ZimFarmTest(BaseWpOneDbTest):
         with self.assertRaises(InvalidZimFlavourError):
             zimfarm.validate_flavour("innvalid_flavour")
 
+    @override_settings(ZIMFARM_CACHE_URL="https://wasabi.fake/bucket")
     def test_get_params_with_flavour_nopic(self):
-        from wp1.zimfarm import CREDENTIALS
-
-        CREDENTIALS[Environment.TEST]["ZIMFARM"][
-            "cache_url"
-        ] = "https://wasabi.fake/bucket"
-
         actual = zimfarm._get_schedule_create_params(
             self.builder,
             self.selection,
@@ -1652,13 +1582,8 @@ class ZimFarmTest(BaseWpOneDbTest):
 
         self.assertEqual(["nopic:nopic"], actual["config"]["offliner"]["format"])
 
+    @override_settings(ZIMFARM_CACHE_URL="https://wasabi.fake/bucket")
     def test_get_params_with_flavour_mini(self):
-        from wp1.zimfarm import CREDENTIALS
-
-        CREDENTIALS[Environment.TEST]["ZIMFARM"][
-            "cache_url"
-        ] = "https://wasabi.fake/bucket"
-
         actual = zimfarm._get_schedule_create_params(
             self.builder,
             self.selection,
@@ -1670,13 +1595,8 @@ class ZimFarmTest(BaseWpOneDbTest):
 
         self.assertEqual(["nodet,nopic:mini"], actual["config"]["offliner"]["format"])
 
+    @override_settings(ZIMFARM_CACHE_URL="https://wasabi.fake/bucket")
     def test_get_params_with_flavour_maxi(self):
-        from wp1.zimfarm import CREDENTIALS
-
-        CREDENTIALS[Environment.TEST]["ZIMFARM"][
-            "cache_url"
-        ] = "https://wasabi.fake/bucket"
-
         actual = zimfarm._get_schedule_create_params(
             self.builder,
             self.selection,
@@ -1688,13 +1608,8 @@ class ZimFarmTest(BaseWpOneDbTest):
 
         self.assertEqual(["novid:maxi"], actual["config"]["offliner"]["format"])
 
+    @override_settings(ZIMFARM_CACHE_URL="https://wasabi.fake/bucket")
     def test_get_params_without_flavour_no_format(self):
-        from wp1.zimfarm import CREDENTIALS
-
-        CREDENTIALS[Environment.TEST]["ZIMFARM"][
-            "cache_url"
-        ] = "https://wasabi.fake/bucket"
-
         actual = zimfarm._get_schedule_create_params(
             self.builder,
             self.selection,


### PR DESCRIPTION
Part of #1292 (stage 3b). Stacked on #1295.

- `ZimfarmClientTokenProvider` reads live settings instead of caching a credentials dict at construction. `requests_timeout` and `token_renewal_window` (never configurable via env) become module constants (30s / 300s — the values every environment already used).
- Email senders check `MAILGUN_API_KEY` directly.
- The reviewed risk: `zimfarm_test` replaces in-place `CREDENTIALS[Environment.TEST]["ZIMFARM"][...] = ...` mutation (which leaked between tests) and MagicMock credential patching with scoped `override_settings(...)`. Email tests likewise. Behavioral assertions unchanged.

🤖 Implemented with Claude Code.