### PR TITLE
dotenv migration stage 2a: env-backed root logging level and format

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -210,3 +210,12 @@ MAILGUN_API_KEY=INSERT_YOUR_MAILGUN_API_KEY_HERE
 # Path where the pageviews.bz2 file (~3GB) will be downloaded and cached.
 # This file is used to calculate article view statistics.
 FILE_PATH_PAGEVIEWS=/tmp/pageviews
+
+# --- Logging ---
+# Configuration for the root logger. Logging is always done to stdout and is
+# redirected/rotated by the supervisor process.
+
+# Log level for the root logger (DEBUG, INFO, WARNING, ...).
+LOGGING_LEVEL=INFO
+# Log line format (Python logging format string).
+LOGGING_FORMAT=%(levelname)s:%(asctime)s:%(name)s:%(message)s

--- a/wp1/config.py
+++ b/wp1/config.py
@@ -412,11 +412,20 @@ class Settings:
         ),
     )
 
-    # --- Logging (code-only; not env-backed) ---
-    # Logging directives. Keys are the names of the loggers, values are
-    # dictionaries with the logging configuration. The special key '*' sets
-    # the default logging configuration. Logging is always done to stdout
-    # and is redirected/rotated by the supervisor process.
+    # --- Logging ---
+    LOGGING_LEVEL: str = _field(
+        "INFO",
+        section="Logging",
+        help="Log level for the root logger (DEBUG, INFO, WARNING, ...).",
+    )
+    LOGGING_FORMAT: str = _field(
+        "%(levelname)s:%(asctime)s:%(name)s:%(message)s",
+        section="Logging",
+        help="Log line format (Python logging format string).",
+    )
+    # Per-logger directives, code-only (not env-backed). Keys are logger
+    # names, values are dicts with the logging configuration; the special
+    # key '*' overrides the root logger config above.
     LOGGING: dict = _field({}, kind="code")
 
     @classmethod
@@ -631,6 +640,10 @@ _SECTION_DOCS = {
         "are ready. Not required for development."
     ),
     "File paths": "",
+    "Logging": (
+        "Configuration for the root logger. Logging is always done to "
+        "stdout and is\nredirected/rotated by the supervisor process."
+    ),
 }
 
 

--- a/wp1/credentials.py
+++ b/wp1/credentials.py
@@ -124,7 +124,13 @@ _active_creds = {
     "FILE_PATH": {
         "pageviews": _settings.FILE_PATH_PAGEVIEWS,
     },
-    "LOGGING": _settings.LOGGING,
+    "LOGGING": {
+        "*": {
+            "level": _settings.LOGGING_LEVEL,
+            "format": _settings.LOGGING_FORMAT,
+        },
+        **_settings.LOGGING,
+    },
 }
 
 # The CREDENTIALS dict keyed by environment


### PR DESCRIPTION
Part of #1292. Sits between the merged stage 2 (#1294) and stage 3a (#1295).

The live production credentials.py carries a `LOGGING` dict whose format string differs from the code fallback (`%(asctime)s:%(levelname)s:...` vs `%(levelname)s:%(asctime)s:...`). Without this, the prod log-line format silently changes at the cutover. Adds env-backed `LOGGING_LEVEL` / `LOGGING_FORMAT` (defaults unchanged = today's code fallbacks) wired through the adapter; the code-only `LOGGING` dict remains for per-logger overrides. Set in `wp1.env`:

```
LOGGING_FORMAT=%(asctime)s:%(levelname)s:%(name)s:%(message)s
```

🤖 Implemented with Claude Code.