### PR TITLE
Hide stale article count while a selection is re-processing

### DIFF
--- a/wp1-frontend/cypress/e2e/myLists.cy.js
+++ b/wp1-frontend/cypress/e2e/myLists.cy.js
@@ -83,6 +83,17 @@ describe('the selections page', () => {
       cy.contains('No ZIM file yet');
     });
 
+    it('hides the stale article count while the selection is re-processing', () => {
+      stubDetailFor(
+        'aafcc4a2-cd5c-4236-85ca-3a10d16f13aa',
+        'simple_builder.json'
+      );
+      cy.contains('.wp1r-railrow', 'updated list').click();
+      cy.wait('@articleCount');
+      cy.get('#detail-title').should('contain.text', 'updated list');
+      cy.contains('34 articles').should('not.exist');
+    });
+
     it('disables Create ZIM when the selection failed to materialize', () => {
       stubDetailFor(
         '7368f534-27f5-4350-bfe3-23b90363df7b',

--- a/wp1-frontend/src/components/selections/SelectionDetail.vue
+++ b/wp1-frontend/src/components/selections/SelectionDetail.vue
@@ -30,7 +30,7 @@
           <TypeBadge :model="item.model" />
           <span aria-hidden="true" class="text-ink-5">·</span>
           <span class="truncate">{{ item.project }}</span>
-          <template v-if="articleCount !== null">
+          <template v-if="showArticleCount">
             <span aria-hidden="true" class="text-ink-5">·</span>
             <span class="whitespace-nowrap"
               >{{ articleCount.toLocaleString() }} articles</span
@@ -553,6 +553,7 @@ import {
   deriveZimStatus,
   definitionText,
   selectionHasError,
+  selectionIsPending,
   tsvReady,
   definitionNote,
   describeSchedule,
@@ -608,6 +609,12 @@ export default {
     },
     selectionStatusInfo: function () {
       return deriveSelectionStatus(this.item);
+    },
+    // While the selection is (re-)materializing, the fetched count describes
+    // the previous materialization and would be stale — hide it until the
+    // s_updated_at watcher re-fetches a fresh one.
+    showArticleCount: function () {
+      return this.articleCount !== null && !selectionIsPending(this.item);
     },
     // Distinct name: `zimStatus` is the /zim/status payload in data.
     zimStatusInfo: function () {


### PR DESCRIPTION
Fixes #1309

After a definition edit, the selection re-materializes but the detail header kept showing the article count from the previous materialization. The count is now hidden while the selection is pending (same `selectionIsPending` predicate that drives the "Processing…" status dot) and reappears when the `s_updated_at` watcher re-fetches a fresh count.

Adds a Cypress test covering the pending case.

Written with Claude Code.