### PR TITLE
Reset ratings that vanish from one assessment kind's categories

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -211,6 +211,15 @@ MAILGUN_API_KEY=INSERT_YOUR_MAILGUN_API_KEY_HERE
 # This file is used to calculate article view statistics.
 FILE_PATH_PAGEVIEWS=/tmp/pageviews
 
+# --- Update process ---
+
+# TEMPORARY escape hatch: when set to 1, project updates emit no
+# assessment-change log entries (the Redis log keys that feed the
+# on-wiki log pages). Intended for a single update cycle when a fix or
+# backfill would cause a one-time wave of rating churn. Suppressed logs
+# are lost permanently, not deferred; unset after the cycle completes.
+# WP1_SUPPRESS_RATING_LOGS=0
+
 # --- Logging ---
 # Configuration for the root logger. Logging is always done to stdout and is
 # redirected/rotated by the supervisor process.

--- a/wp1/config.py
+++ b/wp1/config.py
@@ -412,6 +412,23 @@ class Settings:
         ),
     )
 
+    # --- Update process ---
+    SUPPRESS_RATING_LOGS: int | None = _field(
+        0,
+        kind="int",
+        env_key="WP1_SUPPRESS_RATING_LOGS",
+        section="Update process",
+        commented=True,
+        help=(
+            "TEMPORARY escape hatch: when set to 1, project updates emit no\n"
+            "assessment-change log entries (the Redis log keys that feed the\n"
+            "on-wiki log pages). Intended for a single update cycle when a "
+            "fix or\nbackfill would cause a one-time wave of rating churn. "
+            "Suppressed logs\nare lost permanently, not deferred; unset "
+            "after the cycle completes."
+        ),
+    )
+
     # --- Logging ---
     LOGGING_LEVEL: str = _field(
         "INFO",
@@ -640,6 +657,7 @@ _SECTION_DOCS = {
         "are ready. Not required for development."
     ),
     "File paths": "",
+    "Update process": "",
     "Logging": (
         "Configuration for the root logger. Logging is always done to "
         "stdout and is\nredirected/rotated by the supervisor process."

--- a/wp1/logic/project.py
+++ b/wp1/logic/project.py
@@ -378,7 +378,10 @@ def update_project_assessments(
     if track_progress:
         count_initial_work(redis, wp10db, project.p_project)
 
-    seen = set()
+    seen_by_kind = {
+        AssessmentKind.QUALITY: set(),
+        AssessmentKind.IMPORTANCE: set(),
+    }
     all_deferred_logs = []
     for kind in (AssessmentKind.QUALITY, AssessmentKind.IMPORTANCE):
         logger.debug(
@@ -391,7 +394,7 @@ def update_project_assessments(
             extra_assessments,
             kind,
             old_ratings,
-            seen,
+            seen_by_kind[kind],
             redis=redis,
             track_progress=track_progress,
         )
@@ -401,7 +404,13 @@ def update_project_assessments(
         all_deferred_logs.extend(deferred)
 
     moved_articles = process_unseen_articles(
-        wikidb, wp10db, redis, project, old_ratings, seen
+        wikidb,
+        wp10db,
+        redis,
+        project,
+        old_ratings,
+        seen_by_kind[AssessmentKind.QUALITY],
+        seen_by_kind[AssessmentKind.IMPORTANCE],
     )
 
     # Write deferred logs for articles that were not moved.
@@ -536,9 +545,11 @@ def store_new_ratings(wp10db, redis, new_ratings, old_ratings, rating_to_categor
     return deferred_logs
 
 
-def process_unseen_articles(wikidb, wp10db, redis, project, old_ratings, seen):
+def process_unseen_articles(
+    wikidb, wp10db, redis, project, old_ratings, seen_quality, seen_importance
+):
     moved_articles = set()
-    if len(seen) == 0:
+    if len(seen_quality) == 0 and len(seen_importance) == 0:
         logger.warning(
             "Did not find any articles for %s, skipping unseen processing",
             project.p_project.decode("utf-8"),
@@ -546,7 +557,8 @@ def process_unseen_articles(wikidb, wp10db, redis, project, old_ratings, seen):
         return moved_articles
 
     denom = len(old_ratings.keys())
-    ratio = len(seen) / denom if denom != 0 else "NaN"
+    seen_count = len(seen_quality | seen_importance)
+    ratio = seen_count / denom if denom != 0 else "NaN"
 
     logger.debug("Looking for unseen articles, ratio was: %s", ratio)
     in_seen = 0
@@ -555,32 +567,63 @@ def process_unseen_articles(wikidb, wp10db, redis, project, old_ratings, seen):
     n = 0
     not_a_class_db = NOT_A_CLASS.encode("utf-8")
     for ref, old_rating in old_ratings.items():
-        if ref in seen:
-            in_seen += 1
-            continue
+        in_quality = ref in seen_quality
+        in_importance = ref in seen_importance
 
-        # By default, we evaluate both assessment kinds.
-        kind = AssessmentKind.BOTH
-        if old_rating.r_quality == not_a_class_db or old_rating.r_quality is None:
-            # The quality rating is not set, so just evaluate importance
-            kind = AssessmentKind.IMPORTANCE
+        move_data = None
+        if not in_quality and not in_importance:
+            # The article vanished from every category, so it may have been
+            # moved or deleted. By default, we evaluate both assessment kinds.
+            kind = AssessmentKind.BOTH
+            if old_rating.r_quality == not_a_class_db or old_rating.r_quality is None:
+                # The quality rating is not set, so just evaluate importance
+                kind = AssessmentKind.IMPORTANCE
+                if (
+                    old_rating.r_importance == not_a_class_db
+                    or old_rating.r_importance is None
+                ):
+                    # The importance rating is also not set, so don't do anything.
+                    skipped += 1
+                    continue
+
+            logger.debug("Processing unseen article %s", ref.decode("utf-8"))
+        else:
+            # The article is still on-wiki and categorized for at least one
+            # assessment kind. If it disappeared from every category of the
+            # other kind while still holding a rating there, that rating was
+            # removed on-wiki and has to be reset (issue #695). An empty seen
+            # set for a kind more likely indicates a missing or broken
+            # category tree than a project-wide de-assessment, so it is left
+            # alone.
             if (
-                old_rating.r_importance == not_a_class_db
-                or old_rating.r_importance is None
+                seen_quality
+                and not in_quality
+                and old_rating.r_quality is not None
+                and old_rating.r_quality != not_a_class_db
             ):
-                # The importance rating is also not set, so don't do anything.
-                skipped += 1
+                kind = AssessmentKind.QUALITY
+            elif (
+                seen_importance
+                and not in_importance
+                and old_rating.r_importance is not None
+                and old_rating.r_importance != not_a_class_db
+            ):
+                kind = AssessmentKind.IMPORTANCE
+            else:
+                in_seen += 1
                 continue
 
-        logger.debug("Processing unseen article %s", ref.decode("utf-8"))
+            logger.debug("Processing de-assessed article %s", ref.decode("utf-8"))
+
         processed += 1
         ns, title = ref.decode("utf-8").split(":", 1)
         ns = int(ns.encode("utf-8"))
         title = title.encode("utf-8")
 
-        move_data = logic_page.get_move_data(
-            wp10db, wikidb, ns, title, project.timestamp_dt
-        )
+        if not in_quality and not in_importance:
+            move_data = logic_page.get_move_data(
+                wp10db, wikidb, ns, title, project.timestamp_dt
+            )
         if move_data is not None:
             # Track the new name so deferred logs can be skipped for it.
             new_ref = (
@@ -600,11 +643,12 @@ def process_unseen_articles(wikidb, wp10db, redis, project, old_ratings, seen):
                 move_data["timestamp_dt"],
             )
 
-        # Mark this article as having NOT_A_CLASS for it's quality or importance.
-        # This probably means the article was deleted, but could in fact mean that
-        # we just failed to find its move data. Either way, the new article would
-        # have already been picked up by the assessment updater, assuming it was
-        # tagged correctly.
+        # Mark the evaluated kinds as NOT_A_CLASS. For a fully unseen article
+        # this probably means it was deleted, but could in fact mean that we
+        # just failed to find its move data; either way, the new article would
+        # have already been picked up by the assessment updater, assuming it
+        # was tagged correctly. For a partially seen article, it means the
+        # rating for this kind was removed on-wiki.
         rating = Rating(
             r_project=project.p_project, r_namespace=ns, r_article=title, r_score=0
         )

--- a/wp1/logic/project_test.py
+++ b/wp1/logic/project_test.py
@@ -1095,11 +1095,57 @@ class UpdateProjectAssessmentsTest(ArticlesTest):
         self._insert_ratings(self.quality_pages[:6], 0, AssessmentKind.QUALITY)
 
         logic_project.process_unseen_articles(
-            self.wikidb, self.wp10db, self.redis, self.project, {}, {}
+            self.wikidb, self.wp10db, self.redis, self.project, {}, set(), set()
         )
 
         mock_logic_rating.insert_or_update.assert_not_called()
         mock_logic_rating.add_log_for_rating.assert_not_called()
+
+    @patch("wp1.logic.api.page.site")
+    def test_removed_quality_still_tagged_importance(self, patched_site):
+        """Issue #695: quality removed on-wiki while importance tag remains.
+
+        'Art of testing' is only in an importance category; its stale quality
+        rating has no backing category and must be reset to NotA-Class.
+        """
+        self._insert_pages([p for p in self.quality_pages if p[0] != 201])
+        self._insert_pages(self.importance_pages)
+        self._insert_ratings(self.importance_pages[4:], 0, AssessmentKind.IMPORTANCE)
+        with self.wp10db.cursor() as cursor:
+            cursor.execute(
+                """
+        UPDATE ratings
+          SET r_quality = %(quality)s, r_quality_timestamp = %(ts)s
+        WHERE r_article = %(article)s
+    """,
+                {
+                    "quality": b"FA-Class",
+                    "ts": self.old_ts_wiki,
+                    "article": b"Art of testing",
+                },
+            )
+        self.wp10db.commit()
+
+        logic_project.update_project_assessments(
+            self.wikidb, self.wp10db, self.redis, self.project, {}
+        )
+
+        # The article never vanished, so no move lookups happen.
+        patched_site.assert_not_called()
+
+        ratings = {r.r_article: r for r in _get_all_ratings(self.wp10db)}
+        rating = ratings[b"Art of testing"]
+        self.assertEqual(NOT_A_CLASS.encode("utf-8"), rating.r_quality)
+        self.assertEqual(b"Top-Class", rating.r_importance)
+
+        logs = [
+            l
+            for l in _get_all_logs(self.redis)
+            if l.l_article == b"Art of testing" and l.l_action == b"quality"
+        ]
+        self.assertEqual(1, len(logs))
+        self.assertEqual(b"FA-Class", logs[0].l_old)
+        self.assertEqual(NOT_A_CLASS.encode("utf-8"), logs[0].l_new)
 
 
 class GlobalArticlesTest(ArticlesTest):
@@ -1782,7 +1828,13 @@ class ProcessUnseenArticlesMovedTest(BaseCombinedDbTest):
             "wp1.logic.project.logic_page.update_page_moved"
         ) as mock_update_page_moved:
             moved_articles = logic_project.process_unseen_articles(
-                self.wikidb, self.wp10db, self.redis, self.project, old_ratings, seen
+                self.wikidb,
+                self.wp10db,
+                self.redis,
+                self.project,
+                old_ratings,
+                seen,
+                set(),
             )
 
         self.assertIn(b"0:New_Title", moved_articles)
@@ -1806,7 +1858,7 @@ class ProcessUnseenArticlesMovedTest(BaseCombinedDbTest):
         mock_get_move_data.return_value = None
 
         moved_articles = logic_project.process_unseen_articles(
-            self.wikidb, self.wp10db, self.redis, self.project, old_ratings, seen
+            self.wikidb, self.wp10db, self.redis, self.project, old_ratings, seen, set()
         )
 
         self.assertEqual(0, len(moved_articles))
@@ -1825,7 +1877,7 @@ class ProcessUnseenArticlesMovedTest(BaseCombinedDbTest):
         seen = set()
 
         moved_articles = logic_project.process_unseen_articles(
-            self.wikidb, self.wp10db, self.redis, self.project, old_ratings, seen
+            self.wikidb, self.wp10db, self.redis, self.project, old_ratings, seen, set()
         )
 
         self.assertEqual(0, len(moved_articles))
@@ -1875,7 +1927,7 @@ class ProcessUnseenArticlesRatingTest(BaseCombinedDbTest):
         seen = {b"0:Some_Other_Article"}
 
         logic_project.process_unseen_articles(
-            self.wikidb, self.wp10db, self.redis, self.project, old_ratings, seen
+            self.wikidb, self.wp10db, self.redis, self.project, old_ratings, seen, seen
         )
 
         ratings = _get_all_ratings(self.wp10db)
@@ -1905,7 +1957,7 @@ class ProcessUnseenArticlesRatingTest(BaseCombinedDbTest):
         seen = {b"0:Some_Other_Article"}
 
         logic_project.process_unseen_articles(
-            self.wikidb, self.wp10db, self.redis, self.project, old_ratings, seen
+            self.wikidb, self.wp10db, self.redis, self.project, old_ratings, seen, seen
         )
 
         mock_get_move_data.assert_not_called()
@@ -1931,7 +1983,7 @@ class ProcessUnseenArticlesRatingTest(BaseCombinedDbTest):
         seen = {b"0:Some_Other_Article"}
 
         logic_project.process_unseen_articles(
-            self.wikidb, self.wp10db, self.redis, self.project, old_ratings, seen
+            self.wikidb, self.wp10db, self.redis, self.project, old_ratings, seen, seen
         )
 
         ratings = _get_all_ratings(self.wp10db)
@@ -1942,6 +1994,126 @@ class ProcessUnseenArticlesRatingTest(BaseCombinedDbTest):
         logs = _get_all_logs(self.redis)
         self.assertEqual(1, len(logs))
         self.assertEqual(b"importance", logs[0].l_action)
+
+    @patch("wp1.logic.project.logic_page.get_move_data", return_value=None)
+    def test_seen_importance_only_resets_quality(self, mock_get_move_data):
+        """Article still tagged for importance, quality removed (issue #695)."""
+        old_rating = Rating(
+            r_project=b"Test",
+            r_namespace=0,
+            r_article=b"De_Assessed",
+            r_score=0,
+            r_quality=b"Start-Class",
+            r_quality_timestamp=b"2018-07-04T05:05:05Z",
+            r_importance=b"High-Class",
+            r_importance_timestamp=b"2018-07-04T05:05:05Z",
+        )
+        self._insert_rating(old_rating)
+        old_ratings = {b"0:De_Assessed": old_rating}
+        seen_quality = {b"0:Some_Other_Article"}
+        seen_importance = {b"0:De_Assessed", b"0:Some_Other_Article"}
+
+        logic_project.process_unseen_articles(
+            self.wikidb,
+            self.wp10db,
+            self.redis,
+            self.project,
+            old_ratings,
+            seen_quality,
+            seen_importance,
+        )
+
+        # The article still exists on-wiki, so no move lookup is made.
+        mock_get_move_data.assert_not_called()
+
+        ratings = _get_all_ratings(self.wp10db)
+        self.assertEqual(1, len(ratings))
+        self.assertEqual(self.not_a_class_db, ratings[0].r_quality)
+        self.assertEqual(b"High-Class", ratings[0].r_importance)
+
+        logs = _get_all_logs(self.redis)
+        self.assertEqual(1, len(logs))
+        self.assertEqual(b"quality", logs[0].l_action)
+        self.assertEqual(b"Start-Class", logs[0].l_old)
+        self.assertEqual(self.not_a_class_db, logs[0].l_new)
+
+    @patch("wp1.logic.project.logic_page.get_move_data", return_value=None)
+    def test_seen_quality_only_resets_importance(self, mock_get_move_data):
+        """Article still tagged for quality, importance removed."""
+        old_rating = Rating(
+            r_project=b"Test",
+            r_namespace=0,
+            r_article=b"De_Assessed",
+            r_score=0,
+            r_quality=b"Start-Class",
+            r_quality_timestamp=b"2018-07-04T05:05:05Z",
+            r_importance=b"High-Class",
+            r_importance_timestamp=b"2018-07-04T05:05:05Z",
+        )
+        self._insert_rating(old_rating)
+        old_ratings = {b"0:De_Assessed": old_rating}
+        seen_quality = {b"0:De_Assessed", b"0:Some_Other_Article"}
+        seen_importance = {b"0:Some_Other_Article"}
+
+        logic_project.process_unseen_articles(
+            self.wikidb,
+            self.wp10db,
+            self.redis,
+            self.project,
+            old_ratings,
+            seen_quality,
+            seen_importance,
+        )
+
+        mock_get_move_data.assert_not_called()
+
+        ratings = _get_all_ratings(self.wp10db)
+        self.assertEqual(1, len(ratings))
+        self.assertEqual(b"Start-Class", ratings[0].r_quality)
+        self.assertEqual(self.not_a_class_db, ratings[0].r_importance)
+
+        logs = _get_all_logs(self.redis)
+        self.assertEqual(1, len(logs))
+        self.assertEqual(b"importance", logs[0].l_action)
+        self.assertEqual(b"High-Class", logs[0].l_old)
+        self.assertEqual(self.not_a_class_db, logs[0].l_new)
+
+    @patch("wp1.logic.project.logic_page.get_move_data", return_value=None)
+    def test_empty_kind_seen_set_skips_reset(self, mock_get_move_data):
+        """An empty seen set for a kind (broken/absent category tree) never
+        resets ratings of that kind for articles seen in the other kind."""
+        old_rating = Rating(
+            r_project=b"Test",
+            r_namespace=0,
+            r_article=b"Still_Here",
+            r_score=0,
+            r_quality=b"Start-Class",
+            r_quality_timestamp=b"2018-07-04T05:05:05Z",
+            r_importance=b"High-Class",
+            r_importance_timestamp=b"2018-07-04T05:05:05Z",
+        )
+        self._insert_rating(old_rating)
+        old_ratings = {b"0:Still_Here": old_rating}
+        seen_quality = set()
+        seen_importance = {b"0:Still_Here"}
+
+        logic_project.process_unseen_articles(
+            self.wikidb,
+            self.wp10db,
+            self.redis,
+            self.project,
+            old_ratings,
+            seen_quality,
+            seen_importance,
+        )
+
+        mock_get_move_data.assert_not_called()
+
+        ratings = _get_all_ratings(self.wp10db)
+        self.assertEqual(1, len(ratings))
+        self.assertEqual(b"Start-Class", ratings[0].r_quality)
+        self.assertEqual(b"High-Class", ratings[0].r_importance)
+        self.assertEqual(0, len(_get_all_logs(self.redis)))
 
 
 class DeferredLogMovedArticleTest(ArticlesTest):

--- a/wp1/logic/project_test.py
+++ b/wp1/logic/project_test.py
@@ -1139,9 +1139,9 @@ class UpdateProjectAssessmentsTest(ArticlesTest):
         self.assertEqual(b"Top-Class", rating.r_importance)
 
         logs = [
-            l
-            for l in _get_all_logs(self.redis)
-            if l.l_article == b"Art of testing" and l.l_action == b"quality"
+            log
+            for log in _get_all_logs(self.redis)
+            if log.l_article == b"Art of testing" and log.l_action == b"quality"
         ]
         self.assertEqual(1, len(logs))
         self.assertEqual(b"FA-Class", logs[0].l_old)

--- a/wp1/logic/rating.py
+++ b/wp1/logic/rating.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 import attr
 from redis import Redis
 
+from wp1.config import get_settings
 from wp1.conf import get_conf
 from wp1.constants import GLOBAL_TIMESTAMP, AssessmentKind
 from wp1.logic import log as logic_log
@@ -580,6 +581,11 @@ def count_unassessed_importance_for_project(wp10db, project):
 
 
 def add_log_for_rating(redis, new_rating, kind, old_rating_value):
+    if get_settings().SUPPRESS_RATING_LOGS:
+        # Operational escape hatch, see WP1_SUPPRESS_RATING_LOGS in
+        # .env.example. Suppressed logs are lost, not deferred.
+        return
+
     if kind == AssessmentKind.QUALITY:
         action = b"quality"
         timestamp = new_rating.r_quality_timestamp

--- a/wp1/logic/rating_test.py
+++ b/wp1/logic/rating_test.py
@@ -1,4 +1,5 @@
 from wp1.base_db_test import BaseWpOneDbTest
+from wp1.config import override_settings
 from wp1.constants import AssessmentKind
 from wp1.logic import log as logic_log
 from wp1.logic import rating as logic_rating
@@ -50,6 +51,23 @@ class LogicRatingTest(BaseWpOneDbTest):
         self.assertEqual(b"Mid-Class", log.l_new)
         self.assertEqual(b"NotA-Class", log.l_old)
         self.assertEqual(b"importance", log.l_action)
+
+    def test_add_log_suppressed_by_settings(self):
+        rating = Rating(
+            r_project=b"Test Project",
+            r_namespace=0,
+            r_article=b"Testing Stuff",
+            r_quality=b"GA-Class",
+            r_quality_timestamp=b"2018-04-01T12:30:00Z",
+        )
+        with override_settings(SUPPRESS_RATING_LOGS=1):
+            logic_rating.add_log_for_rating(
+                self.redis, rating, AssessmentKind.QUALITY, b"NotA-Class"
+            )
+
+        self.assertEqual(
+            0, len(logic_log.get_logs(self.redis, article=b"Testing Stuff"))
+        )
 
 
 class GetProjectRatingByTypeTest(BaseWpOneDbTest):


### PR DESCRIPTION
Fixes #695.

`update_project_assessments` tracked a single shared `seen` set across the QUALITY and IMPORTANCE passes, and `process_unseen_articles` skipped any article present in it. An article still tagged for one kind but removed from every category of the other — e.g. a draft whose `|class=` was removed while `|importance=` remained, as in #695 — was counted as fully seen, so its stale rating was never reset and stuck forever at its last value.

Changes:

- Track seen refs per assessment kind.
- Articles gone from every category keep the existing move-detection/reset path unchanged.
- Articles still seen for one kind get the other kind's rating reset to `NotA-Class` when it has vanished, with a proper assessment log and no move lookup (the page still exists on-wiki).
- An empty seen set for a kind is treated as a missing/broken category tree and never triggers resets for that kind, so a transient category-fetch failure can't mass-wipe one kind's ratings.
- A temporary `WP1_SUPPRESS_RATING_LOGS` env flag makes `add_log_for_rating` a no-op, so the first post-deploy update cycle (which resets all accumulated stale rows at once) can run without emitting a one-time wave of `NotA-Class` log transitions to Redis and the on-wiki log pages. Set it for that cycle only, then unset; suppressed logs are lost, not deferred.

The new integration test reproduces the #695 scenario through `update_project_assessments` and fails on `main` (`b'NotA-Class' != b'FA-Class'`); three new unit tests cover the partial-seen reset in both directions and the empty-kind guard, plus a test for the suppression flag.

---

*Written with AI assistance (Claude).*
