### PR TITLE
Make project table counts look clickable

### DIFF
--- a/wp1-frontend/src/components/ProjectTable.vue
+++ b/wp1-frontend/src/components/ProjectTable.vue
@@ -83,10 +83,14 @@
                   v-for="col in tableData.ordered_cols"
                   :key="col"
                   class="px-3 py-[4px] text-right"
-                  :class="{ 'font-semibold': isBoldRow(row) }"
+                  :class="{
+                    'font-semibold': isBoldRow(row),
+                    'hover:bg-accent-tint-2': tableData.data[row][col],
+                  }"
                 >
                   <router-link
                     v-if="tableData.data[row][col]"
+                    class="wt-link"
                     :to="{
                       path: `/project/${currentProject}/articles`,
                       query: { quality: row, importance: col },
@@ -96,8 +100,11 @@
                     }}</router-link
                   >
                 </td>
-                <td class="px-3 py-[4px] text-right font-semibold">
+                <td
+                  class="px-3 py-[4px] text-right font-semibold hover:bg-accent-tint-2"
+                >
                   <router-link
+                    class="wt-link"
                     :to="{
                       path: `/project/${currentProject}/articles`,
                       query: { quality: row },
@@ -120,6 +127,7 @@
                   class="wt-head px-3 py-[4px] text-right font-semibold"
                 >
                   <router-link
+                    class="wt-link"
                     :to="{
                       path: `/project/${currentProject}/articles`,
                       query: { importance: col },

--- a/wp1-frontend/src/tailwind.css
+++ b/wp1-frontend/src/tailwind.css
@@ -198,6 +198,18 @@
   .wp1r .wt-head {
     background-color: #eaecf0;
   }
+  /* Matrix counts read as links even at rest (openzim/wp1#427): dotted
+     underline resting, solid on hover. Two class selectors outweigh the
+     .wp1r a palette rules above, same trick as the button opt-outs. */
+  .wp1r a.wt-link,
+  .wp1r a.wt-link:visited {
+    text-decoration: underline dotted;
+    text-underline-offset: 3px;
+  }
+  .wp1r a.wt-link:hover {
+    text-decoration: underline solid;
+    text-underline-offset: 3px;
+  }
   /* Borderless white channel separating the two project column-groups in
      the compare table, so colour fills never touch across projects. */
   .wp1r .wt .wt-gap {


### PR DESCRIPTION
The quality/importance matrix counts have always been links, but nothing signaled it. Style them as links at rest — accent color, dotted underline, solid underline + cell tint on hover — so the affordance is discoverable without luck.

Fixes #427

Written with AI assistance (Claude).
