### PR TITLE
Hide assessment log headings from transcluding pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ has more all-time edits than any other account on English Wikipedia. It:
   [WikiProjects](https://en.wikipedia.org/wiki/Wikipedia:WikiProject), into
   browsable quality × importance tables, with nightly updates posted back
   on-wiki as [project tables](https://en.wikipedia.org/wiki/User:WP_1.0_bot/Tables/Project/Catholicism)
-  and change logs.
+  and change logs. Log headings appear only on the log page itself, not in
+  the table of contents of pages that transclude it.
 - Lets users build **selections** — custom article lists defined by
   WikiProject, [Petscan](https://petscan.wmcloud.org/),
   [SPARQL](https://query.wikidata.org/), combinations thereof, or plain lists

--- a/wp1/logs_test.py
+++ b/wp1/logs_test.py
@@ -812,12 +812,12 @@ class LogsTest(BaseCombinedDbTest):
     def test_section_for_date(self):
         # Excuse my mess.
         expected = (
-            "=== December 25, 2018 ===\n"
-            "==== Renamed ====\n"
+            "<noinclude>\n=== December 25, 2018 ===\n</noinclude>\n"
+            "<noinclude>\n==== Renamed ====\n</noinclude>\n"
             "* '''[[Test Baz Bang]]''' renamed to '''[[Test Baz]]'''.\n"
             "* '''[[Testing in Copenhaven]]''' renamed to '''[[Testing in "
             "Copenhagen]]'''.\n"
-            "==== Reassessed ====\n"
+            "<noinclude>\n==== Reassessed ====\n</noinclude>\n"
             "* '''[[Lesser-known tests]]''' ([[Talk:Lesser-known "
             "tests|talk]]) reassessed.  Quality rating changed from "
             "'''Stub-Class''' to '''Start-Class'''. <span "
@@ -866,7 +866,7 @@ class LogsTest(BaseCombinedDbTest):
             "title=Talk%3ATesting%20history&oldid=None "
             "t])</span>\n"
             "\n"
-            "==== Assessed ====\n"
+            "<noinclude>\n==== Assessed ====\n</noinclude>\n"
             "* '''[[Important tests]]''' ([[Talk:Important tests|talk]]) "
             "assessed.  Quality assessed as '''NotA-Class'''. <span "
             'style=\\"white-space: '
@@ -884,7 +884,7 @@ class LogsTest(BaseCombinedDbTest):
             "title=Talk%3AImportant%20tests&oldid=None "
             "t])</span>\n"
             "\n"
-            "==== Removed ====\n"
+            "<noinclude>\n==== Removed ====\n</noinclude>\n"
             "* '''[[Testing None-a]]''' ([[Talk:Testing None-a|talk]]) "
             "removed. \n"
             "* '''[[Testing tools]]''' ([[Talk:Testing tools|talk]]) "
@@ -926,9 +926,15 @@ class LogsTest(BaseCombinedDbTest):
         )
 
         self.assertEqual(3, len(actual))
-        self.assertTrue(actual[0].startswith("=== December 27, 2018 ==="))
-        self.assertTrue(actual[1].startswith("=== December 26, 2018 ==="))
-        self.assertTrue(actual[2].startswith("=== December 25, 2018 ==="))
+        self.assertEqual(
+            [datetime(2018, 12, day).date() for day in (27, 26, 25)],
+            [
+                logs.live_page_dates_missing_from_logs(
+                    section, set(), datetime(2018, 12, 24)
+                )[0]
+                for section in actual
+            ],
+        )
 
     @patch("wp1.logs.redis_connect")
     @patch("wp1.logs.wiki_connect")

--- a/wp1/templates/log_section.jinja2
+++ b/wp1/templates/log_section.jinja2
@@ -1,25 +1,35 @@
 {% from 'log_helpers.jinja2' import revs, quality, importance, quality_and_importance with context -%}
+<noinclude>
 === {{log_date}} ===
+</noinclude>
 {% if renamed -%}
+<noinclude>
 ==== Renamed ====
+</noinclude>
 {% for art in renamed -%}
 * '''[[{{name[art]}}]]''' renamed to '''[[{{moved_name[art]}}]]'''.
 {% endfor -%}
 {%- endif -%}
 {%- if reassessed -%}
+<noinclude>
 ==== Reassessed ====
+</noinclude>
 {% for art in reassessed -%}
 * '''[[{{name[art]}}]]''' ([[{{talk[art]}}|talk]]) reassessed. {{quality_and_importance(art)}}
 {% endfor -%}
 {% endif -%}
 {%- if assessed %}
+<noinclude>
 ==== Assessed ====
+</noinclude>
 {% for art in assessed -%}
 * '''[[{{name[art]}}]]''' ([[{{talk[art]}}|talk]]) assessed. {{quality_and_importance(art)}}
 {% endfor -%}
 {% endif -%}
 {%- if removed %}
+<noinclude>
 ==== Removed ====
+</noinclude>
 {% for art in removed -%}
 * '''[[{{name[art]}}]]''' ([[{{talk[art]}}|talk]]) removed. {{quality_and_importance_removed}}
 {% endfor -%}

--- a/wp1/templates_test.py
+++ b/wp1/templates_test.py
@@ -1,6 +1,10 @@
 import unittest
+from datetime import datetime
 
-from wp1.templates import importance_label
+import mwparserfromhell
+
+from wp1 import logs
+from wp1.templates import env, importance_label
 
 
 class ImportanceLabelTest(unittest.TestCase):
@@ -13,3 +17,56 @@ class ImportanceLabelTest(unittest.TestCase):
 
     def test_no_class_suffix_unchanged(self):
         self.assertEqual("NotAClass", importance_label(b"NotAClass"))
+
+
+class LogTransclusionTest(unittest.TestCase):
+    def test_headings_only_appear_on_standalone_log(self):
+        rendered = env.get_template("log_section.jinja2").render(
+            log_date="December 25, 2018",
+            renamed=["Renamed article"],
+            reassessed=["Reassessed article"],
+            assessed=["Assessed article"],
+            removed=["Removed article"],
+            name={
+                name: name
+                for name in (
+                    "Renamed article",
+                    "Reassessed article",
+                    "Assessed article",
+                    "Removed article",
+                )
+            },
+            talk={
+                name: "Talk:" + name
+                for name in (
+                    "Reassessed article",
+                    "Assessed article",
+                    "Removed article",
+                )
+            },
+            moved_name={"Renamed article": "New name"},
+            l={
+                "Reassessed article": {"quality": None, "importance": None},
+                "Assessed article": {"quality": None, "importance": None},
+            },
+        )
+        standalone = mwparserfromhell.parse(rendered)
+        transcluded = mwparserfromhell.parse(rendered)
+        for tag in standalone.filter_tags():
+            if tag.tag == "noinclude":
+                standalone.replace(tag, tag.contents)
+        for tag in transcluded.filter_tags():
+            if tag.tag == "noinclude":
+                transcluded.remove(tag)
+        self.assertEqual(
+            ["December 25, 2018", "Renamed", "Reassessed", "Assessed", "Removed"],
+            [str(h.title).strip() for h in standalone.filter_headings()],
+        )
+        self.assertEqual([], transcluded.filter_headings())
+        self.assertEqual(standalone.filter_wikilinks(), transcluded.filter_wikilinks())
+        self.assertEqual(
+            [datetime(2018, 12, 25).date()],
+            logs.live_page_dates_missing_from_logs(
+                rendered, set(), datetime(2018, 12, 24)
+            ),
+        )


### PR DESCRIPTION
Fixes #1324.

Wrap date and action headings in `<noinclude>` so standalone logs retain their headings without adding them to a transcluding page's table of contents. Keep headings on separate lines so the existing missing-history safeguard still detects log dates.

Regression coverage checks standalone/transcluded headings, preserved article links, and date detection. The new regression failed before the fix; all 29 log/template tests pass afterward. Pre-commit checks pass. Transclusion was checked offline, not on a live Wikipedia page.

Implemented with OpenAI Codex assistance.