### PR TITLE
Fix Dependabot alert 299: update js-yaml

### DIFF
--- a/wp1-frontend/pnpm-lock.yaml
+++ b/wp1-frontend/pnpm-lock.yaml
@@ -1231,8 +1231,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.1:
-    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
+  js-yaml@3.15.2:
+    resolution: {integrity: sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==}
     hasBin: true
 
   jsbn@0.1.1:
@@ -2076,7 +2076,7 @@ snapshots:
       globals: 13.23.0
       ignore: 4.0.6
       import-fresh: 3.3.0
-      js-yaml: 3.15.1
+      js-yaml: 3.15.2
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -2741,7 +2741,7 @@ snapshots:
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
       is-glob: 4.0.3
-      js-yaml: 3.15.1
+      js-yaml: 3.15.2
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -3043,7 +3043,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.1:
+  js-yaml@3.15.2:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1


### PR DESCRIPTION
Updates js-yaml 3.15.1 to 3.15.2 so empty merge sources count toward the merge budget. Addresses Dependabot alert #299.

Verified: frozen pnpm install, staging build, and a regression smoke check showing 3.15.1 bypasses the budget while 3.15.2 rejects the same input and preserves ordinary merges.

AI-assisted with OpenAI Codex.