### PR TITLE
Use privacy.kiwix.org permalink for privacy policy

### DIFF
--- a/wp1-frontend/src/App.vue
+++ b/wp1-frontend/src/App.vue
@@ -70,7 +70,7 @@
           Feedback
         </a>
         <a
-          href="https://kiwix.org/privacy-policy/"
+          href="https://privacy.kiwix.org"
           target="_blank"
           rel="noopener noreferrer"
           class="wp1r-navlink"


### PR DESCRIPTION
Replaces the hard-coded `https://kiwix.org/privacy-policy/` footer link with the new `https://privacy.kiwix.org` permalink (see kiwix/web#412).

Fixes #1315

Co-authored with Claude.